### PR TITLE
Removing next / prev nav

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -56,12 +56,10 @@
             <a href="{{ settings.FEC_APP_URL }}" class="site-nav__link is-current">Campaign finance data</a>
             <button class="site-nav__link site-nav__toggle js-sublist-toggle">Campaign finance data</button>
             <ul class="site-nav__dropdown">
-              <li class="site-nav__item u-under-lg-only">
+              <li class="site-nav__item">
                 <a class="t-bold site-nav__link" href="{{ settings.FEC_APP_URL }}">Campaign finance data home</a>
               </li>
-              <li class="site-nav__item">
-                <span class="t-bold site-nav__subtitle">Browse:</span>
-              </li>
+              <li class="t-bold site-nav__subtitle">Browse:</li>
               <li class="site-nav__item">
                 <a class="site-nav__link site-nav__sublink" href="{{ settings.FEC_APP_URL }}/candidates/?cycle=2012&cycle=2014&cycle=2016">Candidates</a>
               </li>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -14,19 +14,6 @@
   <div class="container">
     <div class="section__heading">
       <h1 class="heading__title t-display">{{ self.title }}</h1>
-      <div class="heading__action">
-        <div class="heading__action__top">
-          <a href="/registration-and-reporting#options">Essentials for other registrants</a>
-        </div>
-        <div class="heading__action__left">
-          <a class="button button--neutral button--previous" href="/registration-and-reporting/get-tax-id/">Previous article</a>
-          <span class="heading__link-name"><a href="/registration-and-reporting/get-tax-id/">Get a tax ID</a></span>
-        </div>
-        <div class="heading__action__right">
-          <a class="t-block button button--neutral button--next" href="/registration-and-reporting/get-treasurer/">Next article</a>
-          <span class="heading__link-name"><a href="/registration-and-reporting/get-treasurer/">Get a treasurer</a></span>
-        </div>
-      </div>
     </div>
     <div class="main__content">
       {{ self.body }}


### PR DESCRIPTION
This removes the previous and next navigation from articles while we wait to figure out how exactly we want it to work (https://github.com/18F/fec-cms/issues/144)

Resolves https://github.com/18F/fec-style/issues/194