### PR TITLE
Changing class name to go with new svg stuff

### DIFF
--- a/fec/fec/static/hbs/calendar/details.hbs
+++ b/fec/fec/static/hbs/calendar/details.hbs
@@ -1,7 +1,7 @@
 <div class="tooltip tooltip--under cal-details" id="{{detailsId}}" role="tooltip">
   <div class="tooltip__heading">
     <span class="tooltip__title">{{ category }}</span>
-    <button class="button button--close--neutral js-close" type="button"><span class="u-visually-hidden">Close</span></button>
+    <button class="button button--close--inverse js-close" type="button"><span class="u-visually-hidden">Close</span></button>
   </div>
   <div class="tooltip__content">
     <span class="cal-details__date">


### PR DESCRIPTION
Changes the name of the close button class to use the new names from the Sass SVG work.