### PR TITLE
[WIP] Nesting calendar filters in accordions

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -7,7 +7,10 @@ election_types = OrderedDict([
 deadline_types = OrderedDict([
     ('report-M', 'Monthly'),
     ('report-Q', 'Quarterly'),
-    ('report-E', 'Pre- and Post-election'),
+    ('report-E', 'Pre- and Post-election')
+])
+
+period_types = OrderedDict([
     ('IE Periods', 'Independent expenditures'),
     ('EC Periods', 'Electioneering communications')
 ])

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -34,12 +34,14 @@ $(document).ready(function() {
   // Initialize new accordions
   $('.js-accordion').each(function(){
     var contentPrefix = $(this).data('content-prefix') || 'accordion';
+    var openFirst = $(this).data('open-first') || false;
     var selectors = {
       body: '.js-accordion',
       trigger: '.js-accordion-trigger'
     };
     var opts = {
       contentPrefix: contentPrefix,
+      openFirst: openFirst
     };
     new Accordion(selectors, opts);
   });

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -11,92 +11,107 @@
 
 <section class="main__content--full">
   <div id="filters" class="filters">
-    <div class="filters__inner">
       <button id="filter-toggle" data-slide="left" class="filters__toggle">
         <span class="filters__toggle__text js-filter-toggle-text">Show filters</span>
       </button>
       <div class="filters__hider">
-        <h2 class="filter__header">
+        <h2 class="filter__header filters__inner">
           Filter events
         </h2>
-        <form id="category-filters">
-          <div class="">
-            <button class="button--sm button--primary-contrast" type="button">Apply filters</button>
-            <button class="button--sm button--neutral js-clear-filters" type="button">Clear filters</button>
+        <form id="category-filters" class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
+          <button type="button" class="js-accordion-trigger accordion__button">Reporting deadlines and elections</button>
+          <div class="accordion__content">
+            <div class="filter">
+              <fieldset class="js-filter js-dropdown">
+                <legend class="label" for="state">State</legend>
+                <ul class="dropdown__selected"></ul>
+                <div class="dropdown">
+                  <button type="button" class="dropdown__button button--neutral">Select</button>
+                  <div class="dropdown__panel" aria-hidden="true">
+                    <ul class="{{ css_class }}">
+                    {% for value, label in settings.CONSTANTS.states.items %}
+                    <li class="dropdown__item">
+                      <input id="state-{{ value }}" name="state" type="checkbox" value="{{ value }}">
+                      <label class="dropdown__value" for="state-{{ value }}">{{ label }}</label>
+                    </li>
+                    {% endfor %}
+                    </ul>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            <div class="filter filter--election">
+              <fieldset class="js-filter">
+                <legend class="label">Elections <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.election_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+            <div class="filter filter--deadline">
+              <fieldset class="js-filter">
+                <legend class="label">Reporting deadlines <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.deadline_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+          </div>
+          <button type="button" class="js-accordion-trigger accordion__button">Other events</button>
+          <div class="accordion__content">
+            <div class="filter filter--meeting">
+              <fieldset class="js-filter">
+                <legend class="label">Commission meetings <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.meeting_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+            <div class="filter filter--deadline">
+              <fieldset class="js-filter">
+                <legend class="label">Reporting periods <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.period_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+            <div class="filter filter--outreach">
+              <fieldset class="js-filter">
+                <legend class="label">Outreach <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.outreach_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+            <div class="filter filter--rules">
+              <fieldset class="js-filter">
+                <legend class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.rule_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
+            <div class="filter filter--other">
+              <fieldset class="js-filter">
+                <legend class="label">Other events <span class="filter__swatch"></span></legend>
+                {% for value, label in settings.CONSTANTS.other_types.items %}
+                  <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                  <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                {% endfor %}
+              </fieldset>
+            </div>
           </div>
           <div class="filter">
-            <fieldset class="js-filter js-dropdown">
-              <legend class="label" for="state">State</legend>
-              <ul class="dropdown__selected"></ul>
-              <div class="dropdown">
-                <button type="button" class="dropdown__button button--neutral">Select</button>
-                <div class="dropdown__panel" aria-hidden="true">
-                  <ul class="{{ css_class }}">
-                  {% for value, label in settings.CONSTANTS.states.items %}
-                  <li class="dropdown__item">
-                    <input id="state-{{ value }}" name="state" type="checkbox" value="{{ value }}">
-                    <label class="dropdown__value" for="state-{{ value }}">{{ label }}</label>
-                  </li>
-                  {% endfor %}
-                  </ul>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-          <h3 class="filters__subheader">Event types</h3>
-          <div class="filter filter--meeting">
-            <fieldset class="js-filter">
-              <legend class="label">Commission meetings <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.meeting_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
-          </div>
-          <div class="filter filter--election">
-            <fieldset class="js-filter">
-              <legend class="label">Elections <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.election_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
-          </div>
-          <div class="filter filter--deadline">
-            <fieldset class="js-filter">
-              <legend class="label">Reporting deadlines <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.deadline_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
-          </div>
-          <div class="filter filter--outreach">
-            <fieldset class="js-filter">
-              <legend class="label">Outreach <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.outreach_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
-          </div>
-          <div class="filter filter--rules">
-            <fieldset class="js-filter">
-              <legend class="label">Advisory Opinions and rulemakings <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.rule_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
-          </div>
-          <div class="filter filter--other">
-            <fieldset class="js-filter">
-              <legend class="label">Other events <span class="filter__swatch"></span></legend>
-              {% for value, label in settings.CONSTANTS.other_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
-            </fieldset>
+            <div class="filters__inner">
+              <button class="button--sm button--primary-contrast" type="button">Apply filters</button>
+              <button class="button--sm button--neutral js-clear-filters" type="button">Clear filters</button>
+            </div>
           </div>
         </form>
       </div>


### PR DESCRIPTION
Alongside the work we just did to put datatable filters inside accordions, this does the same for the calendar filters.

<img width="619" alt="screen shot 2016-03-11 at 2 30 20 pm" src="https://cloud.githubusercontent.com/assets/1696495/13717389/04116a02-e796-11e5-886e-289b7ac22c87.png">

This is loosely based on @jenniferthibault 's original designs, with some slight modifications:

1. I grouped "Reporting periods", "Elections" and "State" together into the same accordion item, since they are they only events that are affected by the "State" filter.
2. Because IE and EC periods aren't affected by the "State" filter (as we don't have the data for that), I broke them out to their own filter called "Reporting periods"
3. I grouped all other filters in a single accordion item for "Other events" since I think it looks weird to have each filter be in an accordion item of their own.

This doesn't _need_ to get into the release, but wanted to propose it on the off-chance that it's an easy change that people agree with.

In particular, curious what @amykort @ChristianHilland @emileighoutlaw and @jenniferthibault think.