### PR TITLE
Feature/Restyles slab, horizontal cards, and icon combinations on Reg/Reporting

### DIFF
--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -203,7 +203,7 @@ Calendar.prototype.styleButtons = function() {
   this.$calendar.find('.fc-prev-button').addClass('button--previous button--standard');
   this.$calendar.find('.fc-right .fc-button-group').addClass('toggles--buttons');
   this.$calendar.find('.fc-monthTime-button').addClass('button--list button--alt');
-  this.$calendar.find('.fc-month-button').addClass('button--cal button--alt');
+  this.$calendar.find('.fc-month-button').addClass('button--grid button--alt');
 };
 
 Calendar.prototype.handleRender = function(view) {

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -126,7 +126,7 @@
 
 <div class="slab slab--neutral">
   <div class="container">
-    <h2 class="t-secondary-contrast">Need help?</h2>
+    <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast card--full-bleed">

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -129,7 +129,7 @@
     <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast card--full-bleed">
+        <aside class="card card--horizontal card--secondary card--full-bleed">
           <div class="card__image">
             <a class="u-no-border" href="http://www.fec.gov/pdf/candgui.pdf">
               <img src="{% static "img/guide--candidates.jpg" %}" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
@@ -141,7 +141,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
               <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
@@ -153,7 +153,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast is-disabled">
+        <aside class="card card--horizontal card--secondary is-disabled">
           <div class="card__image">
             <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
           </div>
@@ -164,7 +164,7 @@
         <p>Coming soon</p>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
           </div>

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -141,21 +141,21 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
-              <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
-            </a>
-          </div>
-          <div class="card__content">
-            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
-          </div>
-        </aside>
+        <a href="/calendar?category=report-E&category=report-M&category=report-Q">
+          <aside class="card card--horizontal card--secondary">
+            <div class="card__image__container">
+              <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
+            </div>
+            <div class="card__content">
+              Reporting deadlines
+            </div>
+          </aside>
+        </a>
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary is-disabled">
-          <div class="card__image">
-            <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
+          <div class="card__image__container">
+            <span class="card__icon i-training"><span class="u-visually-hidden">Icon of a training screen</span></span>
           </div>
           <div class="card__content">
             Attend a training
@@ -165,8 +165,8 @@
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
+          <div class="card__image__container">
+            <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
           </div>
           <div class="card__content">
             Give us a call

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -124,7 +124,7 @@
   </div>
 </article>
 
-<div class="slab slab--secondary">
+<div class="slab slab--neutral">
   <div class="container">
     <h2 class="t-secondary-contrast">Need help?</h2>
     <div class="grid grid--4-wide">
@@ -178,7 +178,7 @@
   </div>
 </div>
 
-<div class="slab slab--secondary footer-disclaimer">
+<div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
     <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -47,7 +47,7 @@
   </div>
 </article>
 
-<div class="slab slab--secondary footer-disclaimer">
+<div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
     <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -140,7 +140,7 @@
       <h2>Need help?</h2>
       <div class="grid grid--4-wide">
         <div class="grid__item">
-          <aside class="card card--horizontal card--secondary-contrast">
+          <aside class="card card--horizontal card--secondary">
             <div class="card__image">
               <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
                 <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
@@ -152,7 +152,7 @@
           </aside>
         </div>
         <div class="grid__item">
-          <aside class="card card--horizontal card--secondary-contrast">
+          <aside class="card card--horizontal card--secondary">
             <div class="card__image">
               <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service represntative">
             </div>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -146,7 +146,7 @@
                   <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
               </div>
               <div class="card__content">
-                Reporting calendar
+                Reporting deadlines
               </div>
             </aside>
           </a>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -140,26 +140,26 @@
       <h2>Need help?</h2>
       <div class="grid grid--4-wide">
         <div class="grid__item">
-          <aside class="card card--horizontal card--secondary">
-            <div class="card__image">
-              <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
-                <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
-              </a>
-            </div>
-            <div class="card__content">
-              <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
-            </div>
-          </aside>
+          <a href="/calendar?category=report-E&category=report-M&category=report-Q">
+            <aside class="card card--horizontal card--secondary">
+              <div class="card__image__container">
+                  <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
+              </div>
+              <div class="card__content">
+                Reporting calendar
+              </div>
+            </aside>
+          </a>
         </div>
         <div class="grid__item">
-          <aside class="card card--horizontal card--secondary">
-            <div class="card__image">
-              <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service represntative">
-            </div>
-            <div class="card__content">
-              Give us a call
-              <br>1-800-424-9530
-            </div>
+            <aside class="card card--horizontal card--secondary">
+              <div class="card__image__container">
+                  <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
+              </div>
+              <div class="card__content">
+                Give us a call
+                <br>1-800-424-9530
+              </div>
           </aside>
         </div>
       </div>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -135,7 +135,7 @@
       </div>
     </section>
   </div>
-  <div class="slab slab--secondary">
+  <div class="slab slab--neutral">
     <div class="container">
       <h2 class="t-secondary-contrast">Need help?</h2>
       <div class="grid grid--4-wide">
@@ -165,7 +165,7 @@
       </div>
     </div>
   </div>
-  <div class="slab slab--secondary footer-disclaimer">
+  <div class="slab slab--neutral footer-disclaimer">
     <div class="container">
       <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
       <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -137,7 +137,7 @@
   </div>
   <div class="slab slab--neutral">
     <div class="container">
-      <h2 class="t-secondary-contrast">Need help?</h2>
+      <h2>Need help?</h2>
       <div class="grid grid--4-wide">
         <div class="grid__item">
           <aside class="card card--horizontal card--secondary-contrast">

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -146,21 +146,21 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
-              <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
-            </a>
-          </div>
-          <div class="card__content">
-            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
-          </div>
-        </aside>
+        <a href="/calendar?category=report-E&category=report-M&category=report-Q">
+          <aside class="card card--horizontal card--secondary">
+            <div class="card__image__container">
+              <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
+            </div>
+            <div class="card__content">
+              Reporting deadlines
+            </div>
+          </aside>
+        </a>
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary is-disabled">
-          <div class="card__image">
-            <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
+          <div class="card__image__container">
+            <span class="card__icon i-training"><span class="u-visually-hidden">Icon of a training screen</span></span>
           </div>
           <div class="card__content">
             Attend a training
@@ -170,8 +170,8 @@
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
+          <div class="card__image__container">
+            <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
           </div>
           <div class="card__content">
             Give us a call

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -134,7 +134,7 @@
     <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast card--full-bleed">
+        <aside class="card card--horizontal card--secondary card--full-bleed">
           <div class="card__image">
             <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
               <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
@@ -146,7 +146,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
               <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
@@ -158,7 +158,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast is-disabled">
+        <aside class="card card--horizontal card--secondary is-disabled">
           <div class="card__image">
             <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
           </div>
@@ -169,7 +169,7 @@
         <p>Coming soon</p>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
           </div>

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -131,7 +131,7 @@
 
 <div class="slab slab--neutral">
   <div class="container">
-    <h2 class="t-secondary-contrast">Need help?</h2>
+    <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast card--full-bleed">

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -129,7 +129,7 @@
   </div>
 </article>
 
-<div class="slab slab--secondary">
+<div class="slab slab--neutral">
   <div class="container">
     <h2 class="t-secondary-contrast">Need help?</h2>
     <div class="grid grid--4-wide">
@@ -183,7 +183,7 @@
   </div>
 </div>
 
-<div class="slab slab--secondary footer-disclaimer">
+<div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
     <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -135,7 +135,7 @@
   </div>
 </article>
 
-<div class="slab slab--secondary">
+<div class="slab slab--neutral">
   <div class="container">
     <h2 class="t-secondary-contrast">Need help?</h2>
     <div class="grid grid--4-wide">
@@ -189,7 +189,7 @@
   </div>
 </div>
 
-<div class="slab slab--secondary footer-disclaimer">
+<div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
     <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -140,7 +140,7 @@
     <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast card--full-bleed">
+        <aside class="card card--horizontal card--secondary card--full-bleed">
           <div class="card__image">
             <a class="u-no-border" href="http://www.fec.gov/pdf/colagui.pdf">
               <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
@@ -152,7 +152,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
               <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
@@ -164,7 +164,7 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast is-disabled">
+        <aside class="card card--horizontal card--secondary is-disabled">
           <div class="card__image">
             <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
           </div>
@@ -175,7 +175,7 @@
         <p>Coming soon</p>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary-contrast">
+        <aside class="card card--horizontal card--secondary">
           <div class="card__image">
             <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
           </div>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -152,21 +152,21 @@
         </aside>
       </div>
       <div class="grid__item">
-        <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <a class="u-no-border" href="/calendar?category=report-E&category=report-M&category=report-Q">
-              <img src="{% static "img/i-calendar--neutral.svg" %}" alt="Icon of a calendar">
-            </a>
-          </div>
-          <div class="card__content">
-            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting calendar</a>
-          </div>
-        </aside>
+        <a href="/calendar?category=report-E&category=report-M&category=report-Q">
+          <aside class="card card--horizontal card--secondary">
+            <div class="card__image__container">
+              <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
+            </div>
+            <div class="card__content">
+              Reporting deadlines
+            </div>
+          </aside>
+        </a>
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary is-disabled">
-          <div class="card__image">
-            <img src="{% static "img/i-resources--neutral.svg" %}" alt="Icon of an open book">
+          <div class="card__image__container">
+            <span class="card__icon i-training"><span class="u-visually-hidden">Icon of a training screen</span></span>
           </div>
           <div class="card__content">
             Attend a training
@@ -176,8 +176,8 @@
       </div>
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary">
-          <div class="card__image">
-            <img src="{% static "img/i-contact--neutral.svg" %}" alt="Icon of a customer service representative">
+          <div class="card__image__container">
+            <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
           </div>
           <div class="card__content">
             Give us a call

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -137,7 +137,7 @@
 
 <div class="slab slab--neutral">
   <div class="container">
-    <h2 class="t-secondary-contrast">Need help?</h2>
+    <h2>Need help?</h2>
     <div class="grid grid--4-wide">
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary-contrast card--full-bleed">


### PR DESCRIPTION
Dependent PR: https://github.com/18F/fec-style/pull/393

## Summary:

1. Changes Reg/Reporting footer-resource slabs to `gray-lightest` instead of `crimson`
  - This makes this space more adaptable between data & r/r, and creates a smoother flow.
  - Keeps basic color pairing
<img width="1275" alt="screen shot 2016-06-13 at 12 07 21 pm" src="https://cloud.githubusercontent.com/assets/11636908/16033112/3cd5dbe8-31d8-11e6-8573-c7e1a60de8c1.png">


2. Introduces new, simple icons for the horizontal resource cards. (not shown)
  - I'm least confident about my implementation of this

## Review
 @noahmanger : The same caveats go for this as do it's partner PR in fec-style