### PR TITLE
Updating the pinned version of fec-style

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "glossary-panel": "0.1.2",
     "ace-builds": "1.2.2",
     "component-sticky": "1.0.0",
-    "fec-style": "1.7.2",
+    "fec-style": "~1.7",
     "fullcalendar": "2.5.0",
     "jquery": "2.1.4",
     "js-beautify": "1.5.10",


### PR DESCRIPTION
This changeset updates the dependency to `fec-style` to allow for retrieving the latest patch level.

/cc @noahmanger