### PR TITLE
Respect x-forwarded-host header.

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -147,6 +147,10 @@ COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'fec.utils.PatchedSCSSCompiler'),
 )
 
+# Proxy settings
+
+USE_X_FORWARDED_HOST = True
+
 
 # Wagtail settings
 


### PR DESCRIPTION
Necessary for URL redirects to work behind the proxy.