### PR TITLE
Feature/improve update display

### DIFF
--- a/fec/fec/templates/partials/body-blocks.html
+++ b/fec/fec/templates/partials/body-blocks.html
@@ -16,7 +16,7 @@
 
 {% with blocks_name=blocks_name|default:"body" %}
 
-  <div class="{{ blocks_name }}-blocks">
+  <div class="{{ blocks_name }}-blocks content__section content__section--narrow">
     {% for block in blocks %}
       <div class="{{ blocks_name }}-block block-{{ block.block_type }}">
         {{ block }}

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -8,6 +8,12 @@
         <a href="{{ link.url }}">{{ link }}</a>
       </li>
       {% endif %}
+      {% if link.title == 'Registration and reporting' %}
+      <li class="breadcrumbs__item">
+        <span class="breadcrumbs__separator">&rsaquo;</span>
+        <span>Essentials</span>
+      </li>
+      {% endif %}
     {% endfor %}
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>

--- a/fec/home/templates/home/collection_page.html
+++ b/fec/home/templates/home/collection_page.html
@@ -56,7 +56,7 @@
             <div class="option__content">
               <h2>{{ block.value.title }}</h2>
               {{ block.value.intro }}
-              <ul class="{% if block.value.style == 'check' %}list--checks list--checks--secondary{% else %}list--bulleted{% endif %} t-sans">
+              <ul class="{% if block.value.style == 'check' %}list--checks list--checks--secondary{% else %}list--bulleted--alt{% endif %} t-sans">
               {% for item in block.value.items %}
                  <li>{{ item }}</li>
               {% endfor %}

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -3,23 +3,8 @@
 {% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
 
 {% block content %}
-<header class="page-header page-header--secondary">
-  <ul class="breadcrumbs">
-    <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">›</span>
-      <a href="/registration-and-reporting" class="breadcrumbs__link">Registration and reporting</a>
-    </li>
-    <li class="breadcrumbs__item">
-      <span class="breadcrumbs__separator">›</span>
-      <span>Essentials</span>
-    </li>
-    <li class="breadcrumbs__item breadcrumbs__item--current">
-      <span class="breadcrumbs__separator">›</span>
-      <span>{{ self.title }}</span>
-    </li>
-  </ul>
-</header>
+
+{% include 'partials/breadcrumbs.html' with page=self links=self.get_ancestors style='secondary' %}
 
 <article class="main">
   <div class="container">

--- a/fec/home/templates/home/digest_page.html
+++ b/fec/home/templates/home/digest_page.html
@@ -10,7 +10,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      <a href="/updates?update_type=weekly-digest">Weekly Digest</a>
+      Latest updates: <a href="/updates?update_type=weekly-digest">Weekly Digest</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>
@@ -23,8 +23,8 @@
   <div class="container">
     <div class="main__content--full">
       <div class="section__heading">
-        <ul class="tags" aria-hidden="false">
-          <li class="tag t-upper">
+        <ul class="tags">
+          <li class="tag tag--secondary t-upper">
             Weekly Digests
           </li>
         </ul>
@@ -62,7 +62,7 @@
       {% if self.read_next %}
         <h4><a href="{{ self.read_next.url }}">{{ self.read_next.title }}</a></h4>
       {% endif %}
-      <h4><a href="#" class="is-disabled">More Weekly Digests</a> &raquo;</h4>
+      <h4><a href="/updates?update_type=weekly-digest">More Weekly Digests</a> &raquo;</h4>
     </div>
   </div>
 </div>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -22,7 +22,7 @@
             {% for option in self.option_blocks %}
               <li class="side-nav__item"><a class="side-nav__link" href="#{{option.value.title | slugify }}">{{ option.value.title }}</a></li>
             {% endfor %}
-              <li class="side-nav__item"><a class="side-nav__link" href="#press-releases">Press releases</a></li>
+              <li class="side-nav__item"><a class="side-nav__link" href="#latest-updates">Latest updates</a></li>
               <li class="side-nav__item"><a class="side-nav__link" href="#contact">Contact</a></li>
           </ul>
         </nav>

--- a/fec/home/templates/home/press_release_page.html
+++ b/fec/home/templates/home/press_release_page.html
@@ -10,7 +10,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      <a href="/updates?release-category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
+      Latest updates: <a href="/updates?release-category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>
@@ -24,8 +24,8 @@
     <div class="main__content--full">
 
       <div class="section__heading">
-        <ul class="tags" aria-hidden="false">
-          <li class="tag t-upper">
+        <ul class="tags">
+          <li class="tag tag--secondary t-upper">
             Press Release
           </li>
         </ul>
@@ -63,7 +63,7 @@
       {% if self.read_next %}
         <h4><a href="{{ self.read_next.url }}">{{ self.read_next.title }}</a></h4>
       {% endif %}
-      <h4><a href="#" class="is-disabled">More press releases</a> &raquo;</h4>
+      <h4><a href="/updates?release-category=press-release">More press releases</a> &raquo;</h4>
     </div>
   </div>
 </div>

--- a/fec/home/templatetags/updates.py
+++ b/fec/home/templatetags/updates.py
@@ -11,11 +11,12 @@ register = template.Library()
 
 @register.inclusion_tag('partials/press-feed.html')
 def press_updates():
-    press_releases = PressReleasePage.objects.all()
-    digests = DigestPage.objects.all()
+    press_releases = PressReleasePage.objects.all().order_by('-date')[:5]
+    digests = DigestPage.objects.all().order_by('-date')[:2]
     updates = sorted(
       chain(press_releases, digests),
       key=attrgetter('date'),
       reverse=True
     )
+
     return {'updates': updates}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ace-builds": "1.2.2",
     "aria-accordion": "0.1.1",
     "component-sticky": "1.0.0",
-    "fec-style": "5.0.1",
+    "fec-style": "5.1.0",
     "fullcalendar": "2.5.0",
     "glossary-panel": "0.1.2",
     "jquery": "2.1.4",


### PR DESCRIPTION
Replaces the breadcrumbs on CustomPage templates with a new partial that programmatically generates breadcrumb links based on ancestor pages. If a page's ancestor is "Registration and reporting" it's an "Essentials" page and so "Essentials" is added as an inactive item. This allows press content pages to show the correct breadcrumbs:
![image](https://cloud.githubusercontent.com/assets/1696495/18603968/9b1d29c0-7c2b-11e6-9189-d2a4aa21666e.png)

Cleans up press release and digest pages by:
- Adding the correct class to the tag
- Adding "Latest updates: " to the breadcrumbs
- Activating the links in the footer to the index page

And last, restricts the feed on the main press page to just the last 5 press releases and last 2 weekly digests (these numbers can be tweaked of course).

Resolves https://github.com/18F/fec-cms/issues/495

cc @LindsayYoung @emileighoutlaw 