### PR TITLE
Feature/calendar accessibility

### DIFF
--- a/fec/fec/static/js/calendar-tooltip.js
+++ b/fec/fec/static/js/calendar-tooltip.js
@@ -27,7 +27,7 @@ CalendarTooltip.prototype.handleClickAway = function(e) {
 CalendarTooltip.prototype.close = function() {
   this.$content.remove();
   this.exportDropdown.destroy();
-  this.$container.find('.fc-content').focus();
+  this.$container.focus();
   this.events.clear();
 };
 

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -60,7 +60,7 @@ function Calendar(opts) {
   this.$calendar.on('calendar:rendered', this.filterPanel.setHeight());
   this.$calendar.on('click', '.js-toggle-view', this.toggleListView.bind(this));
 
-  this.$calendar.on('keypress', '.fc-content, .fc-more, .fc-close', this.simulateClick.bind(this));
+  this.$calendar.on('keypress', '.fc-event, .fc-more, .fc-close', this.simulateClick.bind(this));
   this.$calendar.on('click', '.fc-more', this.managePopoverControl.bind(this));
 
   this.filterPanel.$form.on('change', this.filter.bind(this));
@@ -95,6 +95,7 @@ Calendar.prototype.defaultOpts = function() {
       dayRender: this.handleDayRender.bind(this),
       dayPopoverFormat: 'MMM D, YYYY',
       defaultView: this.defaultView(),
+      eventRender: this.handleEventRender.bind(this),
       eventAfterAllRender: this.handleRender.bind(this),
       eventClick: this.handleEventClick.bind(this),
       eventLimit: true,
@@ -229,7 +230,6 @@ Calendar.prototype.handleRender = function(view) {
   } else if (this.$listToggles) {
     this.$listToggles.remove();
   }
-  this.$calendar.find('.fc-content').attr({'tabindex': '0', 'aria-describedby': this.detailsId});
   this.$calendar.find('.fc-more').attr({'tabindex': '0', 'aria-describedby': this.popoverId});
 };
 
@@ -245,6 +245,16 @@ Calendar.prototype.manageListToggles = function(view) {
   }
 };
 
+Calendar.prototype.handleEventRender = function(event, element) {
+  var eventLabel = event.title + ' ' +
+    event.start.format('dddd MMMM D, YYYY') +
+    '. Category: ' + event.category;
+  element.attr({
+    'tabindex': '0',
+    'aria-describedby': this.detailsId,
+    'aria-label': eventLabel});
+};
+
 Calendar.prototype.handleDayRender = function(date, cell) {
   if (date.date() === 1) {
     cell.append(date.format('MMMM'));
@@ -254,7 +264,8 @@ Calendar.prototype.handleDayRender = function(date, cell) {
 Calendar.prototype.handleEventClick = function(calEvent, jsEvent, view) {
   var $target = $(jsEvent.target);
   if (!$target.closest('.tooltip').length) {
-    var $eventContainer = $target.closest('.fc-content');
+    var $eventContainer = $target.closest('.fc-content').length > 0 ?
+      $target.closest('.fc-content') : $target.find('.fc-content');
     var tooltip = new calendarTooltip.CalendarTooltip(
       templates.details(_.extend({}, calEvent, {detailsId: this.detailsId})),
       $eventContainer.parent()
@@ -280,7 +291,6 @@ Calendar.prototype.managePopoverControl = function(e) {
     .on('click', function() {
       $target.focus();
     });
-  $popover.find('.fc-content').attr('tabindex', '0');
 };
 
 Calendar.prototype.highlightToday = function() {

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -42,50 +42,48 @@
             </div>
           </fieldset>
         </div>
-        <fieldset class="js-filter">
-          <legend class="filters__subheader">Event types</legend>
-          <div class="filter filter--meeting">
-            <span class="label">Commission meetings <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.meeting_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
-          <div class="filter filter--election">
-            <span class="label">Elections <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.election_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
-          <div class="filter filter--deadline">
-            <span class="label">Reporting deadlines <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.deadline_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
-          <div class="filter filter--outreach">
-            <span class="label">Outreach <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.outreach_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
-          <div class="filter filter--rules">
-            <span class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.rule_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
-          <div class="filter filter--other">
-            <span class="label">Other events <span class="filter__swatch"></span></span>
-            {% for value, label in settings.CONSTANTS.other_types.items %}
-              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-            {% endfor %}
-          </div>
+        <h3 class="filters__subheader">Event types</h3>
+        <fieldset class="js-filter filter filter--meeting">
+          <legend class="label">Commission meetings <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.meeting_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
+        </fieldset>
+        <fieldset class="js-filter filter filter--election">
+          <legend class="label">Elections <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.election_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
+        </fieldset>
+        <fieldset class="js-filter filter filter--deadline">
+          <legend class="label">Reporting deadlines <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.deadline_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
+        </fieldset>
+        <fieldset class="js-filter filter filter--outreach">
+          <legend class="label">Outreach <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.outreach_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
+        </fieldset>
+        <fieldset class="js-filter filter filter--rules">
+          <legend class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.rule_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
+        </fieldset>
+        <fieldset class="js-filter filter filter--other">
+          <legend class="label">Other events <span class="filter__swatch"></span></legend>
+          {% for value, label in settings.CONSTANTS.other_types.items %}
+            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+          {% endfor %}
         </fieldset>
       </form>
     </div>

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -43,48 +43,60 @@
           </fieldset>
         </div>
         <h3 class="filters__subheader">Event types</h3>
-        <fieldset class="js-filter filter filter--meeting">
-          <legend class="label">Commission meetings <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.meeting_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
-        <fieldset class="js-filter filter filter--election">
-          <legend class="label">Elections <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.election_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
-        <fieldset class="js-filter filter filter--deadline">
-          <legend class="label">Reporting deadlines <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.deadline_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
-        <fieldset class="js-filter filter filter--outreach">
-          <legend class="label">Outreach <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.outreach_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
-        <fieldset class="js-filter filter filter--rules">
-          <legend class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.rule_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
-        <fieldset class="js-filter filter filter--other">
-          <legend class="label">Other events <span class="filter__swatch"></span></legend>
-          {% for value, label in settings.CONSTANTS.other_types.items %}
-            <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-            <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-          {% endfor %}
-        </fieldset>
+        <div class="filter filter--meeting">
+          <fieldset class="js-filter">
+            <legend class="label">Commission meetings <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.meeting_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div class="filter filter--election">
+          <fieldset class="js-filter">
+            <legend class="label">Elections <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.election_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div class="filter filter--deadline">
+          <fieldset class="js-filter">
+            <legend class="label">Reporting deadlines <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.deadline_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div class="filter filter--outreach">
+          <fieldset class="js-filter">
+            <legend class="label">Outreach <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.outreach_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div class="filter filter--rules">
+          <fieldset class="js-filter">
+            <legend class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.rule_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div class="filter filter--other">
+          <fieldset class="js-filter">
+            <legend class="label">Other events <span class="filter__swatch"></span></legend>
+            {% for value, label in settings.CONSTANTS.other_types.items %}
+              <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+              <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+            {% endfor %}
+          </fieldset>
+        </div>
       </form>
     </div>
   </div>


### PR DESCRIPTION
Makes various fixes to the issues caught in https://github.com/18F/fec-cms/issues/207

- Correctly marks up fieldsets and legends in the filters
- Adds `aria-label` to events with the event title, date, and category (and makes a moves the other aria attributes / tabindex to `.fc-event` rather than `.fc-content` (see the last commit message for more)

This could probably be a hotfix, but fine either way.