### PR TITLE
Reinstating the correct order of the new features list

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -39,15 +39,6 @@
         </div>
         <div class="feature feature--no-title grid__item">
           <div class="card card--primary">
-            <img class="card__image" src="{% static "img/i-glossary--neutral.svg" %}" alt="Icon representing the glossary">
-            <div class="card__content">
-              <span>Use the glossary to learn the meaning of an unfamiliar word or phrase</span>
-            </div>
-          </div>
-          <p>Click words or phrases with the book icon next to them to pull up a definition. Or click the glossary icon at the top of any page to open the full, searchable glossary. For example, click on this term to see its definition: <span class="term" data-term="principal campaign committee">principal campaign committee</span>.</p>
-        </div>
-        <div class="feature feature--no-title grid__item">
-          <div class="card card--primary">
             <a class="card__image-link" href="/registration-and-reporting">
               <img class="card__image" src="{% static "img/i-register--neutral.svg" %}" alt="Icon for reporting and registration">
             </a>
@@ -56,6 +47,15 @@
             </div>
           </div>
           <p>We’re making it easier for groups to learn the essentials of registration and reporting. We started with House and Senate candidates and committees, but soon we’ll have content for all the individuals and groups that register with the FEC.</p>
+        </div>
+        <div class="feature feature--no-title grid__item">
+          <div class="card card--primary">
+            <img class="card__image" src="{% static "img/i-glossary--neutral.svg" %}" alt="Icon representing the glossary">
+            <div class="card__content">
+              <span>Use the glossary to learn the meaning of an unfamiliar word or phrase</span>
+            </div>
+          </div>
+          <p>Click words or phrases with the book icon next to them to pull up a definition. Or click the glossary icon at the top of any page to open the full, searchable glossary. For example, click on this term to see its definition: <span class="term" data-term="principal campaign committee">principal campaign committee</span>.</p>
         </div>
         <div class="feature feature--no-title grid__item">
           <div class="card card--primary">


### PR DESCRIPTION
Now that everything we've previewed as new features is live, we can reinstate the original order of the glossary and registration and reporting cards in the new features section of the home page.

**How it was before:**

<img width="1022" alt="screen shot 2016-03-18 at 11 46 13 am" src="https://cloud.githubusercontent.com/assets/11636908/13883333/3ffad6fc-ecff-11e5-93fc-5907264598f2.png">


**How it was originally, and the order it will be now:**
This alternates the icon colors, and puts the most important content at the front of the list

![screen shot 2016-03-18 at 11 49 24 am](https://cloud.githubusercontent.com/assets/11636908/13883374/7cd4bac0-ecff-11e5-827a-85d2e865c228.png)


Note: this doesn't actually change any content, it just rearranges it.