### PR TITLE
Content update

### DIFF
--- a/fec/fec/templates/404.html
+++ b/fec/fec/templates/404.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}404 Error | beta.fec.gov{% endblock %}
+{% block title %}404 Error | beta.FEC.gov{% endblock %}
 
 {% block content %}
 <section class="content--blank">

--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Server Error | beta.fec.gov{% endblock %}
+{% block title %}Server Error | beta.FEC.gov{% endblock %}
 
 {% block content %}
 <section class="content--blank">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -8,7 +8,7 @@
   <head>
     {% include './partials/meta-tags.html' %}
 
-    <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | beta.fec.gov {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
+    <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }} | beta.FEC.gov {% endif %}{% endblock %}{% block title_suffix %}{% endblock %}</title>
 
     {# Global stylesheets #}
     {% if settings.FEC_WEB_STYLE_URL %}
@@ -38,7 +38,7 @@
 
     <header class="site-header">
       <div class="disclaimer">
-        <span class="disclaimer__left">Looking for <a href="http://www.fec.gov">fec.gov?</a></span>
+        <span class="disclaimer__left">Looking for <a href="http://www.fec.gov">FEC.gov?</a></span>
         <span class="disclaimer__center">An official website of the United States Government <img src="/static/img/us_flag_small.png" alt="US flag signifying that this is a United States Federal Government website"></span>
         <span class="disclaimer__right">This site is in <a title="Learn about this site's development" tabindex="0" href="https://18f.gsa.gov/dashboard/stages/#beta">beta.</a></span>
       </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -17,7 +17,7 @@
     <div class="hero__bottom">
       <div class="container">
         <div class="hero__content">
-          <p class="p--lead">We're designing this site in phases. This allows us to launch new features faster than releasing a completely redesigned fec.gov. The official site for FEC data is still the <a href="http://www.fec.gov/pindex.shtml" target="_blank">Campaign Finance Disclosure Portal</a>.</p>
+          <p class="p--lead">We're designing this site in phases. This allows us to launch new features faster than releasing a completely redesigned FEC.gov. The official site for FEC data is still the <a href="http://www.fec.gov/pindex.shtml" target="_blank">Campaign Finance Disclosure Portal</a>.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Per FEC style request, we're making all beta.FEC.gov and FEC.gov capital `FEC`.

[ci skip]