### PR TITLE
Adds legal disclaimer to legal home page

### DIFF
--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -86,7 +86,7 @@
 
   <div class="slab slab--neutral footer-disclaimer">
     <div class="container">
-      <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
+      <p class="usa-width-one-half">This site is in beta, which means we're testing content. This content is not finalized, is not legal advice and is subject to change.</p>
       <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
     </div>
 </div>

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -83,6 +83,13 @@
         </section>
       </div>
   </div>
+
+  <div class="slab slab--neutral footer-disclaimer">
+    <div class="container">
+      <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
+      <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}


### PR DESCRIPTION
Sends a hotfix to production to add matching legal disclaimer language to legal landing page ASAP.

cc @LindsayYoung 

<img width="1241" alt="screen shot 2016-07-21 at 4 15 41 pm" src="https://cloud.githubusercontent.com/assets/11636908/17037346/8b83ecd2-4f5e-11e6-8793-832c7da7ecac.png">
