### PR TITLE
Legal resources placeholder page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ Settings: ::
 Features
 ~~~~~~~~~~~~~~~~~~~~~~
 
-[settings.py](https://github.com/18F/fec-cms/blob/develop/fec/fec/settings/base.py) includes a set of `FEATURES` which can be enabled using environment flags or via `settings.local`.
+`settings.py <https://github.com/18F/fec-cms/blob/develop/fec/fec/settings/base.py>`_ includes a set of ``FEATURES`` which can be enabled using environment flags or via ``settings.local``. ::
 
-    $ FEC_CMS_FEATURE_LEGAL=1 python fec/manage.py runserver
+    FEC_FEATURE_LEGAL=1 python fec/manage.py runserver
 
 
 Run

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,14 @@ Settings: ::
 
     FEC_APP_URL = 'http://localhost:3000'
 
+Features
+~~~~~~~~~~~~~~~~~~~~~~
+
+[settings.py](https://github.com/18F/fec-cms/blob/develop/fec/fec/settings/base.py) includes a set of `FEATURES` which can be enabled using environment flags or via `settings.local`.
+
+    $ FEC_CMS_FEATURE_LEGAL=1 python fec/manage.py runserver
+
+
 Run
 -----------------
 

--- a/fec/fec/context.py
+++ b/fec/fec/context.py
@@ -1,4 +1,7 @@
 from django.conf import settings
 
+def features(request):
+    return {'features': settings.FEATURES}
+
 def show_settings(request):
     return {'settings': settings}

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -179,11 +179,8 @@ FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(os.getenv('FEC_CMS_ENVIRONMENT'), 'DEVELO
 CONTACT_EMAIL = 'betafeedback@fec.gov';
 CONSTANTS = constants
 
-def feature_enabled(feature):
-    return os.getenv(feature, False) == '1'
-
 FEATURES = {
-    'legal': feature_enabled('FEC_CMS_FEATURE_LEGAL')
+    'legal': bool(os.getenv('FEC_FEATURE_LEGAL', ''))
 }
 
 if os.getenv('SENTRY_DSN'):

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -53,6 +53,7 @@ INSTALLED_APPS = (
     'fec',
     'search',
     'home',
+    'legal',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -85,6 +86,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'fec.context.show_settings',
+                'fec.context.features',
             ],
         },
     },
@@ -176,6 +178,13 @@ ENVIRONMENTS = {
 FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(os.getenv('FEC_CMS_ENVIRONMENT'), 'DEVELOPMENT')
 CONTACT_EMAIL = 'betafeedback@fec.gov';
 CONSTANTS = constants
+
+def feature_enabled(feature):
+    return os.getenv(feature, False) == '1'
+
+FEATURES = {
+    'legal': feature_enabled('FEC_CMS_FEATURE_LEGAL')
+}
 
 if os.getenv('SENTRY_DSN'):
     INSTALLED_APPS += ('raven.contrib.django.raven_compat', )

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -91,7 +91,7 @@
           </li>
           {% if features.legal %}
           <li class="site-nav__item">
-            <a href="/legal-resources" class="site-nav__link">Legal Resources</a>
+            <a href="/legal-resources" class="site-nav__link">Legal resources</a>
           </li>
           {% else %}
           <li class="site-nav__item is-disabled">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -89,9 +89,15 @@
           <li class="site-nav__item">
             <a href="/calendar" class="site-nav__link">Calendar</a>
           </li>
+          {% if features.legal %}
+          <li class="site-nav__item">
+            <a href="/legal-resources" class="site-nav__link">Legal Resources</a>
+          </li>
+          {% else %}
           <li class="site-nav__item is-disabled">
             <a href="#" class="site-nav__link" tabindex="-1">(Page TBD)</a>
           </li>
+          {% endif %}
           <li class="site-nav__item is-disabled">
             <a href="#" class="site-nav__link" tabindex="-1">(Page TBD)</a>
           </li>

--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -3,7 +3,7 @@
     <div class="container">
       <div class="hero__heading">
         <h1 id="hero-heading" class="hero__title t-display">{{ search_hero_heading | default:'Search betaFEC' }}</h1>
-        <h2 class="hero__subtitle t-ruled">Find the resources you need</h2>
+        <h2 class="hero__subtitle t-ruled">Find the information you need</h2>
       </div>
       <form id="large-search" autocomplete="off" class="search__container js-search">
         <div class="combo combo--search--large">

--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -7,14 +7,14 @@
       </div>
       <form id="large-search" autocomplete="off" class="search__container js-search">
         <div class="combo combo--search--large">
-          <select class="search__select js-search-type" name="search_type">
+          <select class="search__select js-search-type" name="search_type" aria-label="Select a search type">
             <option value="all">All sources</option>
             <option value="candidates">Candidates</option>
             <option value="committees">Committees</option>
             <option value="aos">AOs</option>
             <option value="murs">MURs</option>
           </select>
-          <input type="text" name="query" class="combo__input js-search-input" placeholder="e.g. candidate, committee, advisory opinion, topic"{% if search_query %} value="{{ search_query }}"{% endif %}>
+          <input type="text" name="query" class="combo__input js-search-input" aria-label="e.g. candidate, committee, advisory opinion, topic" placeholder="e.g. candidate, committee, advisory opinion, topic"{% if search_query %} value="{{ search_query }}"{% endif %}>
           <button type="submit" class="button--primary button--search combo__button">
            <span class="u-visually-hidden">Search</span>
           </button>

--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -1,0 +1,28 @@
+{% block content %}
+  <section class="hero hero--primary" aria-labelledby="hero-search">
+    <div class="container">
+      <div class="hero__heading">
+        <h1 id="hero-heading" class="hero__title t-display">{{ search_hero_heading | default:'Search betaFEC' }}</h1>
+        <h2 class="hero__subtitle t-ruled">Find the resources you need</h2>
+      </div>
+      <form id="large-search" autocomplete="off" class="search__container js-search">
+        <div class="combo combo--search--large">
+          <select class="search__select js-search-type" name="search_type">
+            <option value="all">All sources</option>
+            <option value="candidates">Candidates</option>
+            <option value="committees">Committees</option>
+            <option value="aos">AOs</option>
+            <option value="murs">MURs</option>
+          </select>
+          <input type="text" name="query" class="combo__input js-search-input" placeholder="e.g. candidate, committee, advisory opinion, topic"{% if search_query %} value="{{ search_query }}"{% endif %}>
+          <button type="submit" class="button--primary button--search combo__button">
+           <span class="u-visually-hidden">Search</span>
+          </button>
+        </div>
+        <div class="search__minor t-right-aligned">
+          <a href="#">Advanced search</a>
+        </div>
+      </form>
+    </div>
+  </section>
+{% endblock %}

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r'^documents/', include(wagtaildocs_urls)),
 
     url(r'^search/$', 'search.views.search', name='search'),
+    url(r'^legal-resources/$', 'legal.views.home', name='legal'),
 
     url(r'', include(wagtail_urls)),
 ]

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+{% load staticfiles %}
+{% block title %}Legal Resources{% endblock %}
+{% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
+
+{% block content %}
+  {% include "partials/search-hero.html" %}
+{% endblock %}
+
+{% block extra_js %}
+<!-- Ethnio Activation Code -->
+<script type="text/javascript" language="javascript" src="https://ethn.io/70862.js" async="true" charset="utf-8"></script>
+{% endblock %}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render
+
+def home(request):
+    search_query = request.GET.get('query', None)
+
+    return render(request, 'legal/home.html', {
+        'search_hero_heading': 'Legal Resources',
+        'search_query': search_query,
+    })


### PR DESCRIPTION
This adds a new `legal` module and page for the [legal resources work](https://projects.invisionapp.com/share/5N6NL76QM#/screens/145835129). This serves as a placeholder where we can put functionality until we figure out where they should live permanently.

This adds a Legal Resources tab in the nav, hidden behind a feature flag. This won't show up on production, but the plan is to have it show in a staging environment so we can get some feedback from clients.

![screenshot from 2016-03-29 17-09-56](https://cloud.githubusercontent.com/assets/509703/14127976/3491bda0-f5d1-11e5-969f-14c545ccda29.png)


cc @anthonygarvan