### PR TITLE
Feature/calendar visual tweaks

### DIFF
--- a/fec/fec/static/hbs/calendar/events.hbs
+++ b/fec/fec/static/hbs/calendar/events.hbs
@@ -1,6 +1,6 @@
 <div class="cal-list cal-list--{{ settings.sortBy }}">
   {{#each groups}}
-  <div class="cal-list__group">
+  <div>
     {{#if title}}
       <h3 class="cal-list__title">{{title}}</h3>
     {{/if}}

--- a/fec/fec/static/js/calendar-list-view.js
+++ b/fec/fec/static/js/calendar-list-view.js
@@ -19,6 +19,7 @@ var categories = {
   Outreach: ['roundtables', 'conferences'],
   Meetings: ['open', 'executive'],
   Rules: ['aos'],
+  Other: ['other']
 };
 
 var categoriesInverse = _.reduce(_.pairs(categories), function(memo, pair) {

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -84,7 +84,7 @@ Calendar.prototype.defaultOpts = function() {
       header: {
         left: 'prev,next,today',
         center: 'title',
-        right: 'month,monthTime'
+        right: 'monthTime,month'
       },
       buttonIcons: false,
       buttonText: {
@@ -94,7 +94,7 @@ Calendar.prototype.defaultOpts = function() {
       contentHeight: 'auto',
       dayRender: this.handleDayRender.bind(this),
       dayPopoverFormat: 'MMM D, YYYY',
-      defaultView: this.defaultView(),
+      defaultView: 'monthTime',
       eventRender: this.handleEventRender.bind(this),
       eventAfterAllRender: this.handleRender.bind(this),
       eventClick: this.handleEventClick.bind(this),
@@ -204,14 +204,6 @@ Calendar.prototype.styleButtons = function() {
   this.$calendar.find('.fc-right .fc-button-group').addClass('toggles--buttons');
   this.$calendar.find('.fc-monthTime-button').addClass('button--list button--alt');
   this.$calendar.find('.fc-month-button').addClass('button--cal button--alt');
-};
-
-Calendar.prototype.defaultView = function() {
-  if ($(document.body).width() < helpers.BREAKPOINTS.MEDIUM) {
-    return 'monthTime';
-  } else {
-    return 'month';
-  }
 };
 
 Calendar.prototype.handleRender = function(view) {

--- a/fec/fec/tests/js/calendar.js
+++ b/fec/fec/tests/js/calendar.js
@@ -78,17 +78,6 @@ describe('calendar', function() {
     it('styles the buttons', function() {
       expect(this.calendar.$calendar.find('.button button--alt')).to.exist;
     });
-
-    it('uses the correct default view on desktop', function() {
-      var defaultView = this.calendar.defaultView();
-      expect(defaultView).to.equal('month');
-    });
-
-    it('uses the correct default view on small screens', function() {
-      $(document.body).width(helpers.BREAKPOINTS.MEDIUM - 1);
-      var defaultView = this.calendar.defaultView();
-      expect(defaultView).to.equal('monthTime');
-    });
   });
 
   describe('filter()', function() {

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -64,19 +64,27 @@
           <div class="filter filter--election">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Elections </legend>
-              {% for value, label in settings.CONSTANTS.election_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.election_types.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
           <div class="filter filter--deadline">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Reporting deadlines </legend>
-              {% for value, label in settings.CONSTANTS.deadline_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.deadline_types.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
         </div>
@@ -85,10 +93,14 @@
           <div class="filter filter--meeting">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Reporting periods </legend>
-              {% for value, label in settings.CONSTANTS.reporting_periods.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.reporting_periods.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
         </div>
@@ -97,19 +109,27 @@
           <div class="filter filter--meeting">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Commission meetings </legend>
-              {% for value, label in settings.CONSTANTS.meeting_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.meeting_types.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
           <div class="filter filter--outreach">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Outreach </legend>
-              {% for value, label in settings.CONSTANTS.outreach_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.outreach_types.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
         </div>
@@ -118,10 +138,14 @@
           <div class="filter filter--rules">
             <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
               <legend class="label">Advisory Opinions and rulemakings </legend>
-              {% for value, label in settings.CONSTANTS.rule_types.items %}
-                <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-              {% endfor %}
+              <ul>
+                {% for value, label in settings.CONSTANTS.rule_types.items %}
+                  <li>
+                    <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                    <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                  </li>
+                {% endfor %}
+              </ul>
             </fieldset>
           </div>
         </div>


### PR DESCRIPTION
- Sets list view to default
- Wraps each filter checkbox in `<li></li>` because checkboxes are now `display: inline-block`, so they were wrapping