### PR TITLE
Use canonical url for legal search

### DIFF
--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -5,7 +5,7 @@
         <h1 id="hero-heading" class="hero__title t-display">{{ search_hero_heading | default:'Search betaFEC' }}</h1>
         <h2 class="hero__subtitle t-ruled">Find the information you need</h2>
       </div>
-      <form id="large-search" method="get" action="{{ settings.FEC_APP_URL }}/legal/search" autocomplete="off" class="search__container js-search">
+      <form id="large-search" method="get" action="{{ settings.FEC_APP_URL }}/legal/search/" autocomplete="off" class="search__container js-search">
         <div class="combo combo--search--large">
           <select class="search__select select--alt-primary js-search-type" name="search_type" aria-label="Select a search type">
             <option value="all">All sources</option>


### PR DESCRIPTION
Avoids a 301 redirect from openFEC-web-app