### PR TITLE
Updates verb tenses

### DIFF
--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -102,7 +102,7 @@
               <li><a href="/registration-and-reporting/pre-election-reports/">Pre-election reports</a></li>
               <li><a href="/registration-and-reporting/48-hour-notices/">48-Hour Notices</a></li>
               <li><a href="/registration-and-reporting/post-general-election-reports/">Post-general election reports</a></li>
-              <li><a href="/registration-and-reporting/terminate-committee/">Committee termination</a></li>
+              <li><a href="/registration-and-reporting/terminate-committee/">Terminating a committee</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -51,7 +51,7 @@
       <div class="sidebar-container sidebar-container--left">
         <nav class="sidebar sidebar--neutral side-nav js-sticky js-toc" data-sticky-container="registration-steps">
           <ul class="sidebar__content">
-            <li class="side-nav__item"><a class="side-nav__link" href="#register">Register</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#register">Registration</a></li>
             <li class="side-nav__item"><a class="side-nav__link" href="#how-to-file">How to file</a></li>
             <li class="side-nav__item"><a class="side-nav__link" href="#regular-filing">Regular filing</a></li>
             <li class="side-nav__item"><a class="side-nav__link" href="#troubleshooting">Troubleshooting</a></li>
@@ -70,10 +70,10 @@
             <p>Candidates for the House of Representatives (and their authorized committees) register with the FEC.</p>
             <p>Candidates for Senate (and their authorized committees) register with the Secretary of the Senate.</p>
             <ul class="list--checks list--checks--secondary t-sans">
-              <li>Get a <a href="/registration-and-reporting/get-tax-id-and-bank-account/">tax ID and bank account</a></li>
-              <li>Get a <a href="/registration-and-reporting/get-treasurer/">treasurer</a></li>
-              <li><a href="/registration-and-reporting/register-now/">Register</a> as a candidate | <a href="/registration-and-reporting/house-and-senate-candidate-registration/">Learn more about how and why</a></li>
-              <li><a href="/registration-and-reporting/register-now/">Register</a> as a candidate committee | <a href="/registration-and-reporting/house-and-senate-candidate-committee-registration/">Learn more about how and why</a></li>
+              <li>Getting a <a href="/registration-and-reporting/get-tax-id-and-bank-account/">tax ID and bank account</a></li>
+              <li>Getting a <a href="/registration-and-reporting/get-treasurer/">treasurer</a></li>
+              <li><a href="/registration-and-reporting/register-now/">Registering</a> as a candidate | <a href="/registration-and-reporting/house-and-senate-candidate-registration/">Learn more about how and why</a></li>
+              <li><a href="/registration-and-reporting/register-now/">Registering</a> as a candidate committee | <a href="/registration-and-reporting/house-and-senate-candidate-committee-registration/">Learn more about how and why</a></li>
             </ul>
           </div>
         </div>
@@ -81,15 +81,15 @@
           <div class="option__content">
             <h2>How to file</h2>
             <ul class="list--checks list--checks--secondary t-sans">
-              <li>File electronically
+              <li>Electronic filing
                 <ul>
                   <li><a href="/registration-and-reporting/mandatory-electronic-filing/">Mandatory electronic filing</a></li>
                   <li><a href="/registration-and-reporting/file-electronically/">Electronic filing overview</a></li>
-                  <li><a href="/registration-and-reporting/get-e-filing-password/">Get an e-filing password</a></li>
+                  <li><a href="/registration-and-reporting/get-e-filing-password/">Getting an e-filing password</a></li>
                  </ul>
               </li>
-              <li><a href="/registration-and-reporting/file-paper/">File by paper</a></li>
-              <li><a href="/registration-and-reporting/get-filing-software/">Get filing software</a></li>
+              <li><a href="/registration-and-reporting/file-paper/">Paper filing</a></li>
+              <li><a href="/registration-and-reporting/get-filing-software/">Filing software</a></li>
             </ul>
           </div>
         </div>
@@ -102,7 +102,7 @@
               <li><a href="/registration-and-reporting/pre-election-reports/">Pre-election reports</a></li>
               <li><a href="/registration-and-reporting/48-hour-notices/">48-Hour Notices</a></li>
               <li><a href="/registration-and-reporting/post-general-election-reports/">Post-general election reports</a></li>
-              <li><a href="/registration-and-reporting/terminate-committee/">Terminate a committee</a></li>
+              <li><a href="/registration-and-reporting/terminate-committee/">Committee termination</a></li>
             </ul>
           </div>
         </div>
@@ -111,7 +111,7 @@
             <h2>Troubleshooting</h2>
             <ul class="list--checks list--checks--secondary t-sans">
               <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
-              <li>Respond to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
+              <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
               <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
               <li><a href="/contact-us/">Contact us</a></li>
             </ul>


### PR DESCRIPTION
I learned from GOV.UK that headers with verbs that sound like an imperative (something you can do right here and now) are confusing when websites are just providing content about the thing. For example, "Register now" just tells people *how* to register. It doesn't provide the service.

Have updated verb tenses in the checklist items to gerunds (-ing verbs) to clarify that we're just providing content around "Registration and reporting" in this section. 

Resolves: https://github.com/18F/fec-cms/issues/190