### PR TITLE
Modify the build-js step to fix Travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_deploy:
   - travis_retry curl -L -o $HOME/cf.tgz "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.15.0"
   - tar xzvf $HOME/cf.tgz -C $HOME
   - travis_retry cf install-plugin autopilot -f -r CF-Community
-  - (cd fec && gulp build-js)
+  - npm run build
 
 deploy:
   provider: script


### PR DESCRIPTION
It looks like Travis was unable to find gulp directly, but it should work within the `npm run` context.