### PR TITLE
implementing skipnav

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
     // Initialize glossary
     new glossary.Glossary(terms, {body: '#glossary'});
 
-    new skipNav.Skipnav('.skip-nav');
+    new skipNav.Skipnav('.skip-nav', 'main');
 
     // Initialize accordions
     $(SLT_ACCORDION).each(function() {

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -7,6 +7,7 @@ var $ = require('jquery');
 var terms = require('fec-style/js/terms');
 var glossary = require('fec-style/js/glossary');
 var accordion = require('fec-style/js/accordion');
+var skipNav = require('fec-style/js/skip-nav');
 
 // Hack: Append jQuery to `window` for use by legacy libraries
 window.$ = window.jQuery = $;
@@ -16,6 +17,8 @@ var SLT_ACCORDION = '.js-accordion';
 $(document).ready(function() {
     // Initialize glossary
     new glossary.Glossary(terms, {body: '#glossary'});
+
+    new skipNav.Skipnav('.skip-nav');
 
     // Initialize accordions
     $(SLT_ACCORDION).each(function() {

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -28,7 +28,7 @@
 
   <body class="{% block body_class %}{% endblock %}">
     {# {% wagtailuserbar %} #}
-    <a href="#main" class="skip-nav">skip navigation</a>
+    <a class="skip-nav" tabindex="0">skip navigation</a>
 
     <header class="site-header">
       <div class="disclaimer">
@@ -102,7 +102,7 @@
       </nav>    
     </header>
 
-    <main id="main" tabindex="-1">
+    <main id="main">
       {% block content %}{% endblock %}
     </main>
 


### PR DESCRIPTION
Removes the tabindex from <main> and implements the skip-nav link from https://github.com/18F/fec-style/pull/113/files