### PR TITLE
Adding new icons and copy for related resources cards

### DIFF
--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -5,7 +5,7 @@
       {% if link.title != 'Home' and link.title != 'Root' %}
       <li class="breadcrumbs__item breadcrumbs__item--current">
         <span class="breadcrumbs__separator">›</span>
-        <a href="{{ link.url }}">{{ link }}</a>
+        <a class="breadcrumbs__link" href="{{ link.url }}">{{ link }}</a>
       </li>
       {% endif %}
       {% if link.title == 'Registration and reporting' %}

--- a/fec/home/templates/home/digest_page.html
+++ b/fec/home/templates/home/digest_page.html
@@ -10,7 +10,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      Latest updates: <a href="/updates?update_type=weekly-digest">Weekly Digest</a>
+      <a class="breadcrumbs__link" href="/updates?update_type=weekly-digest">Weekly Digest</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -99,7 +99,7 @@
                   <span class="card__icon i-updates"><span class="u-visually-hidden">Icon representing latest updates</span></span>
               </div>
               <div class="card__content">
-                All latest updates from the FEC
+               Latest updates from the FEC
               </div>
             </aside>
           </a>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -96,10 +96,10 @@
           <a href="/updates">
             <aside class="card card--horizontal card--secondary">
               <div class="card__image__container">
-                  <span class="card__icon i-info-person"><span class="u-visually-hidden">Icon of a customer service representative</span></span>
+                  <span class="card__icon i-updates"><span class="u-visually-hidden">Icon representing latest updates</span></span>
               </div>
               <div class="card__content">
-                Latest Updates
+                All latest updates from the FEC
               </div>
             </aside>
           </a>
@@ -111,7 +111,7 @@
                   <span class="card__icon i-calendar"><span class="u-visually-hidden">Icon of a calendar</span></span>
               </div>
               <div class="card__content">
-                Calendar
+                Calendar of deadlines and events
               </div>
             </aside>
           </a>
@@ -120,10 +120,10 @@
           <a href="{{ settings.FEC_APP_URL }}">
             <aside class="card card--horizontal card--secondary">
               <div class="card__image__container">
-                  <span class="card__icon i-table"><span class="u-visually-hidden">Icon of a table of data</span></span>
+                  <span class="card__icon i-data-flag"><span class="u-visually-hidden">Icon representing campaign finance data</span></span>
               </div>
               <div class="card__content">
-                Campaign finance data
+                Explore campaign finance data
               </div>
             </aside>
           </a>

--- a/fec/home/templates/home/press_release_page.html
+++ b/fec/home/templates/home/press_release_page.html
@@ -10,7 +10,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      Latest updates: <a href="/updates?release-category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
+      <a class="breadcrumbs__link" href="/updates?release-category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>

--- a/fec/home/templates/home/record_page.html
+++ b/fec/home/templates/home/record_page.html
@@ -10,7 +10,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      <a href="/updates?record-category={{self.get_category_display|slugify}}">FEC Record: {{ self.get_category_display }}</a>
+      <a class="breadcrumbs__link" href="/updates?record-category={{self.get_category_display|slugify}}">FEC Record: {{ self.get_category_display }}</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>


### PR DESCRIPTION
Updates the related resources cards on the press page:

![image](https://cloud.githubusercontent.com/assets/1696495/19174325/d371d7fa-8be2-11e6-8631-85da81596042.png)

Unrelated, it also adds the `.breadcrumbs__link` class to the breadcrumbs on the press release, digest and record pages so the links are white, and removes the "Latest updates:" prefix from the breadcrumb item, per the mockups:

![image](https://cloud.githubusercontent.com/assets/1696495/19174500/0d4b5072-8be4-11e6-8368-34ef6dfe461e.png)

Requires https://github.com/18F/fec-style/pull/535

