### PR TITLE
Build assets on CI.

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/cloudfoundry/python-buildpack#v1.5.1
-https://github.com/cloudfoundry/nodejs-buildpack.git#v1.5.5

--- a/.cfignore
+++ b/.cfignore
@@ -1,1 +1,55 @@
-.gitignore
+coverage
+
+*.sqlite3
+node_modules
+bower_components
+/fec/static
+local.py
+
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+bower_components
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+# Complexity
+output/*.html
+output/*/index.html
+
+# Sphinx
+docs/_build
+README.html
+
+_sandbox
+
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,11 @@ before_deploy:
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
+  - (cd fec && gulp build-js)
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: invoke deploy --branch $TRAVIS_BRANCH --yes
   on:
     all_branches: true

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -10,7 +10,6 @@ invoke notify
 
 # Build static files
 cd fec
-gulp build-js
 ./manage.py collectstatic --settings fec.settings.production --noinput
 ./manage.py compress --settings fec.settings.production
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -10,12 +10,11 @@ invoke notify
 
 # Build static files
 cd fec
-./manage.py collectstatic --settings fec.settings.production --noinput
-./manage.py compress --settings fec.settings.production
+./manage.py compress
 
 # Run migrations
-./manage.py makemigrations --settings fec.settings.production
-./manage.py migrate --settings fec.settings.production --noinput
+./manage.py makemigrations
+./manage.py migrate --noinput
 
 # Run application
 gunicorn fec.wsgi:application

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -6,6 +6,6 @@ applications:
 - name: cms
 env:
   FEC_APP_URL: /data
-  NPM_CONFIG_PRODUCTION: "false"
+  DJANGO_SETTINGS_MODULE: "fec.settings.production"
   NEW_RELIC_CONFIG_FILE: "$HOME/newrelic.ini"
   NEW_RELIC_LOG: stdout

--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -1,7 +1,7 @@
 ---
 domain: 18f.gov
 stack: cflinuxfs2
-buildpack: "https://github.com/ddollar/heroku-buildpack-multi.git"
+buildpack: python_buildpack
 applications:
 - name: cms
 env:


### PR DESCRIPTION
* Switch to vetted python buildpack
* Build assets on travis and include in deploy
* Remove `dist` from `.cfignore`

Part of https://github.com/18F/openFEC/issues/1643.

Note--since auto-deploy won't run from a pull request, verifying this requires merging into develop. Manual deployment can be verified by running `gulp build-js` and deploying as normal.