### PR TITLE
Clean up calendar tests.

### DIFF
--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -215,7 +215,7 @@ Calendar.prototype.styleButtons = function() {
 };
 
 Calendar.prototype.defaultView = function() {
-  if ($(document).width() < helpers.BREAKPOINTS.MEDIUM) {
+  if ($(document.body).width() < helpers.BREAKPOINTS.MEDIUM) {
     return 'monthTime';
   } else {
     return 'month';


### PR DESCRIPTION
* Fix width-dependent tests
* Fix order-dependent tests
* Split up tests by category
* Delete unused imports
* Fix linter errors

@noahmanger: do you have a linter running in your editor? I fixed some linter errors in this patch.