### PR TITLE
Keyboard exit ethnio

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -102,5 +102,32 @@
 
 {% block extra_js %}
 <!-- Ethnio Activation Code -->
-<script type="text/javascript" language="javascript" src="//ethn.io/70862.js" async="true" charset="utf-8"></script>
+<script type="text/javascript" language="javascript" src="https://ethn.io/70862.js" async="true" charset="utf-8"></script>
+<script type="text/javascript">
+  // Hack to add a tabindex to the ethnio popup close button
+  var target = document.querySelector('body');
+  var observer = new MutationObserver(function(mutations){
+    mutations.forEach(function(mutation) {
+      if ( mutation.addedNodes[0].id === 'ethnio-screener-70862' ) {
+        var closeButton = $($('#ethnio-screener-70862').find('div')[0]);
+        closeButton.attr('tabindex',0);
+        closeButton.on('keyup', function(e) {
+          if (e.keyCode === 13) {
+            $(this).click();
+            observer.disconnect();
+          }
+        });
+      }
+      if ( mutation.addedNodes[0].id === 'ethnio-screener-id-70862' ) {
+        $('body').on('keyup', function(e){
+          if (e.keyCode === 27) {
+            $('iframe').remove();
+            observer.disconnect();
+          }
+        })
+      }
+    })
+  });
+  observer.observe(target, {childList: true});
+</script>
 {% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -108,23 +108,25 @@
   var target = document.querySelector('body');
   var observer = new MutationObserver(function(mutations){
     mutations.forEach(function(mutation) {
-      if ( mutation.addedNodes[0].id === 'ethnio-screener-70862' ) {
-        var closeButton = $($('#ethnio-screener-70862').find('div')[0]);
-        closeButton.attr('tabindex',0);
-        closeButton.on('keyup', function(e) {
-          if (e.keyCode === 13) {
-            $(this).click();
-            observer.disconnect();
-          }
-        });
-      }
-      if ( mutation.addedNodes[0].id === 'ethnio-screener-id-70862' ) {
-        $('body').on('keyup', function(e){
-          if (e.keyCode === 27) {
-            $('iframe').remove();
-            observer.disconnect();
-          }
-        })
+      if ( mutation.addedNodes.length > 0 ) {
+        if ( mutation.addedNodes[0].id === 'ethnio-screener-70862' ) {
+          var closeButton = $($('#ethnio-screener-70862').find('div')[0]);
+          closeButton.attr('tabindex',0);
+          closeButton.on('keyup', function(e) {
+            if (e.keyCode === 13) {
+              $(this).click();
+              observer.disconnect();
+            }
+          });
+        }
+        if ( mutation.addedNodes[0].id === 'ethnio-screener-id-70862' ) {
+          $('body').on('keyup', function(e){
+            if (e.keyCode === 27) {
+              $('iframe').remove();
+              observer.disconnect();
+            }
+          })
+        }
       }
     })
   });


### PR DESCRIPTION
Adds a very crude hack to allow the Ethnio popup to be closed by keyboard. Because both the pre-screener modal and the screener modal are closed by `<div>`s masquerading as buttons, it took some ugly code. 

First, it adds a tabindex to the initial close button on the pre-screener modal and fires a click event when hitting enter on it.

Second, if the actual screener is opened, it adds a listener to the body to listen for `escape` and then simply removes the iframe. 

I just heard back from Ethnio that they're looking into this accessibility issue, but in the mean time this can work.

Resolves https://github.com/18F/openFEC-web-app/issues/762