### PR TITLE
Nonconnected content

### DIFF
--- a/fec/home/migrations/0014_nonconnectedchecklistpage.py
+++ b/fec/home/migrations/0014_nonconnectedchecklistpage.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import wagtail.wagtailcore.fields
+import wagtail.wagtailcore.blocks
+import wagtail.wagtailimages.blocks
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wagtailcore', '0001_squashed_0016_change_page_url_path_to_text_field'),
+        ('home', '0013_auto_20160427_2133'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='NonconnectedChecklistPage',
+            fields=[
+                ('page_ptr', models.OneToOneField(auto_created=True, parent_link=True, primary_key=True, to='wagtailcore.Page', serialize=False)),
+                ('body', wagtail.wagtailcore.fields.StreamField((('heading', wagtail.wagtailcore.blocks.CharBlock(classname='full title')), ('paragraph', wagtail.wagtailcore.blocks.RichTextBlock()), ('html', wagtail.wagtailcore.blocks.RawHTMLBlock()), ('image', wagtail.wagtailimages.blocks.ImageChooserBlock())), blank=True, null=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('wagtailcore.page',),
+        ),
+    ]

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -66,6 +66,9 @@ class SSFChecklistPage(ContentPage):
 class PartyChecklistPage(ContentPage):
     pass
 
+class NonconnectedChecklistPage(ContentPage):
+    pass
+
 class ContactPage(ContentPage):
     @property
     def content_section(self):

--- a/fec/home/templates/home/checklist_page.html
+++ b/fec/home/templates/home/checklist_page.html
@@ -42,7 +42,7 @@
           <ul class="sidebar__content">
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></li>
-            <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-nonconnected-committees">Nonconnected committees</a></li>
           </ul>
           <h4 class="sidebar__title">Already registered?</h4>
           <form class="sidebar__content" action="{{ settings.FEC_APP_URL }}" method="GET">
@@ -104,7 +104,7 @@
               <li><a href="/registration-and-reporting/pre-election-reports/">Pre-election reports</a></li>
               <li><a href="/registration-and-reporting/48-hour-notices/">48-Hour Notices</a></li>
               <li><a href="/registration-and-reporting/post-general-election-reports/">Post-general election reports</a></li>
-              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating a committee</a></li>
++              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating a party committee</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -108,8 +108,15 @@
       </div>
       <div id="nonconnected" class="option">
         <div class="option__content">
-          <h3>Coming soon: Nonconnected committees</h3>
-          <p>This is the FEC’s beta site, which means it’s still being developed. Learn more by reading the campaign guide, and check back soon for more information about nonconnected committees.</p>
+          <h3><a href="/registration-and-reporting/essentials-nonconnected-committees">Nonconnected committees</a></h3>
+          <p>If you want to set up a political action committee (PAC) — and your PAC is not a political party committee, 
+ +        a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization — 
+ +        you can set up a “nonconnected” committee.</p>
+ +        <p>Members of congress and other political leaders often establish nonconnected committees, usually called 
+ +        <span class="term" data-term="Leadership PAC">Leadership PACs</span>. Leadership PACs usually support candidates for various federal or nonfederal offices.</p>
+ +        <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are 
+ +        another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are 
+ +        setting up a Super PAC or a Hybrid PAC, find more information on <a href="http://www.fec.gov/ans/answers_pac.shtml#super_hybrid">FEC.gov quick answers</a>.</p>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -109,14 +109,9 @@
       <div id="nonconnected" class="option">
         <div class="option__content">
           <h3><a href="/registration-and-reporting/essentials-nonconnected-committees">Nonconnected committees</a></h3>
-          <p>If you want to set up a political action committee (PAC) — and your PAC is not a political party committee, 
- +        a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization — 
- +        you can set up a “nonconnected” committee.</p>
- +        <p>Members of congress and other political leaders often establish nonconnected committees, usually called 
- +        <span class="term" data-term="Leadership PAC">Leadership PACs</span>. Leadership PACs usually support candidates for various federal or nonfederal offices.</p>
- +        <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are 
- +        another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are 
- +        setting up a Super PAC or a Hybrid PAC, find more information on <a href="http://www.fec.gov/ans/answers_pac.shtml#super_hybrid">FEC.gov quick answers</a>.</p>
+          <p>If you want to set up a political action committee (PAC) &mdash; and your PAC is not a political party committee, a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization &mdash; you can set up a “nonconnected” committee.</p>
+          <p>Members of congress and other political leaders often establish nonconnected committees, usually called <span class="term" data-term="Leadership PAC">Leadership PACs</span>. Leadership PACs usually support candidates for various federal or nonfederal offices.</p>
+          <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are setting up a Super PAC or a Hybrid PAC, find more information on <a href="http://www.fec.gov/ans/answers_pac.shtml#super_hybrid">FEC.gov quick answers</a>.</p>
         </div>
         <div class="option__aside">
           <h5 class="label">Campaign guide</h5>

--- a/fec/home/templates/home/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/nonconnected_checklist_page.html
@@ -24,13 +24,13 @@
     <h1 class="main__title">{{ self.title }}</h1>
     <div class="content__section">
       <div class="main__content">
-        <p>If you want to set up a political action committee (PAC) — and your PAC is not a political party committee, 
-        a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization — 
+        <p>If you want to set up a political action committee (PAC) — and your PAC is not a political party committee,
+        a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization —
         you can set up a “nonconnected” committee.</p>
-        <p>Members of congress and other political leaders often establish nonconnected committees, usually called 
+        <p>Members of congress and other political leaders often establish nonconnected committees, usually called
         <span class="term" data-term="Leadership PAC">Leadership PACs</span>. Leadership PACs usually support candidates for various federal or nonfederal offices.</p>
-        <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are 
-        another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are 
+        <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are
+        another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are
         setting up a Super PAC or a Hybrid PAC, find more information on <a href="http://www.fec.gov/ans/answers_pac.shtml#super_hybrid">FEC.gov quick answers</a>.</p>
       </div>
       <div class="sidebar-container">
@@ -136,8 +136,8 @@
       <div class="grid__item">
         <aside class="card card--horizontal card--secondary card--full-bleed">
           <div class="card__image">
-            <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
-              <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
+            <a class="u-no-border" href="http://www.fec.gov/pdf/nongui.pdf">
+              <img src="{% static "img/guide--nonconnected.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
             </a>
           </div>
           <div class="card__content">

--- a/fec/home/templates/home/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/nonconnected_checklist_page.html
@@ -109,7 +109,7 @@
                   <li><a href="/registration-and-reporting/nonconnected-committee-semi-annual-filers">Semi-annual filers</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating nonconnected committee</a></li>
+              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating a nonconnected committee</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/nonconnected_checklist_page.html
@@ -1,0 +1,193 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+{% load staticfiles %}
+{% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
+
+{% block content %}
+
+<header class="page-header page-header--secondary">
+  <ul class="breadcrumbs">
+    <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
+    <li class="breadcrumbs__item">
+      <span class="breadcrumbs__separator">›</span>
+      <a href="/registration-and-reporting" class="breadcrumbs__link">Registration and reporting</a>
+    </li>
+    <li class="breadcrumbs__item breadcrumbs__item--current">
+      <span class="breadcrumbs__separator">›</span>
+      <span>{{ self.title }}</span>
+    </li>
+  </ul>
+</header>
+
+<article class="main">
+  <div class="container">
+    <h1 class="main__title">{{ self.title }}</h1>
+    <div class="content__section">
+      <div class="main__content">
+        <p>If you want to set up a political action committee (PAC) — and your PAC is not a political party committee, 
+        a candidate’s authorized committee or a separate segregated fund (SSF) established by a corporation or labor organization — 
+        you can set up a “nonconnected” committee.</p>
+        <p>Members of congress and other political leaders often establish nonconnected committees, usually called 
+        <span class="term" data-term="Leadership PAC">Leadership PACs</span>. Leadership PACs usually support candidates for various federal or nonfederal offices.</p>
+        <p><span class="term" data-term="Super PAC">Super PACs</span> and <span class="term" data-term="Hybrid PAC">Hybrid PACs</span> are 
+        another type of nonconnected committee. These committees must register and report all of their receipts and disbursements. If you are 
+        setting up a Super PAC or a Hybrid PAC, find more information on <a href="http://www.fec.gov/ans/answers_pac.shtml#super_hybrid">FEC.gov quick answers</a>.</p>
+      </div>
+      <div class="sidebar-container">
+        <aside class="sidebar sidebar--secondary">
+          <h4 class="sidebar__title">Essentials for other registrants</h4>
+          <ul class="sidebar__content">
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></li>
+          </ul>
+          <h4 class="sidebar__title">Already registered?</h4>
+          <form class="sidebar__content" action="{{ settings.FEC_APP_URL }}" method="GET">
+            <label class="label" for="committee-search">Find your committee</label>
+            <div class="combo--search--mini">
+              <input id="committee-search" name="search" class="combo__input" type="text">
+              <input type="hidden" name="search_type" value="committees" placeholder="Search committees">
+              <button class="combo__button button--search button--standard" type="submit"><span class="u-visually-hidden">Search</span></button>
+            </div>
+          </form>
+        </aside>
+      </div>
+    </div>
+    <div class="row" id="registration-steps">
+      <div class="sidebar-container sidebar-container--left">
+        <nav class="sidebar sidebar--neutral side-nav js-sticky-side js-toc" data-sticky-container="registration-steps">
+          <ul class="sidebar__content">
+            <li class="side-nav__item"><a class="side-nav__link" href="#register">Registration</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#how-to-file">How to file</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#regular-filing">Regular filing</a></li>
+            <li class="side-nav__item"><a class="side-nav__link" href="#troubleshooting">Troubleshooting</a></li>
+          </ul>
+        </nav>
+      </div>
+      <div class="main__content--right">
+        <div id="register" class="option">
+          <div class="option__content">
+            <h2>Registration</h2>
+            <ul class="list--checks list--checks--secondary t-sans">
+              <li>Getting a <a href="/registration-and-reporting/get-tax-id-and-bank-account/">tax ID and bank account</a></li>
+              <li>Getting a <a href="/registration-and-reporting/get-treasurer/">treasurer</a></li>
+              <li>Registering a <a href="/registration-and-reporting/nonconnected-committee-registration/">nonconnected committee</a></li>
+            </ul>
+          </div>
+        </div>
+        <div id="how-to-file" class="option">
+          <div class="option__content">
+            <h2>How to file</h2>
+            <ul class="list--checks list--checks--secondary t-sans">
+              <li>Electronic filing
+                <ul>
+                  <li><a href="/registration-and-reporting/mandatory-electronic-filing/">Mandatory electronic filing</a></li>
+                  <li><a href="/registration-and-reporting/file-electronically/">Electronic filing overview</a></li>
+                  <li><a href="/registration-and-reporting/get-e-filing-password/">Getting an e-filing password</a></li>
+                 </ul>
+              </li>
+              <li><a href="/registration-and-reporting/party-committee-file-paper/">Paper filing</a></li>
+              <li><a href="/registration-and-reporting/get-filing-software/">Filing software</a></li>
+            </ul>
+          </div>
+        </div>
+        <div id="regular-filing" class="option">
+          <div class="option__content">
+            <h2>Regular filing</h2>
+            <ul class="list--checks list--checks--secondary t-sans">
+              <li><a href="/registration-and-reporting/nonconnected-committee-filing-requirements">Filing requirements</a></li>
+              <li><a href="/registration-and-reporting/nonconnected-committee-election-year-filing">Election years</a>
+                <ul>
+                  <li><a href="/registration-and-reporting/nonconnected-committee-quarterly-filers">Quarterly filers</a></li>
+                  <li><a href="/registration-and-reporting/nonconnected-committee-monthly-filers">Monthly filers</a></li>
+                  <li><a href="/registration-and-reporting/nonconnected-committee-independent-expenditures">Independent expenditures</a></li>
+                </ul>
+              </li>
+              <li><a href="/registration-and-reporting/nonconnected-committee-non-election-year-filing">Non-election years</a>
+                <ul>
+                  <li><a href="/registration-and-reporting/nonconnected-committee-non-election-monthly-filers">Monthly filers</a></li>
+                  <li><a href="/registration-and-reporting/nonconnected-committee-semi-annual-filers">Semi-annual filers</a></li>
+                </ul>
+              </li>
+              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating nonconnected committee</a></li>
+            </ul>
+          </div>
+        </div>
+        <div id="troubleshooting" class="option option--border-bottom">
+          <div class="option__content">
+            <h2>Troubleshooting</h2>
+            <ul class="list--checks list--checks--secondary t-sans">
+              <li><a href="/registration-and-reporting/missed-deadline/">Missed deadlines</a></li>
+              <li>Responding to a <a href="/registration-and-reporting/request-additional-information/">Request for Additional Information (RFAI)</a></li>
+              <li><a href="/registration-and-reporting/administrative-fines/">Administrative fines</a></li>
+              <li><a href="/contact-us/">Contact us</a></li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>
+
+<div class="slab slab--neutral">
+  <div class="container">
+    <h2>Need help?</h2>
+    <div class="grid grid--4-wide">
+      <div class="grid__item">
+        <aside class="card card--horizontal card--secondary card--full-bleed">
+          <div class="card__image">
+            <a class="u-no-border" href="http://www.fec.gov/pdf/partygui.pdf">
+              <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
+            </a>
+          </div>
+          <div class="card__content">
+            <a class="t-sans" href="http://www.fec.gov/pdf/nongui.pdf">Read the campaign guide (PDF)</a>
+          </div>
+        </aside>
+      </div>
+      <div class="grid__item">
+        <a href="/calendar?category=report-E&category=report-M&category=report-Q">
+          <aside class="card card--horizontal card--secondary">
+            <div class="card__image__container">
+              <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
+            </div>
+            <div class="card__content">
+              Reporting deadlines
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <aside class="card card--horizontal card--secondary is-disabled">
+          <div class="card__image__container">
+            <span class="card__icon i-training"><span class="u-visually-hidden">Icon of a training screen</span></span>
+          </div>
+          <div class="card__content">
+            Attend a training
+          </div>
+        </aside>
+        <p>Coming soon</p>
+      </div>
+      <div class="grid__item">
+        <aside class="card card--horizontal card--secondary">
+          <div class="card__image__container">
+            <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
+          </div>
+          <div class="card__content">
+            Give us a call
+            <br>1-800-424-9530
+          </div>
+        </aside>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="slab slab--neutral footer-disclaimer">
+  <div class="container">
+    <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
+    <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
+  </div>
+</div>
+
+{% endblock %}

--- a/fec/home/templates/home/nonconnected_checklist_page.html
+++ b/fec/home/templates/home/nonconnected_checklist_page.html
@@ -86,7 +86,7 @@
                   <li><a href="/registration-and-reporting/get-e-filing-password/">Getting an e-filing password</a></li>
                  </ul>
               </li>
-              <li><a href="/registration-and-reporting/party-committee-file-paper/">Paper filing</a></li>
+              <li><a href="/registration-and-reporting/nonconnected-file-paper/">Paper filing</a></li>
               <li><a href="/registration-and-reporting/get-filing-software/">Filing software</a></li>
             </ul>
           </div>

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -39,7 +39,7 @@
           <ul class="sidebar__content">
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-corporations-and-labor-organizations/">Corporations and labor organizations</a></li>
-            <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-nonconnected-committees">Nonconnected committees</a></li>
           </ul>
           <h4 class="sidebar__title">Already registered?</h4>
           <form class="sidebar__content" action="{{ settings.FEC_APP_URL }}" method="GET">

--- a/fec/home/templates/home/party_checklist_page.html
+++ b/fec/home/templates/home/party_checklist_page.html
@@ -109,7 +109,7 @@
                   <li><a href="/registration-and-reporting/party-committee-semi-annual-filers">Semi-annual filers</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating party committee</a></li>
++              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating a party committee</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -115,7 +115,7 @@
                   <li><a href="/registration-and-reporting/non-election-monthly-filers">Monthly filers</a></li>
                 </ul>
               </li>
-              <li><a href="/registration-and-reporting/terminating-a-party-committee/">Terminating an SSF</a></li>
++              <li><a href="/registration-and-reporting/terminating-a-committee">Terminating an SSF</a></li>
             </ul>
           </div>
         </div>

--- a/fec/home/templates/home/ssf_checklist_page.html
+++ b/fec/home/templates/home/ssf_checklist_page.html
@@ -45,7 +45,7 @@
           <ul class="sidebar__content">
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-house-and-senate-candidates-and-committees/">Congressional candidates and committees</a></li>
             <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-political-party-committees">Political party committees</a></li>
-            <li class="u-padding--bottom is-disabled">Nonconnected committees</li>
+            <li class="u-padding--bottom"><a href="/registration-and-reporting/essentials-nonconnected-committees">Nonconnected committees</a></li>
           </ul>
           <h4 class="sidebar__title">Already registered?</h4>
           <form class="sidebar__content" action="{{ settings.FEC_APP_URL }}" method="GET">


### PR DESCRIPTION
This commit adds:

- Updates landing page with nonconnected committee content
- Adds checklist page for nonconnected committees
- Updates termination page link for all essentials checklist pages (we now have a unified termination page)
- Links to nonconnected content from other checklist pages