### PR TITLE
Fix calendar markup.

### DIFF
--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -101,15 +101,15 @@
         </form>
       </div>
     </div>
-    <div class="data-container">
-      <div class="data-container__widgets data-container__widgets--secondary js-data-widgets">
-        <div class="data-container__export">
-          <div id="calendar-subscribe" class="export-widget"></div>
-          <div id="calendar-download" class="export-widget"></div>
-        </div>
+  </div>
+  <div class="data-container">
+    <div class="data-container__widgets data-container__widgets--secondary js-data-widgets">
+      <div class="data-container__export">
+        <div id="calendar-subscribe" class="export-widget"></div>
+        <div id="calendar-download" class="export-widget"></div>
       </div>
-      <div id="calendar" class="data-container__body"></div>
     </div>
+    <div id="calendar" class="data-container__body"></div>
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
Because I closed a `<div>` in the wrong place. Targeting the release branch so we don't release the wrong markup.