### PR TITLE
Switching to a class for glossary toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+bower_components
 
 # Installer logs
 pip-log.txt

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -15,7 +15,7 @@ var SLT_ACCORDION = '.js-accordion';
 
 $(document).ready(function() {
     // Initialize glossary
-    new glossary.Glossary(terms, {body: '#glossary', toggle: '#glossary-toggle'});
+    new glossary.Glossary(terms, {body: '#glossary'});
 
     // Initialize accordions
     $(SLT_ACCORDION).each(function() {

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -98,7 +98,7 @@
           </li>
         </ul>
         <a title="Home" href="{{ cms_url }}" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
-        <button id="glossary-toggle" title="View site glossary" class="button--neutral site-nav__button site-nav__button--right">Glossary</button>
+        <button title="View site glossary" class="js-glossary-toggle button--neutral site-nav__button site-nav__button--right">Glossary</button>
       </nav>    
     </header>
 

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -45,7 +45,7 @@
         </div>
         <div class="feature feature--no-title">
           <div class="card card--primary">
-            <img class="card__image" src="/static/img/i-glossary--neutral.svg" alt="Icon representing the glossary">
+            <a class="js-glossary-toggle"><img class="card__image" src="/static/img/i-glossary--neutral.svg" alt="Icon representing the glossary"></a>
             <div class="card__content">
               <span>Use the glossary to learn the meaning of an unfamiliar word or phrase</span>
             </div>


### PR DESCRIPTION
And adding it to the icon on the glossary card on the home page to open
the glossary.

Requires https://github.com/18F/fec-style/pull/102

Resolves https://github.com/18F/fec-cms/issues/47
