### PR TITLE
Removes "FEC"

### DIFF
--- a/fec/fec/templates/partials/glossary.html
+++ b/fec/fec/templates/partials/glossary.html
@@ -5,7 +5,7 @@
       class="button button--close--inverse toggle js-glossary-close"
     ><span class="u-visually-hidden">Hide glossary</span>
   </button>
-  <h2>FEC Glossary</h2>
+  <h2>Glossary</h2>
   <label for="glossary-search" class="label">Filter glossary terms</label>
   <input id="glossary-search" class="glossary__search js-glossary-search" type="search" placeholder="e.g. Committee">
   <div class="glossary__content" id="glossary-result">

--- a/fec/fec/templates/partials/glossary.html
+++ b/fec/fec/templates/partials/glossary.html
@@ -6,8 +6,8 @@
     ><span class="u-visually-hidden">Hide glossary</span>
   </button>
   <h2>Glossary</h2>
-  <label for="glossary-search" class="label">Filter glossary terms</label>
-  <input id="glossary-search" class="glossary__search js-glossary-search" type="search" placeholder="e.g. Committee">
+  <label for="glossary-search" class="label">Filter terms</label>
+  <input id="glossary-search" class="glossary__search js-glossary-search" type="search" placeholder="e.g., Authorized committee">
   <div class="glossary__content" id="glossary-result">
     <ul class="glossary__list js-glossary-list accordion--inverse"></ul>
   </div>


### PR DESCRIPTION
Content only change: 

We've been talking about naming and branding with regards to the 18F site, and so this content piece stuck out to me when we were doing design demo today.

There's lots of available branding and visual clues that people are on the FEC website. So having the glossary called "FEC Glossary" rather than "Glossary," feels a little redundant. And any word we can remove is one less word we to distract site visitors who don't want the cognitive burden of reading. 

Anyone have any objections to this change?


This PR also adds a needed comma after "e.g.," and changes the exampled to "authorized committee" (which is in the glossary, unlike the current "committee," which is not)