### PR TITLE
Bump fec-style version to support ~1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "aria-accordion": "0.1.0",
     "glossary-panel": "0.1.2",
     "component-sticky": "1.0.0",
-    "fec-style": "~1.8",
+    "fec-style": "~1.10",
     "fullcalendar": "2.5.0",
     "jquery": "2.1.4",
     "js-beautify": "1.5.10",


### PR DESCRIPTION
This changeset brings the `fec-style` dependency up to date with the latest release.