### PR TITLE
Typesetting

### DIFF
--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -73,8 +73,7 @@
           <h3><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Corporations and labor organizations</a></h3>
           <p>Corporations and labor organizations <span class="t-bold">can't</span> contribute to federal candidates, but they <span class="t-bold">can</span> establish and administer a special kind of political committee: the separate segregated fund (SSF).</p>
           <p>An SSF can raise funds to make contributions to candidates — including expenditures that are coordinated with candidates — within the applicable contribution limits.</p>
-          <p>
-            <span class="t-bold">Who can set up an SSF?</span>
+          <h4>Who can set up an SSF?</h4>
             <ul class="list--bulleted">
               <li>Corporations (including those without capital stock)</li>
               <li>Labor organizations</li>
@@ -82,7 +81,6 @@
               <li>National banks</li>
               <li>Incorporated cooperatives</li>
             </ul>
-          </p>
           <p>The sponsoring corporation or labor organization is called the SSF’s “connected organization.”  The connected organization can use its own money to solicit contributions to the SSF and to pay the costs of establishing and operating the SSF, for example staff salaries and office space.</p>
           <p>SSFs may solicit contributions only from a limited group of people, including the connected organization’s executive or administrative personnel, its stockholders (if the connected organization is a corporation), or its members (if the connected organization is a labor organization or a membership organization).</p>
           <a class="button button--cta button--go" href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Get started</a>
@@ -98,11 +96,11 @@
       <div id="parties" class="option">
         <div class="option__content">
           <h3><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></h3>
-          <h4 class="t-bold">Forming a new national or state political party organization</h4>
+          <h4>Forming a new national or state political party organization</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
           <p>The FEC determines if a committee has demonstrated enough national (or state) activity to qualify as a national (or state) <span class="term" data-term="party committee">party committee</span>. Before taking advantage of higher contribution limits available to these party committees, you’ll have to ask for an FEC <a href="http://www.fec.gov/pages/brochures/ao.shtml">advisory opinion</a> to verify that your committee has attained national (or state) committee status.</p>
           <p>If your party organization will be active <span class="t-bold">only</span> in state or local elections, you don’t need to register with the FEC.</p>
-          <h4 class="t-bold">Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h4>
+          <h4>Forming a local branch of an existing political party (for example, Democratic, Republican, Libertarian or Green party)</h4>
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
           <p>When your local party organization is required to register with the FEC, it becomes a local <span class="term" data-term="party committee">party committee</span>. Your local party committee is presumed to be affiliated with the other federal party committees in your state. Affiliated committees share limits on contributions made and received.</p>
           <p>If your party organization will be active <span class="t-bold">only</span> in state or local elections, you don’t need to register with the FEC.</p>


### PR DESCRIPTION
## Dependent PR's:
- Style: https://github.com/18F/fec-style/pull/345
- Web app: https://github.com/18F/openFEC-web-app/pull/1210

## Resolves issues:
- Resolves https://github.com/18F/fec-style/issues/336
- Resolves https://github.com/18F/fec-style/issues/311

## Changes:

Changes style to `h4`:

<img width="1066" alt="screen shot 2016-05-09 at 6 27 33 pm" src="https://cloud.githubusercontent.com/assets/11636908/15151313/9c0086a4-169e-11e6-8f6a-c18dcf573c07.png">

Removes `t-bold` and uses `h4` without customization

<img width="1155" alt="screen shot 2016-05-09 at 6 24 16 pm" src="https://cloud.githubusercontent.com/assets/11636908/15151326/a44f9264-169e-11e6-93ad-17fb85f2fd3a.png">

cc @noahmanger 