### PR TITLE
Adding checklist and landing page content for party committees

### DIFF
--- a/fec/home/migrations/0011_ssfchecklistpage.py
+++ b/fec/home/migrations/0011_ssfchecklistpage.py
@@ -26,4 +26,15 @@ class Migration(migrations.Migration):
             },
             bases=('wagtailcore.page',),
         ),
+        migrations.CreateModel(
+            name='PartyChecklistPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(primary_key=True, auto_created=True, to='wagtailcore.Page', serialize=False, parent_link=True)),
+                ('body', wagtail.wagtailcore.fields.StreamField((('heading', wagtail.wagtailcore.blocks.CharBlock(classname='full title')), ('paragraph', wagtail.wagtailcore.blocks.RichTextBlock()), ('html', wagtail.wagtailcore.blocks.RawHTMLBlock()), ('image', wagtail.wagtailimages.blocks.ImageChooserBlock())), blank=True, null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
     ]

--- a/fec/home/migrations/0012_auto_20160427_2133.py
+++ b/fec/home/migrations/0012_auto_20160427_2133.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailforms', '0002_add_verbose_names'),
+        ('wagtailredirects', '0002_add_verbose_names'),
+        ('wagtailsearch', '0002_add_verbose_names'),
+        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+        ('home', '0011_ssfchecklistpage'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='optionspage',
+            name='page_ptr',
+        ),
+        migrations.DeleteModel(
+            name='OptionsPage',
+        ),
+    ]

--- a/fec/home/migrations/0012_partychecklistpage.py
+++ b/fec/home/migrations/0012_partychecklistpage.py
@@ -11,12 +11,12 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
-        ('home', '0010_calendarpage'),
+        ('home', '0011_ssfchecklistpage'),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='SSFChecklistPage',
+            name='PartyChecklistPage',
             fields=[
                 ('page_ptr', models.OneToOneField(primary_key=True, auto_created=True, to='wagtailcore.Page', serialize=False, parent_link=True)),
                 ('body', wagtail.wagtailcore.fields.StreamField((('heading', wagtail.wagtailcore.blocks.CharBlock(classname='full title')), ('paragraph', wagtail.wagtailcore.blocks.RichTextBlock()), ('html', wagtail.wagtailcore.blocks.RawHTMLBlock()), ('image', wagtail.wagtailimages.blocks.ImageChooserBlock())), blank=True, null=True)),

--- a/fec/home/migrations/0013_auto_20160427_2133.py
+++ b/fec/home/migrations/0013_auto_20160427_2133.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
         ('wagtailredirects', '0002_add_verbose_names'),
         ('wagtailsearch', '0002_add_verbose_names'),
         ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
-        ('home', '0011_ssfchecklistpage'),
+        ('home', '0012_partychecklistpage'),
     ]
 
     operations = [

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -55,7 +55,7 @@ class ChecklistPage(ContentPage):
 class SSFChecklistPage(ContentPage):
     pass
 
-class OptionsPage(ContentPage):
+class PartyChecklistPage(ContentPage):
     pass
 
 class ContactPage(ContentPage):

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -41,8 +41,8 @@
           <h4 class="sidebar__title">Essentials for other registrants</h4>
           <ul class="sidebar__content">
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></li>
             <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
-            <li class="u-padding--bottom is-disabled">Political party committees</li>
           </ul>
           <h4 class="sidebar__title">Already registered?</h4>
           <form class="sidebar__content" action="{{ settings.FEC_APP_URL }}" method="GET">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -107,7 +107,7 @@
           <h3>Political party committees</h3>
           <h4 class="t-bold">Forming a new national or state political party organization</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
-          <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) <span class="term" data-term="party committee">party committees</span>. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
+          <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) <span class="term" data-term="party committee">party committees</span>. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC <a href="http://www.fec.gov/pages/brochures/ao.shtml">advisory opinion</a> to verify that your committee has attained national (or state) committee status.</p>
           <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
           <h4 class="t-bold">Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -77,7 +77,7 @@
       </div>
       <div id="corporations-and-labor" class="option">
         <div class="option__content">
-          <h3><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></h3>
+          <h3><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Corporations and labor organizations</a></h3>
           <p>Corporations and labor organizations <span class="t-bold">can't</span> contribute to federal candidates, but they <span class="t-bold">can</span> establish and administer a special kind of political committee: the separate segregated fund (SSF).</p>
           <p>An SSF can raise funds to make contributions to candidates — including expenditures that are coordinated with candidates — within the applicable contribution limits.</p>
           <p>
@@ -92,7 +92,7 @@
           </p>
           <p>The sponsoring corporation or labor organization is called the SSF’s “connected organization.”  The connected organization can use its own money to solicit contributions to the SSF and to pay the costs of establishing and operating the SSF, for example staff salaries and office space.</p>
           <p>SSFs may solicit contributions only from a limited group of people, including the connected organization’s executive or administrative personnel, its stockholders (if the connected organization is a corporation), or its members (if the connected organization is a labor organization or a membership organization).</p>
-          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Get started</a>
+          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Get started</a>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>
@@ -100,6 +100,27 @@
             <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/colagui.pdf">(PDF)</a>
+        </div>
+      </div>
+      <div id="parties" class="option">
+        <div class="option__content">
+          <h3>Political party committees</h3>
+          <h4 class="t-bold">Forming a new national or state political party organization</h4>
+          <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
+          <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) party committee. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
+          <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
+          <h4 class="t-bold">Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h4>
+          <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
+          <p>When your local party organization is required to register with the FEC, it becomes a local party committee. Your local party committee is presumed to be affiliated with the other federal party committees in your state. Affiliated committees share limits on contributions made and received.</p>
+          <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
+          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-political-party-committees">Get started</a>
+        </div>
+        <div class="option__aside">
+          <h5 class="label">Campaign guide</h5>
+          <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
+            <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
+          </a>
+          <a class="t-sans" href="http://www.fec.gov/pdf/partygui.pdf">(PDF)</a>
         </div>
       </div>
       <div id="nonconnected" class="option">
@@ -113,19 +134,6 @@
             <img src="{% static "img/guide--nonconnected.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/nongui.pdf">(PDF)</a>
-        </div>
-      </div>
-      <div id="parties" class="option">
-        <div class="option__content">
-          <h3>Coming soon: Political party committees</h3>
-          <p>This is the FEC’s beta site, which means it’s still being developed. Learn more by reading the campaign guide, and check back soon for more information about political party committees.</p>
-        </div>
-        <div class="option__aside">
-          <h5 class="label">Campaign guide</h5>
-          <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
-            <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
-          </a>
-          <a class="t-sans" href="http://www.fec.gov/pdf/partygui.pdf">(PDF)</a>
         </div>
       </div>
       <div class="option">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -107,7 +107,7 @@
           <h3>Political party committees</h3>
           <h4 class="t-bold">Forming a new national or state political party organization</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
-          <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) party committee. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
+          <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) <span class="term" data-term="party committee">party committees</span>. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
           <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
           <h4 class="t-bold">Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -24,27 +24,21 @@
     <h1 class="main__title">{{ self.title }}</h1>
     <div class="content__section">
       <div class="main__content">
-          <p>Corporations and labor organizations <span class="t-bold">can't</span> contribute to federal candidates, but they <span class="t-bold">can</span> establish and administer a special kind of political committee: the separate segregated fund (SSF).</p>
-          <p>An SSF can raise funds to make contributions to candidates — including expenditures that are coordinated with candidates — within the applicable contribution limits.</p>
-          <p>
-            <span class="t-bold">Who can set up an SSF?</span>
-            <ul class="list--bulleted">
-              <li>Corporations (including those without capital stock)</li>
-              <li>Labor organizations</li>
-              <li>Incorporated membership organizations (including trade associations)</li>
-              <li>National banks</li>
-              <li>Incorporated cooperatives</li>
-            </ul>
-          </p>
-          <p>The sponsoring corporation or labor organization is called the SSF’s “connected organization.”  The connected organization can use its own money to solicit contributions to the SSF and to pay the costs of establishing and operating the SSF, for example staff salaries and office space.</p>
-          <p>SSFs may solicit contributions only from a limited group of people, including the connected organization’s executive or administrative personnel, its stockholders (if the connected organization is a corporation), or its members (if the connected organization is a labor organization or a membership organization).</p>
+        <h3>Forming a new national or state political party organization</h3>
+        <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
+        <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) party committee. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
+        <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
+        <h3>Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h3>
+        <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
+        <p>When your local party organization is required to register with the FEC, it becomes a local party committee. Your local party committee is presumed to be affiliated with the other federal party committees in your state. Affiliated committees share limits on contributions made and received.</p>
+        <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
       </div>
       <div class="sidebar-container">
         <aside class="sidebar sidebar--secondary">
           <h4 class="sidebar__title">Essentials for other registrants</h4>
           <ul class="sidebar__content">
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
-            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
             <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
           </ul>
           <h4 class="sidebar__title">Already registered?</h4>
@@ -77,7 +71,7 @@
             <ul class="list--checks list--checks--secondary t-sans">
               <li>Getting a <a href="/registration-and-reporting/get-tax-id-and-bank-account/">tax ID and bank account</a></li>
               <li>Getting a <a href="/registration-and-reporting/get-treasurer/">treasurer</a></li>
-              <li>Registering <a href="/registration-and-reporting/ssf-registration/">an SSF</a></li>
+              <li>Registering a <a href="/registration-and-reporting/party-committee-registration/">party committee</a></li>
             </ul>
           </div>
         </div>
@@ -87,12 +81,12 @@
             <ul class="list--checks list--checks--secondary t-sans">
               <li>Electronic filing
                 <ul>
-                  <li><a href="/registration-and-reporting/get-e-filing-password/">Getting an e-filing password</a></li>
-                  <li><a href="/registration-and-reporting/file-electronically/">Electronic filing overview</a></li>
                   <li><a href="/registration-and-reporting/mandatory-electronic-filing/">Mandatory electronic filing</a></li>
+                  <li><a href="/registration-and-reporting/file-electronically/">Electronic filing overview</a></li>
+                  <li><a href="/registration-and-reporting/get-e-filing-password/">Getting an e-filing password</a></li>
                  </ul>
               </li>
-              <li><a href="/registration-and-reporting/ssf-file-paper/">Paper filing</a></li>
+              <li><a href="/registration-and-reporting/party-committee-file-paper/">Paper filing</a></li>
               <li><a href="/registration-and-reporting/get-filing-software/">Filing software</a></li>
             </ul>
           </div>
@@ -101,21 +95,21 @@
           <div class="option__content">
             <h2>Regular filing</h2>
             <ul class="list--checks list--checks--secondary t-sans">
-              <li><a href="/registration-and-reporting/ssf-filing-requirements/">Filing requirements</a></li>
-              <li><a href="/registration-and-reporting/ssf-election-year-filing">Election years</a>
+              <li><a href="/registration-and-reporting/party-committee-filing-requirements/">Filing requirements</a></li>
+              <li><a href="/registration-and-reporting/party-committee-election-year-filing">Election years</a>
                 <ul>
-                  <li><a href="/registration-and-reporting/quarterly-filers">Quarterly filers</a></li>
-                  <li><a href="/registration-and-reporting/monthly-filers">Monthly filers</a></li>
-                  <li><a href="/registration-and-reporting/independent-expenditures">Independent expenditures</a></li>
+                  <li><a href="/registration-and-reporting/party-committee-quarterly-filers">Quarterly filers</a></li>
+                  <li><a href="/registration-and-reporting/party-committee-monthly-filers">Monthly filers</a></li>
+                  <li><a href="/registration-and-reporting/party-committee-independent-expenditures">Independent expenditures</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/non-election-year-filing">Non-election years</a>
+              <li><a href="/registration-and-reporting/party-committee-non-election-year-filing">Non-election years</a>
                 <ul>
-                  <li><a href="/registration-and-reporting/semi-annual-filers">Semi-annual filers</a></li>
-                  <li><a href="/registration-and-reporting/non-election-monthly-filers">Monthly filers</a></li>
+                  <li><a href="/registration-and-reporting/party-committee-non-election-monthly-filers">Monthly filers</a></li>
+                  <li><a href="/registration-and-reporting/party-committee-semi-annual-filers">Semi-annual filers</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/terminating-an-ssf/">Terminating an SSF</a></li>
+              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating party committee</a></li>
             </ul>
           </div>
         </div>
@@ -142,12 +136,12 @@
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast card--full-bleed">
           <div class="card__image">
-            <a class="u-no-border" href="http://www.fec.gov/pdf/colagui.pdf">
-              <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
+            <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
+              <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
             </a>
           </div>
           <div class="card__content">
-            <a href="http://www.fec.gov/pdf/colagui.pdf">Read the campaign guide (PDF)</a>
+            <a class="t-sans" href="http://www.fec.gov/pdf/partygui.pdf">Read the campaign guide (PDF)</a>
           </div>
         </aside>
       </div>

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -26,7 +26,7 @@
       <div class="main__content">
         <h3>Forming a new national or state political party organization</h3>
         <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
-        <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) party committee. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC advisory opinion to verify that your committee has attained national (or state) committee status.</p>
+        <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) <span class="term" data-term="party committee">party committees</span>. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC <a href="http://www.fec.gov/pages/brochures/ao.shtml">advisory opinion</a> to verify that your committee has attained national (or state) committee status.</p>
         <p>If your party organization will be active only in state or local elections, you don’t need to register with the FEC.</p>
         <h3>Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h3>
         <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>


### PR DESCRIPTION
Adds the static content for political party content.

![image](https://cloud.githubusercontent.com/assets/1696495/14869507/c291a1a6-0c88-11e6-9c43-470140e9ecd3.png)

![image](https://cloud.githubusercontent.com/assets/1696495/14869516/cc4630a4-0c88-11e6-91a9-57bb5344f6a9.png)

@ccostino or @LindsayYoung can you review this in the morning and merge to develop so partners can review for an end-of-day release?

Requires adding a new page using the "Party checklist page" template. The page should be titled "Essentials for political party committees".