### PR TITLE
Add active nav classes based on content page

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -24,9 +24,8 @@
     {% endblock %}
   </head>
 
-  <body class="{% block body_class %}{% endblock %} {{ self.content_section }}">
+  <body class="{% block body_class %}{% endblock %}">
     {% if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}
-    {{ page }}
     <div class="banner">
       <div class="container">
         <span class="t-block t-bold t-centered">{{ settings.FEC_CMS_ENVIRONMENT }}</span>

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -45,8 +45,8 @@
         <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
         <ul class="utility-nav list--flat">
           <li class="utility-nav__item is-disabled">About</li>
-          <li class="utility-nav__item"><a href="/contact-us/">Contact</a></li>
-          <li class="utility-nav__item"><a href="/calendar/">Calendar</a></li>
+          <li class="utility-nav__item{% if content_section == 'contact' %} is-active{% endif %}"><a href="/contact-us/">Contact</a></li>
+          <li class="utility-nav__item{% if content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
           <li class="utility-nav__item"><button class="js-glossary-toggle glossary__toggle">Glossary</button></li>
         </ul>
       </div>
@@ -59,7 +59,7 @@
               <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
             </li>
             <li class="site-nav__item">
-              <a href="/registration-and-reporting/" class="site-nav__link">Registration and reporting</a>
+              <a href="/registration-and-reporting/" class="site-nav__link{% if content_section == 'registration-and-reporting' %} is-parent{% endif %}">Registration and reporting</a>
             </li>
             {% if features.legal %}
             <li class="site-nav__item">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -24,8 +24,9 @@
     {% endblock %}
   </head>
 
-  <body class="{% block body_class %}{% endblock %} {{ page.content_section }}">
+  <body class="{% block body_class %}{% endblock %} {{ self.content_section }}">
     {% if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}
+    {{ page }}
     <div class="banner">
       <div class="container">
         <span class="t-block t-bold t-centered">{{ settings.FEC_CMS_ENVIRONMENT }}</span>
@@ -45,8 +46,8 @@
         <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
         <ul class="utility-nav list--flat">
           <li class="utility-nav__item is-disabled">About</li>
-          <li class="utility-nav__item{% if page.content_section == 'contact' %} is-active{% endif %}"><a href="/contact-us/">Contact</a></li>
-          <li class="utility-nav__item{% if page.content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
+          <li class="utility-nav__item{% if self.content_section == 'contact' %} is-active{% endif %}"><a href="/contact-us/">Contact</a></li>
+          <li class="utility-nav__item{% if self.content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
           <li class="utility-nav__item"><button class="js-glossary-toggle glossary__toggle">Glossary</button></li>
         </ul>
       </div>
@@ -59,7 +60,7 @@
               <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
             </li>
             <li class="site-nav__item">
-              <a href="/registration-and-reporting/" class="site-nav__link{% if page.content_section == 'registration-and-reporting' %} is-parent{% endif %}">Registration and reporting</a>
+              <a href="/registration-and-reporting/" class="site-nav__link{% if self.content_section == 'registration-and-reporting' %} is-parent{% endif %}">Registration and reporting</a>
             </li>
             {% if features.legal %}
             <li class="site-nav__item">

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -24,7 +24,7 @@
     {% endblock %}
   </head>
 
-  <body class="{% block body_class %}{% endblock %}">
+  <body class="{% block body_class %}{% endblock %} {{ page.content_section }}">
     {% if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}
     <div class="banner">
       <div class="container">
@@ -45,8 +45,8 @@
         <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
         <ul class="utility-nav list--flat">
           <li class="utility-nav__item is-disabled">About</li>
-          <li class="utility-nav__item{% if content_section == 'contact' %} is-active{% endif %}"><a href="/contact-us/">Contact</a></li>
-          <li class="utility-nav__item{% if content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
+          <li class="utility-nav__item{% if page.content_section == 'contact' %} is-active{% endif %}"><a href="/contact-us/">Contact</a></li>
+          <li class="utility-nav__item{% if page.content_section == 'calendar' %} is-active{% endif %}"><a href="/calendar/">Calendar</a></li>
           <li class="utility-nav__item"><button class="js-glossary-toggle glossary__toggle">Glossary</button></li>
         </ul>
       </div>
@@ -59,7 +59,7 @@
               <button class="site-nav__link button--nav-panel js-panel-trigger u-under-lg-only" aria-controls="nav-data">Campaign finance data</button>
             </li>
             <li class="site-nav__item">
-              <a href="/registration-and-reporting/" class="site-nav__link{% if content_section == 'registration-and-reporting' %} is-parent{% endif %}">Registration and reporting</a>
+              <a href="/registration-and-reporting/" class="site-nav__link{% if page.content_section == 'registration-and-reporting' %} is-parent{% endif %}">Registration and reporting</a>
             </li>
             {% if features.legal %}
             <li class="site-nav__item">

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -43,17 +43,16 @@ class ContentPage(Page):
     ]
 
     # Default content section for determining the active nav
-    content_section = 'registration-and-reporting'
-
-    def get_context(self, request):
-        context = super(ContentPage, self).get_context(request)
-        context['content_section'] = self.content_section
-        return context
+    @property
+    def content_section(self):
+        return 'registration-and-reporting'
 
 
 class HomePage(ContentPage, UniqueModel):
     """Unique home page."""
-    content_section = ''
+    @property
+    def content_section(self):
+        return ''
 
 class LandingPage(ContentPage):
     pass
@@ -68,11 +67,15 @@ class PartyChecklistPage(ContentPage):
     pass
 
 class ContactPage(ContentPage):
-    content_section = 'contact'
+    @property
+    def content_section(self):
+        return 'contact'
 
 
 class CalendarPage(ContentPage):
-    content_section = 'calendar'
+    @property
+    def content_section(self):
+        return 'calendar'
 
 
 class CustomPage(Page):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -42,9 +42,18 @@ class ContentPage(Page):
         StreamFieldPanel('body'),
     ]
 
+    # Default content section for determining the active nav
+    content_section = 'registration-and-reporting'
+
+    def get_context(self, request):
+        context = super(ContentPage, self).get_context(request)
+        context['content_section'] = self.content_section
+        return context
+
+
 class HomePage(ContentPage, UniqueModel):
     """Unique home page."""
-    pass
+    content_section = ''
 
 class LandingPage(ContentPage):
     pass
@@ -59,10 +68,12 @@ class PartyChecklistPage(ContentPage):
     pass
 
 class ContactPage(ContentPage):
-    pass
+    content_section = 'contact'
+
 
 class CalendarPage(ContentPage):
-    pass
+    content_section = 'calendar'
+
 
 class CustomPage(Page):
     """Flexible customizable page."""


### PR DESCRIPTION
The nav section is based on the wagtail `Page` model. I think this makes sense.

Is there a way to add `content_section` as a model property without making it a database field? I thought we could do something like `full_name` property [described here](https://docs.djangoproject.com/en/1.8/topics/db/models/#model-methods) but it's not exposed in the template.