### PR TITLE
Target cloud.gov api for deploy

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -92,6 +92,10 @@ def deploy(space=None, branch=None, yes=False):
     if space is None:
         return
 
+    # Set api
+    api = 'https://api.cloud.gov'
+    run('cf api {0}'.format(api), echo=True)
+
     # Log in if necessary
     if os.getenv('FEC_CF_USERNAME') and os.getenv('FEC_CF_PASSWORD'):
         run('cf auth "$FEC_CF_USERNAME" "$FEC_CF_PASSWORD"', echo=True)


### PR DESCRIPTION
When we're using `cf auth`, you need to specify which API to use before hand. Here's the [travis failure](https://travis-ci.org/18F/fec-cms/builds/139029719#L1504).