### PR TITLE
[MERGE WITH GITFLOW] Adds missing data-filter tags

### DIFF
--- a/fec/home/templates/home/calendar_page.html
+++ b/fec/home/templates/home/calendar_page.html
@@ -24,7 +24,7 @@
           <button type="button" class="js-accordion-trigger accordion__button">Elections, deadlines and compliance</button>
           <div class="accordion__content">
             <div class="filter">
-              <fieldset class="js-filter js-dropdown">
+              <fieldset class="js-filter js-dropdown" data-filter="checkbox">
                 <legend class="label" for="state">State</legend>
                 <ul class="dropdown__selected"></ul>
                 <div class="dropdown">
@@ -43,7 +43,7 @@
               </fieldset>
             </div>
             <div class="filter filter--election">
-              <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <fieldset class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <legend class="label">Election dates</legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.election_types.items %}
@@ -57,7 +57,7 @@
               </fieldset>
             </div>
             <div class="filter filter--deadline">
-              <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Filing deadlines </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.deadline_types.items %}
@@ -70,7 +70,7 @@
               </fieldset>
             </div>
             <div class="filter filter--meeting">
-              <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Reporting and compliance periods </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.reporting_periods.items %}
@@ -86,7 +86,7 @@
           <button type="button" class="js-accordion-trigger accordion__button">Meetings and outreach</button>
           <div class="accordion__content">
             <div class="filter filter--meeting">
-              <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <fieldset class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <legend class="label">Commission meetings </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.meeting_types.items %}
@@ -99,7 +99,7 @@
               </fieldset>
             </div>
             <div class="filter filter--outreach">
-              <fieldset class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Outreach </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.outreach_types.items %}
@@ -115,7 +115,7 @@
           <button type="button" class="js-accordion-trigger accordion__button">Legal</button>
           <div class="accordion__content">
             <div class="filter filter--rules">
-              <div class="js-filter js-multi-filter" data-filter-group="#category-filters">
+              <div class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <ul>
                   {% for value, label in settings.CONSTANTS.rule_types.items %}
                     <li>


### PR DESCRIPTION
I'm the worst and forgot to add the `data-filter` attributes to the filters on the calendar page. This will fix the calendar in production.