### PR TITLE
fec-style version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ace-builds": "1.2.2",
     "aria-accordion": "0.1.0",
     "component-sticky": "1.0.0",
-    "fec-style": "~2.3.0",
+    "fec-style": "~2.1.1",
     "fullcalendar": "2.5.0",
     "glossary-panel": "0.1.2",
     "jquery": "2.1.4",


### PR DESCRIPTION
The newer version of `fec-style` was accidentally pushed to production when it was only intended for our next release test in staging.  This hotfix fixes the issue and reverts the version back to match what is currently deployed with the web app.

Note that this hotfix is not intended to be merge back into `develop`, so I propose we ignore git flow for this one and merge this directly into `master` ourselves and leave it at that.

/cc @noahmanger, @jenniferthibault, @LindsayYoung, @adborden, @jontours