### PR TITLE
Updates content for Registration landing page

### DIFF
--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -7,10 +7,7 @@
 <section class="hero hero--secondary" aria-labelledby="hero-heading">
   <div class="container">
     <h1 class="t-display">Registration and reporting</h1>
-    <h2 class="t-ruled">Register your candidacy or committee and get started reporting</h2>
-    <div class="hero__content">
-      <a class="hero__action hero__down" href="#options">View registration categories</a>
-    </div>
+    <h2 class="t-ruled">Requirements for federal candidates and committees</h2>
   </div>
 </section>
 
@@ -19,19 +16,15 @@
     <div class="container">
       <h2 class="t-ruled--bottom main__content">What does it mean to register and report?</h2>
       <div class="main__content">
-        <p>The FEC helps citizens make informed voting decisions based, in part, on knowing the sources of financial support for
-        federal candidates and political committees.</p>
-        <p>Campaign finance law generally requires that federal candidates and political committees register once
-        they reach certain monetary thresholds.</p>
-        <p>After registration, federal political committees must file regular reports with the FEC or the Secretary of the Senate.
-        These reports disclose information about their receipts and disbursements. The FEC makes that information available to the
-        public on its website.</p>
+        <p>Federal candidates and political committees must register with the FEC when they reach certain thresholds. 
+        Once registered, they make regular reports about their financial activity.</p>
+        <p>Learn more about those groups and the requirements that apply to them.</p>
       </div>
       <div class="sidebar-container">
         <aside class="card card--secondary">
           <h3 class="t-secondary-contrast t-left-aligned">Already registered?</h3>
           <form action="{{ settings.FEC_APP_URL }}" method="GET">
-            <label class="label t-left-aligned" for="committee-search">Find your committee</label>
+            <label class="label t-left-aligned" for="committee-search">Search for candidates and committees in any election</label>
             <div class="combo--search--mini">
               <input id="committee-search" name="search" class="combo__input" type="text">
               <input type="hidden" name="search_type" value="committees" placeholder="Search committees">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -24,7 +24,7 @@
         <aside class="card card--secondary">
           <h3 class="t-secondary-contrast t-left-aligned">Already registered?</h3>
           <form action="{{ settings.FEC_APP_URL }}" method="GET">
-            <label class="label t-left-aligned" for="committee-search">Search for candidates and committees in any election</label>
+            <label class="label t-left-aligned" for="committee-search">Find candidates and committees in any election</label>
             <div class="combo--search--mini">
               <input id="committee-search" name="search" class="combo__input" type="text">
               <input type="hidden" name="search_type" value="committees" placeholder="Search committees">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -24,7 +24,7 @@
         <aside class="card card--secondary">
           <h3 class="t-secondary-contrast t-left-aligned">Already registered?</h3>
           <form action="{{ settings.FEC_APP_URL }}" method="GET">
-            <label class="label t-left-aligned" for="committee-search">Find candidates and committees in any election</label>
+            <label class="label t-left-aligned" for="committee-search">Find your committee</label>
             <div class="combo--search--mini">
               <input id="committee-search" name="search" class="combo__input" type="text">
               <input type="hidden" name="search_type" value="committees" placeholder="Search committees">


### PR DESCRIPTION
Content only: 

- Updates subhead to clarify what this page is _about_ 
- Shortens and clarifies section on "What does it mean to register and report?"
- Removes arrow for "view registration categories" because content is shortened


Resolves: https://github.com/18F/fec-cms/issues/283#issuecomment-213586159 (and discussion here)
Resolves: https://github.com/18F/fec-cms/issues/282#issuecomment-214481549 (and discussion here)