### PR TITLE
Disable migration prompts

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -16,7 +16,7 @@ gulp build-js
 
 # Run migrations
 ./manage.py makemigrations --settings fec.settings.production
-./manage.py migrate --settings fec.settings.production
+./manage.py migrate --settings fec.settings.production --noinput
 
 # Run application
 gunicorn fec.wsgi:application


### PR DESCRIPTION
This changeset disables any input prompts when running the migrations automatically (e.g., during deployment).  These need to be turned off because our deployments happen automatically and remotely, so we are not on the server actively managing them.

Please refer to http://stackoverflow.com/a/35250116 and https://code.djangoproject.com/ticket/25036 for more details.

There is also the caveat that stale content types won't be deleted with this (as noted in the Django ticket), but I don't believe this is an issue for us right now.