### PR TITLE
Rearranging calendar page

### DIFF
--- a/fec/fec/static/hbs/calendar/download.hbs
+++ b/fec/fec/static/hbs/calendar/download.hbs
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <button class="button button--alt-primary dropdown__button button--download">Download</button>
+  <button class="button button--standard dropdown__button button--download">Download</button>
   <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
     <li class="dropdown__item"><a class="dropdown__value" href="{{ics}}">.ics</a></li>
     <li class="dropdown__item"><a class="dropdown__value" href="{{csv}}">.csv</a></li>

--- a/fec/fec/static/hbs/calendar/subscribe.hbs
+++ b/fec/fec/static/hbs/calendar/subscribe.hbs
@@ -1,5 +1,5 @@
 <div class="dropdown">
-  <button class="button button--alt-primary dropdown__button button--subscribe">Subscribe</button>
+  <button class="button button--standard dropdown__button button--subscribe">Subscribe</button>
   <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
     <li class="dropdown__item"><a class="dropdown__value" href="{{calendar}}">Apple calendar</a></li>
     <li class="dropdown__item"><a class="dropdown__value" href="{{google}}">Google calendar</a></li>

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -42,6 +42,7 @@ function Calendar(opts) {
   this.opts = $.extend({}, this.defaultOpts(), opts);
 
   this.$calendar = $(this.opts.selector);
+  this.$head = $('.data-container__head');
   this.$calendar.fullCalendar(this.opts.calendarOpts);
   this.url = URI(this.opts.url);
   this.exportUrl = URI(this.opts.exportUrl);
@@ -56,7 +57,6 @@ function Calendar(opts) {
 
   this.$download = $(opts.download);
   this.$subscribe = $(opts.subscribe);
-  this.$toolbar = this.$calendar.find('.fc-toolbar');
 
   this.$calendar.on('click', '.js-toggle-view', this.toggleListView.bind(this));
 
@@ -71,11 +71,8 @@ function Calendar(opts) {
   this.filter();
   this.styleButtons();
 
-  this.$toolbar.after($('.js-data-widgets'));
-  this.$toolbar.append($('.js-calendar-action'));
-
   if (!helpers.isLargeScreen()) {
-    this.$toolbar.after($('#filters'));
+    this.$head.after($('#filters'));
   }
 }
 
@@ -89,7 +86,7 @@ Calendar.prototype.defaultOpts = function() {
     calendarOpts: {
       header: {
         left: 'prev,next,today',
-        center: 'title',
+        center: '',
         right: 'monthTime,month'
       },
       buttonIcons: false,
@@ -231,25 +228,13 @@ Calendar.prototype.handleRender = function(view) {
     this.$listToggles = null;
   }
   this.$calendar.find('.fc-more').attr({'tabindex': '0', 'aria-describedby': this.popoverId});
-
-  // Replace the h2 with an h1
-  this.$calendar.find('.fc-center h2').replaceWith(function(){
-    return $('<h1>', {html: $(this).html(), class: 'data-container__title'});
-  });
-
-  // Create a new div for controls elements
-  if (this.$calendar.find('.fc-view-controls').length === 0) {
-    this.$calendar.find('.fc-view-container').before('<div class="fc-view-controls"></div>');
-  }
-
-  // Move the .fc-left and .fc-right controls into .fc-view-controls
-  this.$calendar.find('.cal-list__toggles, .fc-left, .fc-right').prependTo('.fc-view-controls');
+  this.$head.find('.js-calendar-title').html(view.title);
 };
 
 Calendar.prototype.manageListToggles = function(view) {
   if (!this.$listToggles) {
     this.$listToggles = $('<div class="cal-list__toggles"></div>');
-    this.$listToggles.prependTo(this.$calendar.find('.fc-view-container'));
+    this.$listToggles.appendTo(this.$calendar.find('.fc-right'));
   }
   this.$listToggles.html(templates.listToggles(view.options));
   // Highlight the "List" button on monthTime

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -69,6 +69,13 @@ function Calendar(opts) {
 
   this.filter();
   this.styleButtons();
+
+  this.$calendar.find('.fc-toolbar').after($('.js-data-widgets'));
+  this.$calendar.find('.fc-toolbar').append($('.js-calendar-action'));
+
+  if (!helpers.isLargeScreen()) {
+    this.$calendar.find('.fc-toolbar').after($('#filters'));
+  }
 }
 
 Calendar.prototype.toggleListView = function(e) {
@@ -214,6 +221,19 @@ Calendar.prototype.handleRender = function(view) {
     this.$listToggles = null;
   }
   this.$calendar.find('.fc-more').attr({'tabindex': '0', 'aria-describedby': this.popoverId});
+
+  // Replace the h2 with an h1
+  this.$calendar.find('.fc-center h2').replaceWith(function(){
+    return $('<h1>', {html: $(this).html(), class: 'data-container__title'});
+  });
+
+  // Create a new div for controls elements
+  if (this.$calendar.find('.fc-view-controls').length === 0) {
+    this.$calendar.find('.fc-view-container').before('<div class="fc-view-controls"></div>');
+  }
+
+  // Move the .fc-left and .fc-right controls into .fc-view-controls
+  this.$calendar.find('.cal-list__toggles, .fc-left, .fc-right').prependTo('.fc-view-controls');
 };
 
 Calendar.prototype.manageListToggles = function(view) {

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -56,6 +56,7 @@ function Calendar(opts) {
 
   this.$download = $(opts.download);
   this.$subscribe = $(opts.subscribe);
+  this.$toolbar = this.$calendar.find('.fc-toolbar');
 
   this.$calendar.on('click', '.js-toggle-view', this.toggleListView.bind(this));
 
@@ -70,11 +71,11 @@ function Calendar(opts) {
   this.filter();
   this.styleButtons();
 
-  this.$calendar.find('.fc-toolbar').after($('.js-data-widgets'));
-  this.$calendar.find('.fc-toolbar').append($('.js-calendar-action'));
+  this.$toolbar.after($('.js-data-widgets'));
+  this.$toolbar.append($('.js-calendar-action'));
 
   if (!helpers.isLargeScreen()) {
-    this.$calendar.find('.fc-toolbar').after($('#filters'));
+    this.$toolbar.after($('#filters'));
   }
 }
 

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -82,7 +82,10 @@ $(document).ready(function() {
   new legal.Legal(feedbackWidget, '#share-feedback-link', '#ethnio-link');
 
   // Initialize filter tags
-  var $tagList = new filterTags.TagList({resultType: 'events'}).$body;
+  var $tagList = new filterTags.TagList({
+    resultType: 'events',
+    emptyText: 'all events',
+  }).$body;
   $('.js-filter-tags').prepend($tagList);
 
   // Initialize filters

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -82,7 +82,7 @@ $(document).ready(function() {
   new legal.Legal(feedbackWidget, '#share-feedback-link', '#ethnio-link');
 
   // Initialize filter tags
-  var $tagList = new filterTags.TagList({title: 'All records'}).$body;
+  var $tagList = new filterTags.TagList({resultType: 'events'}).$body;
   $('.js-filter-tags').prepend($tagList);
 
   // Initialize filters

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -16,30 +16,10 @@
 </header>
 
 <section class="main__content--full">
-  <div class="data-container__widgets js-data-widgets">
-    <div class="js-filter-tags data-container__tags">
-      <div class="js-panel-controls panel__controls">
-        <button type="button" class="js-filter-toggle filters__toggle" aria-hidden="true">Add filters +</button>
-        <button type="button" class="js-filter-clear filters__toggle filters__clear" aria-hidden="true">Clear all filters</button>
-      </div>
-    </div>
-    <div class="data-container__export">
-      <div id="calendar-subscribe" class="export-widget"></div>
-      <div id="calendar-download" class="export-widget"></div>
-    </div>
-  </div>
-
   <div class="data-container__wrapper">
     <div id="filters" class="filters">
-      <button class="js-filter-close filters__close button--close--primary">
-        <span class="u-visually-hidden">Close</span>
-      </button>
-      <div class="filters__hider">
-        <div class="filters__inner">
-          <h2 class="filter__header">
-            Filter events
-          </h2>
-        </div>
+      <button type="button" class="filters__header js-filter-toggle">Edit filters</button>
+      <div class="filters__content">
         <div id="category-filters" class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
           <button type="button" class="js-accordion-trigger accordion__button">Elections, deadlines and compliance</button>
           <div class="accordion__content">
@@ -151,7 +131,19 @@
       </div>
     </div>
     <div class="data-container">
-      <div id="calendar" class="data-container__body"></div>
+      <div class="data-container__widgets js-data-widgets">
+        <div class="js-filter-tags data-container__tags">
+          <div class="js-panel-controls panel__controls">
+            <button type="button" class="js-filter-toggle filters__toggle" aria-hidden="true">Add filters +</button>
+            <button type="button" class="js-filter-clear filters__toggle filters__clear" aria-hidden="true">Clear all filters</button>
+          </div>
+        </div>
+      </div>
+      <div class="data-container__action js-calendar-action">
+        <div id="calendar-subscribe" class="export-widget"></div>
+        <div id="calendar-download" class="export-widget"></div>
+      </div>
+      <div id="calendar"></div>
     </div>
   </div>
 </section>

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -131,17 +131,19 @@
       </div>
     </div>
     <div class="data-container">
+      <div class="data-container__head calendar__head">
+        <h1 class="data-container__title js-calendar-title"></h1>
+        <div class="data-container__action js-calendar-action">
+          <div id="calendar-subscribe" class="export-widget"></div>
+          <div id="calendar-download" class="export-widget"></div>
+        </div>
+      </div>
       <div class="data-container__widgets js-data-widgets">
         <div class="js-filter-tags data-container__tags">
           <div class="js-panel-controls panel__controls">
-            <button type="button" class="js-filter-toggle filters__toggle" aria-hidden="true">Add filters +</button>
             <button type="button" class="js-filter-clear filters__toggle filters__clear" aria-hidden="true">Clear all filters</button>
           </div>
         </div>
-      </div>
-      <div class="data-container__action js-calendar-action">
-        <div id="calendar-subscribe" class="export-widget"></div>
-        <div id="calendar-download" class="export-widget"></div>
       </div>
       <div id="calendar"></div>
     </div>

--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -19,7 +19,7 @@
   <div class="data-container__wrapper">
     <div id="filters" class="filters">
       <button type="button" class="filters__header js-filter-toggle">Edit filters</button>
-      <div class="filters__content">
+      <div class="filters__content" aria-hidden="true">
         <div id="category-filters" class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
           <button type="button" class="js-accordion-trigger accordion__button">Elections, deadlines and compliance</button>
           <div class="accordion__content">


### PR DESCRIPTION
Supports the new designs and styles from https://github.com/18F/fec-style/pull/446

Unfortunately, because a lot of the title area and controls are generated by the FullCalendar library we're using, I had to use some gunky jQuery to move elements around and get them into their proper place. (Not much new from the way this code has been working, though).

![image](https://cloud.githubusercontent.com/assets/1696495/17349088/ee606aa4-58cf-11e6-982b-7fe5237ef40a.png)

cc @jenniferthibault @xtine 
