### PR TITLE
Adding contact page

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -58,6 +58,10 @@ class OptionsPage(ContentPage):
     """Options page."""
     pass
 
+class ContactPage(ContentPage):
+    """Contact page."""
+    pass
+
 class CustomPage(Page):
     """Flexible customizable page."""
     author = models.CharField(max_length=255)

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load staticfiles %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -96,14 +97,14 @@
     <aside class="sidebar sidebar--secondary">
         <h2>Need help?</h2>
         <div class="card card--mini">
-          <img alt="Call center support icon" src="/static/img/i-contact--neutral.svg" class="icon--complex card__image">
+          <img alt="Call center support icon" src="{% static "img/i-contact--neutral.svg" %}" class="icon--complex card__image">
           <div class="card__content">
             <span class="t-block">Give us a call</span>
             <span class="t-block">(800) 424-9530</span>
           </div>
         </div>
         <div class="card card--mini is-disabled">
-          <img alt="Calendar icon" src="/static/img/i-calendar--neutral.svg" class="icon--complex card__image">
+          <img alt="Calendar icon" src="{% static "img/i-calendar--neutral.svg" %}" class="icon--complex card__image">
           <div class="card__content">
             <span>Reporting calendar &raquo;</span>
           </div>

--- a/fec/home/templates/home/contact_page.html
+++ b/fec/home/templates/home/contact_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load staticfiles %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -13,7 +14,7 @@
       <ul>
         <li class="contact-item">
           <div class="contact-item__icon">
-            <img src="/static/img/i-phone--primary.svg" alt="Icon of a phone">
+            <img src="{% static "img/i-phone--primary.svg" %}" alt="Icon of a phone">
           </div>     
           <div class="contact-item__content">
             <h5 class="contact-item__title">Toll free</h5>
@@ -37,7 +38,7 @@
       <ul>
         <li class="contact-item">
           <div class="contact-item__icon">
-            <img src="/static/img/i-mail--primary.svg" alt="Icon of a stamp">
+            <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
           </div>     
           <div class="contact-item__content">
             <span class="t-block">Federal Election Commission</span>
@@ -58,7 +59,6 @@
         <li class="contact-item contact-item--half">
           <h5 class="contact-item__title">Press Office</h5>
           <span class="t-block">Including media inquiries and speaker requests</span>
-          <span class="contact-item__phone">XXX-XXX-XXXX</span>
           <span class="t-block"><a href="mailto:press@fec.gov">press@fec.gov</a></span>
         </li>
         <li class="contact-item contact-item--half">

--- a/fec/home/templates/home/contact_page.html
+++ b/fec/home/templates/home/contact_page.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+{% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
+
+{% block content %}
+<div class="hero__banner--office"></div>
+<article class="main">
+  <div class="container">
+    <h1 class="t-ruled--bottom t-ruled--bold t-display">{{ self.title }}</h1>
+    <div class="main__content--full u-padding--top">
+     <div class="usa-width-one-third">
+      <h2>General inquiries</h2>
+      <ul>
+        <li class="contact-item">
+          <div class="contact-item__icon">
+            <img src="/static/img/i-phone--primary.svg" alt="Icon of a phone">
+          </div>     
+          <div class="contact-item__content">
+            <h5 class="contact-item__title">Toll free</h5>
+            <span class="t-block">1-800-424-9530</span>
+          </div>
+        </li>
+        <li class="contact-item">
+          <div class="contact-item__content--offset">
+            <h5 class="contact-item__title">Local</h5>
+            <span class="t-block">202-694-1000</span>
+          </div>
+        </li>
+        <li class="contact-item">        
+          <div class="contact-item__content--offset">
+            <h5 class="contact-item__title">Teletypwriter (TTY) for the hearing impaired</h5>
+            <span class="t-block">202-219-3336</span>
+          </div>                    
+        </li>
+      </ul>
+      <h2>Mailing address</h2>
+      <ul>
+        <li class="contact-item">
+          <div class="contact-item__icon">
+            <img src="/static/img/i-mail--primary.svg" alt="Icon of a stamp">
+          </div>     
+          <div class="contact-item__content">
+            <span class="t-block">Federal Election Commission</span>
+            <span class="t-block">999 E St NW</span>
+            <span class="t-block">Washington, DC 20463</span>
+          </div>
+        </li>
+      </ul>      
+    </div>
+    <div class="usa-width-two-thirds">
+      <h2>Specific requests</h2>
+      <ul>
+        <li class="contact-item contact-item--half">
+          <h5 class="contact-item__title">Electronic Filing Office</h5>
+          <span class="t-block">Including password assistance and technical support</span>
+          <span class="contact-item__phone">202-694-1307</span>
+        </li>
+        <li class="contact-item contact-item--half">
+          <h5 class="contact-item__title">Press Office</h5>
+          <span class="t-block">Including media inquiries and speaker requests</span>
+          <span class="contact-item__phone">XXX-XXX-XXXX</span>
+          <span class="t-block"><a href="mailto:press@fec.gov">press@fec.gov</a></span>
+        </li>
+        <li class="contact-item contact-item--half">
+          <h5 class="contact-item__title">Information Division</h5>
+          <span class="t-block">Including help with educational materials, registering a committee, ordering a reporting form or campaign finance law</span>
+          <span class="contact-item__phone">202-694-1100</span>
+        </li>
+        <li class="contact-item contact-item--half">
+          <h5 class="contact-item__title">Public Records Division</h5>
+          <span class="t-block">Including help accessing reports and other public documents</span>
+          <span class="contact-item__phone">1-800-424-9530, menu option 2</span>
+          <span class="t-block"><a href="mailto:pubrec@fec.gov">pubrec@fec.gov</a></span>
+        </li>
+        <li class="contact-item contact-item--half">
+          <h5 class="contact-item__title">Reports Analysis Division</h5>
+          <span class="t-block">Including help with report creation, transactions and amendments </span>
+          <span class="contact-item__phone">202-694-1130</span>
+        </li>             
+      </ul>
+    </div>
+  </div>
+</div>
+</article>
+{% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load staticfiles %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -27,7 +28,9 @@
         <div class="feature">
           <h2 class="feature__title">New features</h2>
           <div class="card card--primary">
-            <a class="card__image-link" href="{{ settings.FEC_APP_URL }}"><img class="card__image" src="/static/img/i-data--neutral.svg" alt="Icon for explore campaign finance data"></a>
+            <a class="card__image-link" href="{{ settings.FEC_APP_URL }}">
+              <img class="card__image" src="{% static "img/i-data--neutral.svg" %}" alt="Icon for explore campaign finance data">
+            </a>
             <div class="card__content">
               Explore <a href="{{ settings.FEC_APP_URL }}">campaign finance data</a>
             </div>
@@ -36,7 +39,9 @@
         </div>
         <div class="feature feature--no-title">
           <div class="card card--primary">
-            <a class="card__image-link js-glossary-toggle"><img class="card__image" src="/static/img/i-glossary--neutral.svg" alt="Icon representing the glossary"></a>
+            <a class="card__image-link js-glossary-toggle">
+              <img class="card__image" src="{% static "img/i-glossary--neutral.svg" %}" alt="Icon representing the glossary">
+            </a>
             <div class="card__content">
               <span>Use the <a href="#" class="js-glossary-toggle">glossary</a> to learn the meaning of an unfamiliar word or phrase</span>
             </div>
@@ -46,7 +51,7 @@
         <div class="feature">
           <h2 class="feature__title">Coming soon</h2>
           <div class="card card--primary is-disabled">
-            <img class="card__image" src="/static/img/i-register--neutral.svg" alt="Icon for reporting and registration">
+            <img class="card__image" src="{% static "img/i-register--neutral.svg" %}" alt="Icon for reporting and registration">
             <div class="card__content">
               <p>Learn how congressional candidates and committees register and report</p>
             </div>
@@ -55,7 +60,7 @@
         </div>        
         <div class="feature feature--no-title">
           <div class="card card--primary is-disabled">
-            <img class="card__image" src="/static/img/i-calendar--neutral.svg" alt="Icon for the calendar">
+            <img class="card__image" src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon for the calendar">
             <div class="card__content">
               View a calendar of FEC deadlines and events
             </div>
@@ -91,7 +96,7 @@
     <div class="container">
       <div class="billboard">
         <div class="billboard__image__container">
-          <img class="billboard__image" src="/static/img/api@2x.png" alt="API documentation screenshot">
+          <img class="billboard__image" src="{% static "img/api@2x.png" %}" alt="API documentation screenshot">
         </div>
         <div class="billboard__content">
           <h2 class="feature__title">The FEC API: Use our data in your project</h2>
@@ -102,5 +107,5 @@
 
 {% block extra_js %}
 <!-- Ethnio Activation Code -->
-<script type="text/javascript" language="javascript" src="//ethn.io/70862.js" async="true" charset="utf-8"></script>
+<script type="text/javascript" language="javascript" src="https://ethn.io/70862.js" async="true" charset="utf-8"></script>
 {% endblock %}

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <section class="hero hero--home" aria-labelledby="hero-heading">
-    <div class="hero__banner">
+    <div class="hero__banner hero__banner--monument">
       <div class="container">
         <div class="hero__heading">
           <h1 id="hero-heading" class="hero__title t-display"><span class="t-italic">beta</span>.FEC.gov</h1>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load staticfiles %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -30,14 +31,14 @@
       <aside class="sidebar sidebar--secondary">
         <h2>Need help?</h2>
         <div class="card card--mini">
-          <img alt="Call center support icon" src="/static/img/i-contact--neutral.svg" class="icon--complex card__image">
+          <img alt="Call center support icon" src="{% static "img/i-contact--neutral.svg" %}" class="icon--complex card__image">
           <div class="card__content">
             <span class="t-block">Give us a call</span>
             <span class="t-block">(800) 424-9530</span>
           </div>
         </div>
         <div class="card card--mini is-disabled">
-          <img alt="Calendar icon" src="/static/img/i-calendar--neutral.svg" class="icon--complex card__image">
+          <img alt="Calendar icon" src="{% static "img/i-calendar--neutral.svg" %}" class="icon--complex card__image">
           <div class="card__content">
             <span>Reporting calendar</span>
           </div>
@@ -51,7 +52,7 @@
           <p>A number of factors dictate how individuals and groups must register and file. Visit this page to identify what kind of filer you are. When you’re ready, use our checklist to get started filing your reports.</p>
           <div class="card card--secondary card--horizontal">
             <a href="/registration-options" class="card__image card__image-link icon--complex">
-              <img alt="Registration icon" src="/static/img/i-register--neutral.svg" class="icon--complex">
+              <img alt="Registration icon" src="{% static "img/i-register--neutral.svg" %}" class="icon--complex">
             </a>
             <div class="card__content">
               <a href="/registration-options">Explore registration and reporting</a>
@@ -68,25 +69,25 @@
             <li class="usa-width-one-fourth">
               <p class="t-sans">Congressional candidates and committees (<a href="http://www.fec.gov/pdf/candgui.pdf">PDF</a>)</p>
               <a class="u-no-border" href="http://www.fec.gov/pdf/candgui.pdf">
-                <img src="/static/img/guide--candidates.jpg" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
+                <img src="{% static "img/guide--candidates.jpg" %}" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
               </a>
             </li>
             <li class="usa-width-one-fourth">
               <p class="t-sans">Corporations and labor organizations (<a href="http://www.fec.gov/pdf/colagui.pdf">PDF</a>)</p>
               <a class="u-no-border" href="http://www.fec.gov/pdf/colagui.pdf">
-                <img src="/static/img/guide--orgs.jpg" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
+                <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
               </a>
             </li>
             <li class="usa-width-one-fourth">
               <p class="t-sans">Nonconnected committees <br>(<a href="http://www.fec.gov/pdf/nongui.pdf">PDF</a>)</p>
               <a class="u-no-border" href="http://www.fec.gov/pdf/nongui.pdf">
-                <img src="/static/img/guide--nonconnected.jpg" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
+                <img src="{% static "img/guide--nonconnected.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
               </a>
             </li>
             <li class="usa-width-one-fourth usa-end-row">
               <p class="t-sans">Political party committees <br>(<a href="http://www.fec.gov/pdf/partygui.pdf">PDF</a>)</p>
               <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
-                <img src="/static/img/guide--parties.jpg" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
+                <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
               </a>
             </li>
           </ul>

--- a/fec/home/templates/home/options_page.html
+++ b/fec/home/templates/home/options_page.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags %}
+{% load staticfiles %}
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
@@ -26,7 +27,7 @@
         <div class="sidebar__section--skinny">
           <div class="card card--vertical card--secondary">
             <a class="card__image-link" href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">
-              <img alt="Call center support icon" src="/static/img/i-register--neutral.svg" class="icon--complex card__image">
+              <img alt="Register icon" src="{% static "img/i-register--neutral.svg" %}" class="icon--complex card__image">
             </a>
             <div class="card__content">
               <a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Learn more</a>
@@ -43,7 +44,7 @@
       <div class="sidebar">
         <div class="sidebar__section--skinny content__section--ruled">
           <div class="card card--vertical card--secondary">
-            <img alt="Call center support icon" src="/static/img/i-register--neutral.svg" class="icon--complex card__image">
+            <img alt="Register icon" src="{% static "img/i-register--neutral.svg" %}" class="icon--complex card__image">
             <div class="card__content">
               <span>Learn more</span>
             </div>
@@ -59,7 +60,7 @@
       <div class="sidebar">      
         <div class="sidebar__section--skinny content__section--ruled">
           <div class="card card--vertical card--secondary">
-            <img alt="Call center support icon" src="/static/img/i-register--neutral.svg" class="icon--complex card__image">
+            <img alt="Register icon" src="{% static "img/i-register--neutral.svg" %}" class="icon--complex card__image">
             <div class="card__content">
               <span>Learn more<span>
             </div>
@@ -75,7 +76,7 @@
       <div class="sidebar">
         <div class="sidebar__section--skinny content__section--ruled">
           <div class="card card--vertical card--secondary">
-            <img alt="Call center support icon" src="/static/img/i-register--neutral.svg" class="icon--complex card__image">
+            <img alt="Register icon" src="{% static "img/i-register--neutral.svg" %}" class="icon--complex card__image">
             <div class="card__content">
               <span>Learn more</span>
             </div>


### PR DESCRIPTION
Adds a new contact page template, though there's no map yet:

![screen shot 2015-10-08 at 4 31 41 pm](https://cloud.githubusercontent.com/assets/1696495/10382667/2d4abac0-6ddb-11e5-80e2-47f4170da0dc.png)

I'm thinking we may wait on the map while we figure out our long term map solution. This is the kind of thing we could use our custom map tiles for (if we get them) rather than introducing a third map style.

Thoughts?

Depends on https://github.com/18F/fec-style/pull/135