### PR TITLE
Change search text

### DIFF
--- a/fec/fec/templates/partials/glossary.html
+++ b/fec/fec/templates/partials/glossary.html
@@ -6,8 +6,8 @@
     ><span class="u-visually-hidden">Hide glossary</span>
   </button>
   <h2>Glossary</h2>
-  <label for="glossary-search" class="label">Filter terms</label>
-  <input id="glossary-search" class="glossary__search js-glossary-search" type="search" placeholder="e.g., Authorized committee">
+  <label for="glossary-search" class="label">Search terms</label>
+  <input id="glossary-search" class="glossary__search js-glossary-search" type="search">
   <div class="glossary__content" id="glossary-result">
     <ul class="glossary__list js-glossary-list accordion--inverse"></ul>
   </div>


### PR DESCRIPTION
First, I replaced "Filter" with "Search", which is the word we use elsewhere on the website. Our pattern has been to use "search" as a verb and "filters" as a noun for the _thing_ we use to make searches. 


This placeholder text has been bugging me for a while. We have good content research evidence that many folks are confused by "e.g." And "for example" is too long for placeholder text.

This is might be crazy, but I want to try putting no placeholder words in the search bar. With the instruction to "Search," I think users will be okay. 

What do y'all think?

cc @noahmanger @xtine 