### PR TITLE
Fixes `R`

### DIFF
--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -4,6 +4,6 @@ def home(request):
     search_query = request.GET.get('query', None)
 
     return render(request, 'legal/home.html', {
-        'search_hero_heading': 'Legal Resources',
+        'search_hero_heading': 'Legal resources',
         'search_query': search_query,
     })


### PR DESCRIPTION
`Legal resources` should be lowercase `r`, in keeping with our sentence case style.

Content only. 

cc @porta-antiporta @adborden @edmullen 

Anyone can merge! :)