### PR TITLE
Account for CF target in deploy task

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -94,14 +94,10 @@ def deploy(space=None, branch=None, yes=False):
 
     # Log in if necessary
     if os.getenv('FEC_CF_USERNAME') and os.getenv('FEC_CF_PASSWORD'):
-        args = (
-            ('--a', 'https://api.cloud.gov'),
-            ('--u', '$FEC_CF_USERNAME'),
-            ('--p', '$FEC_CF_PASSWORD'),
-            ('--o', 'fec'),
-            ('--s', space),
-        )
-        run('cf login {0}'.format(' '.join(' '.join(arg) for arg in args)), echo=True)
+        run('cf auth "$FEC_CF_USERNAME" "$FEC_CF_PASSWORD"', echo=True)
+
+    # Target space
+    run('cf target -o fec -s {0}'.format(space), echo=True)
 
     # Set deploy variables
     with open('.cfmeta', 'w') as fp:


### PR DESCRIPTION
Addresses https://github.com/18F/openFEC/issues/1738

This changeset ensures that we only authenticate with cloud.gov if the login environment variables are set (which should only be in the case of a bot, e.g., Travis CI), but that we always change our target organization and space to match what was detected and/or passed in.

h/t to @adborden on accounting for the targeting step!

/cc @LindsayYoung, @jontours, @noahmanger, @adborden, @anthonygarvan 