### PR TITLE
Disable admin user bar.

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -27,7 +27,7 @@
   </head>
 
   <body class="{% block body_class %}{% endblock %}">
-    {% wagtailuserbar %}
+    {# {% wagtailuserbar %} #}
     <a href="#main-content" class="u-visually-hidden">skip navigation</a>
 
     <header class="site-header">


### PR DESCRIPTION
The Wagtail admin user bar is rendered in an iframe, which is blocked by
our Cloud Foundry nginx configuration (via the `x-frame-options`
header). As a result, all scripts loaded after the iframe is inserted
fail for logged-in admin users. As a temporary fix, this patch disables
the admin user bar. In the future @dlapiduz may update the nginx
configuration to let us override `x-frame-options`, in which case we can
revert this change.