### PR TITLE
Clarifies language

### DIFF
--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -73,10 +73,10 @@
                 The acts of Congress that shape campaign finance law are the Federal Election
                 Campaign Act, the Presidential Election Campaign Fund Act and the Presidential
                 Primary Matching Payment Account Act. Those acts are collected and restated as
-                law in Title 52 and Title 26 of the U.S. Code (USC).
+                law in Title 52 and Title 26 of the U.S. Code.
               </p>
               <p>
-                This archive contains the portions of 52 USC and 26 USC that are administered by FEC.
+                This archive contains the portions of Title 52 and Title 26 that are administered by FEC.
               </p>
               <a class="button--cta button--go" href="{{ settings.FEC_APP_URL }}/legal/statutes/">Explore statutes</a>
             </div>


### PR DESCRIPTION
I think we should be consistent in our naming of statutes. 

By that I mean either we refer to them as `Title 26 and Title 52` or `26 USC and 52 USC`. That'll be less for readers to keep in mind when trying to understand statutes. 

I'm going with `Title 26 and Title 52`. 

Content only. Should be a fast merge!

cc @adborden @porta-antiporta 