### PR TITLE
Consolidate heading styles

### DIFF
--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -24,7 +24,7 @@
 <article class="main">
   <div class="container">
     <div class="section__heading">
-      <h1 class="heading__title t-display">{{ self.title }}</h1>
+      <h1 class="heading__title heading__title--main">{{ self.title }}</h1>
     </div>
     <div class="main__content">
       {{ self.body }}


### PR DESCRIPTION
Reduces the size of headers on the custom page by using the new `header__title--main`

<img alt="screenshot from 2016-08-11 18-30-55" src="https://cloud.githubusercontent.com/assets/509703/17610320/cc316d74-5ff1-11e6-81ea-88c3f86ead09.png" width="400">

cc @jenniferthibault 

Depends on https://github.com/18F/fec-style/pull/465