### PR TITLE
new breadcrumbs

### DIFF
--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -31,7 +31,7 @@
         <aside class="sidebar sidebar--secondary">
           <h4 class="sidebar__title">Essentials for other registrants</h4>
           <ul class="sidebar__content">
-            <li class="u-padding--bottom"><a href="registration-and-reporting/corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
+            <li class="u-padding--bottom"><a href="registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
             <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
             <li class="u-padding--bottom is-disabled">Political party committees</li>
           </ul>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -4,10 +4,13 @@
 
 {% block content %}
 <header class="page-header slab--secondary">
-  <span class="page-header__title">
-    <a href="/registration-and-reporting">Registration and reporting</a> //
-    <a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Essentials for House and Senate candidates and committees</a> //
-    {{ self.title }}</span>
+  <div class="container">
+    <span class="t-sans">
+      <a href="/registration-and-reporting">Registration and reporting</a> //
+      Essentials //
+      {{ self.title }}
+    </span>
+  </div>
 </header>
 
 <article class="main">

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -132,12 +132,12 @@
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast card--full-bleed">
           <div class="card__image">
-            <a class="u-no-border" href="http://www.fec.gov/pdf/candgui.pdf">
-              <img src="{% static "img/guide--candidates.jpg" %}" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
+            <a class="u-no-border" href="http://www.fec.gov/pdf/colagui.pdf">
+              <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
             </a>
           </div>
           <div class="card__content">
-            <a href="http://www.fec.gov/pdf/candgui.pdf">Read the campaign guide (PDF)</a>
+            <a href="http://www.fec.gov/pdf/colagui.pdf">Read the campaign guide (PDF)</a>
           </div>
         </aside>
       </div>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -33,7 +33,7 @@
         <aside class="sidebar sidebar--secondary">
           <h4 class="sidebar__title">Essentials for other registrants</h4>
           <ul class="sidebar__content">
-            <li class="u-padding--bottom"><a href="registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
             <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
             <li class="u-padding--bottom is-disabled">Political party committees</li>
           </ul>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "aria-accordion": "0.1.0",
-    "glossary-panel": "0.1.1",
+    "glossary-panel": "0.1.2",
     "ace-builds": "1.2.2",
     "component-sticky": "1.0.0",
     "fec-style": "1.7.0",


### PR DESCRIPTION
Adjusts the breadcrumbs so that essentials pages that may be referenced from the new SSF checklist don't appear nested under the candidate committee essentials list.

![screen shot 2016-03-16 at 1 50 56 pm](https://cloud.githubusercontent.com/assets/1696495/13828312/25da4b72-eb7e-11e5-9e29-96a39de03923.png)

## Update: Also fixes other small things:
- Fixes the link to the campaign guide to go to the SSF guide [Resolves https://github.com/18F/fec-cms/issues/246]
- Resolves https://github.com/18F/fec-cms/issues/245
