### PR TITLE
Adding legal disclaimer to the end of legal landing page

### DIFF
--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -83,6 +83,13 @@
         </section>
       </div>
   </div>
+
+  <div class="slab slab--neutral footer-disclaimer">
+    <div class="container">
+      <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
+      <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
+    </div>
+  </div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Adds this unit right above the footer, matching the Registration & Reporting home page:

<img width="1275" alt="screen shot 2016-07-21 at 3 09 53 pm" src="https://cloud.githubusercontent.com/assets/11636908/17035446/408dbf40-4f55-11e6-9880-d0f7278ee87b.png">
