### PR TITLE
Bump fec-style version to 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ace-builds": "1.2.2",
     "aria-accordion": "0.1.1",
     "component-sticky": "1.0.0",
-    "fec-style": "2.6",
+    "fec-style": "2.6.1",
     "fullcalendar": "2.5.0",
     "glossary-panel": "0.1.2",
     "jquery": "2.1.4",


### PR DESCRIPTION
This changeset accounts for the latest `fec-style` release (2.6.1).