### PR TITLE
Cms link update

### DIFF
--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -104,7 +104,7 @@
               <li><a href="/registration-and-reporting/pre-election-reports/">Pre-election reports</a></li>
               <li><a href="/registration-and-reporting/48-hour-notices/">48-Hour Notices</a></li>
               <li><a href="/registration-and-reporting/post-general-election-reports/">Post-general election reports</a></li>
-              <li><a href="/registration-and-reporting/terminate-committee/">Terminating a committee</a></li>
+              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating a committee</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -115,7 +115,7 @@
                   <li><a href="/registration-and-reporting/non-election-monthly-filers">Monthly filers</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/terminating-an-ssf/">Terminating an SSF</a></li>
+              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating an SSF</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
We wrote the `party committee termination page` so that it could apply to *all* committees (i.e., be re-used). 

This PR redirects the candidate and SSF termination pages to the reusable one. Once it's live, I'll remove from the other pages from Wagtail. 

cc @ccostino 


This change isn't urgent, but I'd love to get it released as soon as possible. :)