### PR TITLE
Adding links to deadlines to reg & rep landing page

### DIFF
--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -58,6 +58,9 @@
             <img src="{% static "img/guide--candidates.jpg" %}" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/candgui.pdf">(PDF)</a>
+          <div class="icon-heading--calendar--secondary option__aside__alt-action">
+            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
+          </div>
         </div>
       </div>
       <div id="corporations-and-labor" class="option">
@@ -83,6 +86,9 @@
             <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/colagui.pdf">(PDF)</a>
+          <div class="icon-heading--calendar--secondary option__aside__alt-action">
+            <a href="/calendar?category=EC+Periods&category=FEA+Periods&category=IE+Periods&category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
+          </div>
         </div>
       </div>
       <div id="parties" class="option">
@@ -104,6 +110,9 @@
             <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/partygui.pdf">(PDF)</a>
+          <div class="icon-heading--calendar--secondary  option__aside__alt-action">
+            <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
+          </div>
         </div>
       </div>
       <div id="nonconnected" class="option">
@@ -117,6 +126,9 @@
             <img src="{% static "img/guide--nonconnected.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/nongui.pdf">(PDF)</a>
+          <div class="icon-heading--calendar--secondary option__aside__alt-action">
+            <a href="/calendar?category=EC+Periods&category=FEA+Periods&category=IE+Periods&category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
+          </div>
         </div>
       </div>
       <div class="option">

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -50,7 +50,7 @@
         <p>House and Senate candidates must designate at least one campaign committee. These <span class="term" data-term="authorized committee">authorized
         committees</span> take in contributions and make expenditures for the candidate’s campaign. One of the candidate's authorized
         campaign committees must be designated as the candidate's <span class="term" data-term="principal campaign committee">principal campaign committee</span>.</p>
-          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Get started</a>
+          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Learn more</a>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>
@@ -78,7 +78,7 @@
             </ul>
           <p>The sponsoring corporation or labor organization is called the SSF’s “connected organization.”  The connected organization can use its own money to solicit contributions to the SSF and to pay the costs of establishing and operating the SSF, for example staff salaries and office space.</p>
           <p>SSFs may solicit contributions only from a limited group of people, including the connected organization’s executive or administrative personnel, its stockholders (if the connected organization is a corporation), or its members (if the connected organization is a labor organization or a membership organization).</p>
-          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Get started</a>
+          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-corporations-and-labor-organizations">Learn more</a>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>
@@ -102,7 +102,7 @@
           <p>You must register your party organization with the FEC when you raise or spend money over certain thresholds in connection with a federal election.</p>
           <p>When your local party organization is required to register with the FEC, it becomes a local <span class="term" data-term="party committee">party committee</span>. Your local party committee is presumed to be affiliated with the other federal party committees in your state. Affiliated committees share limits on contributions made and received.</p>
           <p>If your party organization will be active <span class="t-bold">only</span> in state or local elections, you don’t need to register with the FEC.</p>
-          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-political-party-committees">Get started</a>
+          <a class="button button--cta button--go" href="/registration-and-reporting/essentials-political-party-committees">Learn more</a>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>


### PR DESCRIPTION
Adds links from the registration and reporting landing blurbs to reporting deadlines for each registrant type.

Resolves https://github.com/18F/fec-cms/issues/298

Requires https://github.com/18F/fec-style/pull/410