### PR TITLE
Enabling calendar cards

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -14,7 +14,7 @@ deadline_types = OrderedDict([
 
 outreach_types = OrderedDict([
     ('Conferences', 'Conferences'),
-    ('Roundtables', 'Roundtables'),
+    ('Roundtables', 'Webinars'),
 ])
 
 meeting_types = OrderedDict([

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -139,15 +139,16 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast is-disabled">
+        <aside class="card card--horizontal card--secondary-contrast">
           <div class="card__image">
-            <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
+            <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
+              <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
+            </a>
           </div>
           <div class="card__content">
-            Reporting calendar
+            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
           </div>
         </aside>
-        <p>Coming soon</p>
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast is-disabled">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -20,12 +20,12 @@
     <div class="container">
       <h2 class="t-ruled--bottom main__content">What does it mean to register and report?</h2>
       <div class="main__content">
-        <p>The FEC helps citizens make informed voting decisions based, in part, on knowing the sources of financial support for 
+        <p>The FEC helps citizens make informed voting decisions based, in part, on knowing the sources of financial support for
         federal candidates and political committees.</p>
-        <p>Campaign finance law generally requires that federal candidates and political committees register once 
+        <p>Campaign finance law generally requires that federal candidates and political committees register once
         they reach certain monetary thresholds.</p>
-        <p>After registration, federal political committees must file regular reports with the FEC or the Secretary of the Senate. 
-        These reports disclose information about their receipts and disbursements. The FEC makes that information available to the 
+        <p>After registration, federal political committees must file regular reports with the FEC or the Secretary of the Senate.
+        These reports disclose information about their receipts and disbursements. The FEC makes that information available to the
         public on its website.</p>
       </div>
       <div class="sidebar-container">
@@ -128,15 +128,16 @@
       <h2 class="t-secondary-contrast">Need help?</h2>
       <div class="grid grid--4-wide">
         <div class="grid__item">
-          <aside class="card card--horizontal card--secondary-contrast is-disabled card--coming-soon">
+          <aside class="card card--horizontal card--secondary-contrast">
             <div class="card__image">
-              <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
+              <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
+                <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
+              </a>
             </div>
             <div class="card__content">
-              Reporting calendar
+              <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
             </div>
           </aside>
-          <p>Coming soon</p>
         </div>
         <div class="grid__item">
           <aside class="card card--horizontal card--secondary-contrast">


### PR DESCRIPTION
- Removes the disabled state for the cards on reporting and
registration pages
- Adds links to the calendar filtered down to monthly, quarterly and
pre-and-post-election reporting deadlines

Resolves https://github.com/18F/fec-cms/issues/217
Resolves #212 