### PR TITLE
Adding printer-only logo

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -38,6 +38,7 @@
           <span class="disclaimer__left">This site is in beta, visit <a href="http://www.fec.gov">FEC.gov</a></span>
           <span class="disclaimer__right">An official website of the United States Government <img src="{% static 'img/us_flag_small.png' %}"  alt="US flag signifying that this is a United States Federal Government website"></span>
         </div>
+        <img src="{% static 'img/print-logo.png' %}" class="u-print-only" alt="FEC logo">
         <a title="Home" href="/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
         <ul class="utility-nav list--flat">
           <li class="utility-nav__item is-disabled">About</li>


### PR DESCRIPTION
Adds the print logo from https://github.com/18F/fec-style/pull/496

Because certain browsers don't render background images it has to be included as an `img`.