### PR TITLE
Capitalization

### DIFF
--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -68,7 +68,7 @@
             <li class="list--checkboxes__item"><a href="/registration-and-reporting/know-your-filing-requirements">Know your filing requirements</a></li>
             <li class="list--checkboxes__item"><a href="/registration-and-reporting/quarterly-reports">Quarterly reports</a></li>
             <li class="list--checkboxes__item"><a href="/registration-and-reporting/pre-election-reports">Pre-election reports</a></li>
-            <li class="list--checkboxes__item"><a href="/registration-and-reporting/48-hour-notices">48-hour notices</a></li>
+            <li class="list--checkboxes__item"><a href="/registration-and-reporting/48-hour-notices">48-Hour Notices</a></li>
             <li class="list--checkboxes__item"><a href="/registration-and-reporting/post-general-election-reports">Post-general election reports</a></li>
             <li class="list--checkboxes__item"><a href="/registration-and-reporting/terminate-your-committee">Terminate your committee</a></li>
           </ul>


### PR DESCRIPTION
Small edit: 48-Hour Notices is the proper noun and should be capitalized.