### PR TITLE
Feature/add legal content

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
   });
 
   // Initialize feedback widget
-  new feedback.Feedback(window.FEC_APP_URL + '/issue/');
+  window.feedbackWidget = new feedback.Feedback(window.FEC_APP_URL + '/issue/');
 
   // Initialize filter tags
   var $tagList = new filterTags.TagList({title: 'All records'}).$body;

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -21,6 +21,8 @@ var calendar = require('./calendar');
 var calendarHelpers = require('./calendar-helpers');
 var toc = require('./toc');
 
+var legal = require('./legal');
+
 $(document).ready(function() {
   // Initialize glossary
   // Initialize glossary
@@ -68,7 +70,10 @@ $(document).ready(function() {
   });
 
   // Initialize feedback widget
-  window.feedbackWidget = new feedback.Feedback(window.FEC_APP_URL + '/issue/');
+  var feedbackWidget = new feedback.Feedback(window.FEC_APP_URL + '/issue/');
+
+  // Initialize legal page
+  new legal.Legal(feedbackWidget, '#share-feedback-link', '#ethnio-link');
 
   // Initialize filter tags
   var $tagList = new filterTags.TagList({title: 'All records'}).$body;

--- a/fec/fec/static/js/legal.js
+++ b/fec/fec/static/js/legal.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function Legal(feedbackWidget, feedbackSelector, ethnioSelector) {
+  $(feedbackSelector).click(function(e) {
+    e.preventDefault();
+    feedbackWidget.show()
+  });
+
+  $(ethnioSelector).click(function(e) {
+    e.preventDefault();
+    Ethnio.close();
+    Ethnio.show();
+  })
+}
+
+module.exports = {Legal: Legal}

--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -8,8 +8,6 @@
       <form id="large-search" method="get" action="{{ settings.FEC_APP_URL }}/legal/search/" autocomplete="off" class="search__container js-search">
         <div class="combo combo--search--large">
           <select class="search__select select--alt-primary js-search-type" name="search_type" aria-label="Select a search type">
-            <option value="all">All sources</option>
-            <option value="advisory_opinions">AOs</option>
             <option value="regulations">Regulations</option>
           </select>
           <input type="text" name="search" class="combo__input js-search-input" aria-label="e.g. candidate, committee, advisory opinion, topic" placeholder="e.g. candidate, committee, advisory opinion, topic"{% if search_query %} value="{{ search_query }}"{% endif %}>

--- a/fec/fec/templates/partials/search-hero.html
+++ b/fec/fec/templates/partials/search-hero.html
@@ -15,9 +15,6 @@
            <span class="u-visually-hidden">Search</span>
           </button>
         </div>
-        <div class="search__minor t-right-aligned">
-          <a href="#">Advanced search</a>
-        </div>
       </form>
     </div>
   </section>

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -6,8 +6,7 @@
 
 {% block content %}
   {% include "partials/search-hero.html" %}
-  <div class="main">
-    <div class="container">
+  <div class="container">
       <div class="message message--no-icon">We're designing a new way to get legal resources.
         We could use your help! If you're interested in <a href="javascript:void(0);"
         onclick="feedbackWidget.show(); return false;">sharing feedback</a> or
@@ -38,27 +37,27 @@
             </ul>
           </nav>
         </div>
-        <section class="main__content">
-          <div class="u-padding--bottom">
+        <section class="main__content--right">
+          <div class="option">
                 <h2 class="results-info__title" id="regulations"><a href="/regulations">Regulations</a></h2>
                 <p class="u-padding--top">As part of its role administering campaign finance law,
                   the Commission issues regulations,
                   which are published every year in Title 11 of the Code of Federal Regulations (CFR).
                   This archive contains a full-text version of 11 CFR, as published January 1, 2016.
               </p>
-              <button class="is-active button--cta-primary">Get started
+              <a class="is-active button--cta-primary" href="/regulations">Get started
                   <img class="u-padding-left" src="{% static "img/i-right--inverse.svg" %}"
                 alt="Icon for Get started">
-              </button>
+              </a>
             </div>
-            <div class="content__section--ruled u-padding--top u-padding--bottom">
+            <div class="option">
               <h2 class="results-info__title" id="advisory-opinions">Advisory Opinions</h2>
               <p class="u-padding--top">Coming soon.
                 Advisory opinions are available on
                 <a href="http://saos.fec.gov/saos/searchao">FEC.gov</a>
               </p>
           </div>
-            <div class="content__section--ruled u-padding--top">
+            <div class="option">
             <h2 class="results-info__title" id="enforcement-matters">Enforcement Matters</h2>
             <p class="u-padding--top">Coming soon.
               Enforcement matters are available on
@@ -67,7 +66,6 @@
         </div>
         </section>
       </div>
-    </div>
   </div>
 {% endblock %}
 

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -7,7 +7,7 @@
 {% block content %}
   {% include "partials/search-hero.html" %}
   <div class="container">
-      <div class="message message--no-icon">We're designing a new way to get legal resources.
+      <div class="message message--no-icon">We&rsquo;re designing a new way to get legal resources.
         We could use your help! If you're interested in <a id="share-feedback-link" href="#">
           sharing feedback</a> or
         <a id="ethnio-link" href="#">

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -8,9 +8,9 @@
   {% include "partials/search-hero.html" %}
   <div class="container">
       <div class="message message--no-icon">We're designing a new way to get legal resources.
-        We could use your help! If you're interested in <a href="javascript:void(0);"
-        onclick="feedbackWidget.show(); return false;">sharing feedback</a> or
-        <a href="javascript:void(0);" onclick="Ethnio.show(); return false;">
+        We could use your help! If you're interested in <a id="share-feedback-link" href="#">
+          sharing feedback</a> or
+        <a id="ethnio-link" href="#">
           testing features
         </a> as we build them, let us know.</div>
       <div class="row">

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -8,6 +8,12 @@
   {% include "partials/search-hero.html" %}
   <div class="main">
     <div class="container">
+      <div class="message message--no-icon">We're designing a new way to get legal resources.
+        We could use your help! If you're interested in <a href="javascript:void(0);"
+        onclick="feedbackWidget.show(); return false;">sharing feedback</a> or
+        <a href="javascript:void(0);" onclick="Ethnio.show(); return false;">
+          testing features
+        </a> as we build them, let us know.</div>
       <div class="row">
         <div class="sidebar-container sidebar-container--left">
           <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
@@ -33,10 +39,7 @@
           </nav>
         </div>
         <section class="main__content">
-          <div class="message message--no-icon">We're designing a new way to get legal resources.
-            We could use your help! If you're interested in <a href="#">sharing feedback</a> or
-            <a href="#">testing features</a> as we build them, let us know.</div>
-          <div class="content__section--ruled u-padding--bottom">
+          <div class="u-padding--bottom">
                 <h2 class="results-info__title" id="regulations"><a href="/regulations">Regulations</a></h2>
                 <p class="u-padding--top">As part of its role administering campaign finance law,
                   the Commission issues regulations,

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -6,6 +6,66 @@
 
 {% block content %}
   {% include "partials/search-hero.html" %}
+  <div class="main">
+    <div class="container">
+      <div class="row">
+        <div class="sidebar-container sidebar-container--left">
+          <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">
+            <ul class="sidebar__content">
+              <li class="side-nav__item">
+                <a class="side-nav__link" href="#regulations">
+                Regulations
+                </a>
+              </li>
+              <li class="side-nav__item">
+                <a class="side-nav__link" href="#advisory-opinions">
+                Advisory Opinions
+                </a>
+              </li>
+              <li class="side-nav__item">
+                <a class="side-nav__link" href="#enforcement-matters">
+                Enforcement Matters
+                </a>
+              </li>
+              <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
+              <li class="is-disabled side-nav__item"><span class="side-nav__link">(Resource TBD)</span></li>
+            </ul>
+          </nav>
+        </div>
+        <section class="main__content">
+          <div class="message message--no-icon">We're designing a new way to get legal resources.
+            We could use your help! If you're interested in <a href="#">sharing feedback</a> or
+            <a href="#">testing features</a> as we build them, let us know.</div>
+          <div class="content__section--ruled u-padding--bottom">
+                <h2 class="results-info__title" id="regulations"><a href="/regulations">Regulations</a></h2>
+                <p class="u-padding--top">As part of its role administering campaign finance law,
+                  the Commission issues regulations,
+                  which are published every year in Title 11 of the Code of Federal Regulations (CFR).
+                  This archive contains a full-text version of 11 CFR, as published January 1, 2016.
+              </p>
+              <button class="is-active button--cta-primary">Get started
+                  <img class="u-padding-left" src="{% static "img/i-right--inverse.svg" %}"
+                alt="Icon for Get started">
+              </button>
+            </div>
+            <div class="content__section--ruled u-padding--top u-padding--bottom">
+              <h2 class="results-info__title" id="advisory-opinions">Advisory Opinions</h2>
+              <p class="u-padding--top">Coming soon.
+                Advisory opinions are available on
+                <a href="http://saos.fec.gov/saos/searchao">FEC.gov</a>
+              </p>
+          </div>
+            <div class="content__section--ruled u-padding--top">
+            <h2 class="results-info__title" id="enforcement-matters">Enforcement Matters</h2>
+            <p class="u-padding--top">Coming soon.
+              Enforcement matters are available on
+              <a href="http://www.fec.gov/em/em.shtml">FEC.gov</a>
+            </p>
+        </div>
+        </section>
+      </div>
+    </div>
+  </div>
 {% endblock %}
 
 {% block extra_js %}

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -8,7 +8,7 @@
   {% include "partials/search-hero.html" %}
   <div class="container">
       <div class="message message--no-icon">We&rsquo;re designing a new way to get legal resources.
-        We could use your help! If you're interested in <a id="share-feedback-link" href="#">
+        We could use your help! If you&rsquo;re interested in <a id="share-feedback-link" href="#">
           sharing feedback</a> or
         <a id="ethnio-link" href="#">
           testing features


### PR DESCRIPTION
This PR builds out the legal page in preparation for releasing eregs as described in 18F/fec-eregs#68 including
- integrating @emileighoutlaw 's content
- removing advanced search (from async discussion with @edmullen 
- restricting search criteria to Regulations only
- adding template as described in issue and refined discussions in #fec-design, which clarified that due to css issues it would be better to have message above content rather than in right pane (where there was an offset). 
- links added for ethnio and feedback