### PR TITLE
Revert "Bump python for cloud foundry"

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.4.5
+python-3.4.3


### PR DESCRIPTION
This reverts commit b7bf2ca34539a8be11827c2c6dc247c5e46ade89.

The cms is still on the multi-buildpack, which does not support python 3.4.5.