### PR TITLE
Updates content

### DIFF
--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -15,7 +15,7 @@
 <article>
   <div id="options" class="container main">
     <div class="content__section">
-      <h2>Who can register and report?</h2>
+      <h2>Who registers and reports?</h2>
     </div>
     <div class="sidebar-container sidebar-container--left">
       <div class="js-sticky-side" data-sticky-container="options">


### PR DESCRIPTION
This changes the content per FEC feedback:


> Also, wondering about "can" as in "who can register and report?" It is a legal requirement so I'm tempted to suggest "must" even though that's not the friendliest of greetings. Does suggesting an optional choice stir resentment? If the IRS said "Who can pay taxes?" I'd growl.



Resolves: https://github.com/18F/FEC/issues/489#issuecomment-252088579