### PR TITLE
Eliminates typo

### DIFF
--- a/fec/home/templates/home/options_page.html
+++ b/fec/home/templates/home/options_page.html
@@ -8,7 +8,7 @@
   <div class="container">
     <div class="usa-width-one-half">
       <h1 class="t-ruled--bottom t-display">Registration options</h1>
-      <p>By law, certain groups must register with the FEC and file regular reports about their campaign financial activity. Registrants range from candidates to political action committees (PACs). Every group has different registration and reporting rules.</p>
+      <p>By law, certain groups must register with the FEC and file regular reports about their campaign finance activity. Registrants range from candidates to political action committees (PACs). Every group has different registration and reporting rules.</p>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Makes "financial" into "finance"