### PR TITLE
Release fixes

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -183,7 +183,7 @@ CONTACT_EMAIL = 'betafeedback@fec.gov';
 CONSTANTS = constants
 
 FEATURES = {
-    
+    'latest_updates': bool(env.get_credential('FEC_FEATURE_LATEST_UPDATES', ''))
 }
 
 if os.getenv('SENTRY_DSN'):

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -2,10 +2,12 @@
   <ul class="breadcrumbs">
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     {% for link in links %}
+      {% if link.title != 'Home' and link.title != 'Root' %}
       <li class="breadcrumbs__item breadcrumbs__item--current">
         <span class="breadcrumbs__separator">›</span>
-        <span>Latest updates</span>
+        <a href="{{ link.url }}">{{ link }}</a>
       </li>
+      {% endif %}
     {% endfor %}
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>

--- a/fec/home/templates/home/collection_page.html
+++ b/fec/home/templates/home/collection_page.html
@@ -5,20 +5,7 @@
 
 {% block content %}
 
-<header class="page-header page-header--secondary">
-  <ul class="breadcrumbs">
-    <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">›</span>
-      <a href="/registration-and-reporting" class="breadcrumbs__link">Registration and reporting</a>
-    </li>
-    <li class="breadcrumbs__item breadcrumbs__item--current">
-      <span class="breadcrumbs__separator">›</span>
-      <span>{{ self.title }}</span>
-    </li>
-  </ul>
-</header>
-
+{% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style='secondary' %}
 <article class="main">
   <div class="container">
     <h1 class="main__title">{{ self.title }}</h1>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -26,8 +26,6 @@
             <option value="for-media" {% if 'for-media' in update_types %}selected{% endif %}>For media professionals:</option>
             <option value="press-release" {% if 'press-release' in update_types %}selected{% endif %}>- Press releases</option>
             <option value="weekly-digest" {% if 'weekly-digest' in update_types %}selected{% endif %}>- Weekly Digest</option>
-            <option value="for-committees" {% if 'for-committees' in update_types %}selected{% endif %}>For committees:</option>
-            <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>- FEC Record</option>
           </select>
         </div>
           <div class="filter">
@@ -38,16 +36,6 @@
                 {% for cat in settings.CONSTANTS.press_release_page_categories.items %}
                   <option value="{{ cat.0 | slugify }}"
                     {% if cat.0|slugify in category_list %}selected{% endif %}>
-                    {{ cat.1 }}</option>
-                {% endfor %}
-              </select>
-            {% elif 'fec-record' in update_types or 'for-committees' in update_types %}
-              <label class="label" for="release-categories">FEC Record subjects</label>
-              <select id="release-categories" name="category">
-                <option value="">All</option>
-                {% for cat in settings.CONSTANTS.record_page_categories.items %}
-                  <option value="{{ cat.0 | slugify }}"
-                    {% if cat.0|slugify == category %}selected{% endif %}>
                     {{ cat.1 }}</option>
                 {% endfor %}
               </select>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -43,7 +43,12 @@
         </div>
         <div class="content__section">
           <div class="row">
-            <a class="button button--cta button--go u-float-right" href="/updates?update_type=for-media">More updates</a>
+            <div class="section__heading">
+              <h4 class="heading__title heading__title--with-action t-upper h4">Updates preview</h4>
+              <div class="heading__action">
+                <a class="button button--cta button--go" href="/updates?update_type=for-media">More updates</a>
+              </div>
+            </div>
           </div>
           {% press_updates %}
         </div>

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.conf import settings
 from itertools import chain
 from operator import attrgetter
 from home.models import DigestPage
@@ -37,6 +38,8 @@ def get_press_releases(category_list=False, year=False):
   return press_releases
 
 def updates(request):
+  # Only render view if the user is authenticated or there's a feature flag
+  if request.user.is_authenticated() or settings.FEATURES['latest_updates']:
     digests = ''
     records = ''
     press_releases = ''
@@ -105,3 +108,7 @@ def updates(request):
         'updates': updates,
         'year': year
     })
+
+  # If not authenticated or no feature flag, show 404
+  else:
+    return render(request, '404.html')

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -39,7 +39,10 @@ def get_press_releases(category_list=False, year=False):
 
 def updates(request):
   # Only render view if the user is authenticated or there's a feature flag
-  if request.user.is_authenticated() or settings.FEATURES['latest_updates']:
+  if not (request.user.is_authenticated() or settings.FEATURES['latest_updates']):
+    return render(request, '404.html')
+
+  else:
     digests = ''
     records = ''
     press_releases = ''
@@ -108,7 +111,3 @@ def updates(request):
         'updates': updates,
         'year': year
     })
-
-  # If not authenticated or no feature flag, show 404
-  else:
-    return render(request, '404.html')

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -53,7 +53,7 @@ def updates(request):
     if update_types:
       if 'for-media' in update_types:
         press_releases = get_press_releases(category_list=category_list, year=year)
-        records = get_records(category_list=category_list, year=year)
+        digests = get_digests(year=year)
       if 'for-committees' in update_types:
         records = get_records(category_list=category_list, year=year)
       if 'fec-record' in update_types:


### PR DESCRIPTION
This makes  a few fixes to the latest updates page in preparation for the release:

1. It only renders the latest updates view if either the user is authenticated or a feature flag is set. This will allow it to exist on production and be visible to authenticated users, and also on staging / dev / local and be visible to everyone. This page is just created in the code, not the DB, so I had to hide with some mechanism until they're ready.

Two questions (maybe fore @adborden or @ccostino ):
- Am I doing this right? cc @adborden 
- Where do the flags get set for the different environments? 

2. Adds the "updates preview" title to the press page above the feed
3. Removes the "FEC Record" from the filter options
4. Programmatically generates breadcrumb links on the `CollectionPage` template, which is used for the 'Resources for media professionals' page