### PR TITLE
Plain Language updates to calendar filters

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -13,7 +13,7 @@ deadline_types = OrderedDict([
 reporting_periods = OrderedDict([
     ('IE Periods', 'Independent expenditures'),
     ('EC Periods', 'Electioneering communications'),
-    ('FEA Periods', 'FEA period')
+    ('FEA Periods', 'Federal election activity period')
 ])
 
 outreach_types = OrderedDict([
@@ -28,7 +28,7 @@ meeting_types = OrderedDict([
 ])
 
 rule_types = OrderedDict([
-    ('AOs and Rules', 'AOs and rulemakings'),
+    ('AOs and Rules', 'Advisory opinions and rulemakings'),
 ])
 
 states = OrderedDict([


### PR DESCRIPTION
Spelled out labeling in the left rail of the calendar for the Legal and Advisory Opinions accordions. 

cc: @emileighoutlaw @ccostino 