### PR TITLE
Pinning to new minor update of glossary

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "component-sticky": "1.0.0",
     "fec-style": "5.1.0",
     "fullcalendar": "2.5.0",
-    "glossary-panel": "0.1.2",
+    "glossary-panel": "0.2.0",
     "jquery": "2.1.4",
     "js-beautify": "1.5.10",
     "moment": "2.10.3",


### PR DESCRIPTION
Makes use of the new version of the glossary panel that sets focus on the element that opened the glossary.

cc @xtine 