### PR TITLE
Add feedback widget to base template.

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -7,6 +7,7 @@ var $ = require('jquery');
 var terms = require('fec-style/js/terms');
 var glossary = require('fec-style/js/glossary');
 var accordion = require('fec-style/js/accordion');
+var feedback = require('fec-style/js/feedback');
 var skipNav = require('fec-style/js/skip-nav');
 var siteNav = require('fec-style/js/site-nav');
 
@@ -16,13 +17,15 @@ window.$ = window.jQuery = $;
 var SLT_ACCORDION = '.js-accordion';
 
 $(document).ready(function() {
-    // Initialize glossary
-    new glossary.Glossary(terms, {body: '#glossary'});
-    new skipNav.Skipnav('.skip-nav', 'main');
-    new siteNav.SiteNav('.js-site-nav');
-    
-    // Initialize accordions
-    $(SLT_ACCORDION).each(function() {
-      Object.create(accordion).init($(this));
-    });
+  // Initialize glossary
+  new glossary.Glossary(terms, {body: '#glossary'});
+  new skipNav.Skipnav('.skip-nav', 'main');
+  new siteNav.SiteNav('.js-site-nav');
+
+  // Initialize accordions
+  $(SLT_ACCORDION).each(function() {
+    Object.create(accordion).init($(this));
+  });
+
+  new feedback.Feedback(window.FEC_APP_URL + '/issue/');
 });

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -151,5 +151,8 @@
     <script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=FEC"></script>
     {% endif %}
 
+    <script>
+      window.FEC_APP_URL = '{{ settings.FEC_APP_URL }}';
+    </script>
   </body>
 </html>

--- a/fec/gulpfile.js
+++ b/fec/gulpfile.js
@@ -3,11 +3,13 @@
 var gulp = require('gulp');
 var browserify = require('browserify');
 var source = require('vinyl-source-stream');
+var stringify = require('stringify');
 
 var entry = './fec/static/js/fec.js';
 
 gulp.task('build-js', function () {
   return browserify(entry)
+    .transform({global: true}, stringify(['.html']))
     .bundle()
     .pipe(source(entry))
     .pipe(gulp.dest('dist'));

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "gulp": "^3.9.0",
+    "stringify": "^3.1.0",
     "vinyl-source-stream": "^1.1.0"
   }
 }


### PR DESCRIPTION
* Add feedback widget to fec.js
* Install and apply stringify transform
* Add app URL globally to base template

Note: this should work locally if the CMS is run with `FEC_APP_URL=http://localhost:3000`. It *will not* work on develop or production until we take the password off. I can work around this if necessary, but I'm not sure it's worth the time. The only caveat is that we'll have to manually check this as soon as the password comes down.

cc @noahmanger 