### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,29 +9,32 @@ betaFEC is a collaboration between `18F <http://18f.gsa.gov>`_ and the FEC. It a
 
 FEC repositories 
 ================
-We welcome you to explore our FEC repositories, make suggestions, and contribute to our code. Our repositories are:
+We welcome you to explore, make suggestions, and contribute to our code. 
 
+This repository, `fec-cms <https://github.com/18F/fec-cms>`_: the content management system (CMS) for betaFEC.
+
+All repositories
+-----------------
 - `FEC <https://github.com/18F/fec>`_: a general discussion forum. We compile `feedback <https://github.com/18F/fec/issues>`_ from betaFEC’s feedback widget here, and this is the best place to submit general feedback.
 - `openFEC <https://github.com/18F/openfec>`_: betaFEC’s API
 - `openFEC-web-app <https://github.com/18f/openfec-web-app>`_: the betaFEC web app for exploring campaign finance data
 - `fec-style <https://github.com/18F/fec-style>`_: shared styles and user interface components
 - `fec-cms <https://github.com/18F/fec-cms>`_: the content management system (CMS) for betaFEC. This project uses `Wagtail <https://github.com/torchbox/wagtail>`_, an open source CMS written in Python and built on the Django framework.
 
-How you can help
+Get involved
 ================
-We’re thrilled you want to get involved! Here are some suggestions:
-- Check out our contributing `guidelines <https://github.com/18F/openfec/blob/master/CONTRIBUTING.md>`_. Then, file an `issue <https://github.com/18F/fec/issues>`_ or submit a pull request.
+We’re thrilled you want to get involved! 
+- Read our contributing `guidelines <https://github.com/18F/openfec/blob/master/CONTRIBUTING.md>`_. Then, file an `issue <https://github.com/18F/fec/issues>`_ or submit a pull request.
 - Send us an email at betafeedback@fec.gov. 
 - If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer. 
+- Check out our StoriesonBoard `FEC story map <https://18f.storiesonboard.com/m/fec>`_.
 
-Copyright and licensing
-=======================
-This project is in the public domain within the United States, and we waive worldwide copyright and related rights through `CC0 universal public domain dedication <https://creativecommons.org/publicdomain/zero/1.0/>`_. Read more on our license page.
 
-A few restrictions limit the way you can use FEC data. For example, you can’t use contributor lists for commercial purposes or to solicit donations. Learn more on FEC.gov.
+Set up
+============
 
 Installation
-============
+-----------------
 
 Install PostgreSQL.
 
@@ -49,8 +52,8 @@ Install dependencies: ::
     npm install -g gulp
     pip install -U -r requirements.txt
 
-Setup
-=====
+Set up
+-----------------
 
 .. code::
 
@@ -61,7 +64,7 @@ Setup
     ./manage.py migrate
 
 Local styles
-------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 Environment variable: ::
 
@@ -72,7 +75,7 @@ Settings: ::
     FEC_WEB_STYLE_URL = 'http://localhost:8080/css/styles.css'
 
 Developing with openFEC
------------------------
+~~~~~~~~~~~~~~~~~~~~~~
 
 Environment variable: ::
 
@@ -83,14 +86,14 @@ Settings: ::
     FEC_APP_URL = 'http://localhost:3000'
 
 Run
-===
+-----------------
 
 .. code::
     
     ./manage.py runserver
 
 Deploy
-======
+-----------------
 
 Provision development database: ::
 
@@ -108,3 +111,10 @@ Install `autopilot`: ::
 Deploy: ::
 
     cf zero-downtime-push cms -f manifest.yml
+
+
+Copyright and licensing
+=======================
+This project is in the public domain within the United States, and we waive worldwide copyright and related rights through `CC0 universal public domain dedication <https://creativecommons.org/publicdomain/zero/1.0/>`_. Read more on our license page.
+
+A few restrictions limit the way you can use FEC data. For example, you can’t use contributor lists for commercial purposes or to solicit donations. Learn more on FEC.gov.

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ We’re thrilled you want to get involved!
 - Read our contributing `guidelines <https://github.com/18F/openfec/blob/master/CONTRIBUTING.md>`_. Then, file an `issue <https://github.com/18F/fec/issues>`_ or submit a pull request.
 - Send us an email at betafeedback@fec.gov. 
 - If you’re a developer, follow the installation instructions in the README.md page of each repository to run the apps on your computer. 
-- Check out our StoriesonBoard `FEC story map <https://18f.storiesonboard.com/m/fec>`_.
+- Check out our StoriesonBoard `FEC story map <https://18f.storiesonboard.com/m/fec>`_ to get a sense of the user needs we'll be addressing in the future.
 
 
 Set up


### PR DESCRIPTION
Adds StoriesonBoard line

Per feedback from Content Critique group:
- Moves licensing to bottom
- Makes "Installation" fall under larger "Set up" heading
- Tweaks to language and repository information

cc @noahmanger 

[ci skip]