### PR TITLE
Add Notification Support

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,3 +1,11 @@
+#!/bin/bash
+
+# Set environment options to exit immediately if a non-zero status code
+# appears from a command or within a pipe
+set -o errexit
+set -o pipefail
+
+# Send out Slack notification(s)
 invoke notify
 
 # Build static files

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,3 +1,5 @@
+invoke notify
+
 # Build static files
 cd fec
 gulp build-js


### PR DESCRIPTION
This changeset adds the notification hook that is currently missing in the `run` script.  Closes #272.

/cc @LindsayYoung, @anthonygarvan, @adborden, @noahmanger