### PR TITLE
Update fec-style package to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "glossary-panel": "0.1.1",
     "ace-builds": "1.2.2",
     "component-sticky": "1.0.0",
-    "fec-style": "1.7.0",
+    "fec-style": "1.7.1",
     "fullcalendar": "2.5.0",
     "jquery": "2.1.4",
     "js-beautify": "1.5.10",


### PR DESCRIPTION
This changeset updates the `fec-style` package to pin version 1.7.1, the latest current release.