### PR TITLE
[MERGE WITH GITFLOW] Hotfix/fix author list

### DIFF
--- a/fec/fec/static/scss/fec.scss
+++ b/fec/fec/static/scss/fec.scss
@@ -58,7 +58,8 @@
 // Author attributions following an article.
 
 .author-list {
-  display: inline;
+  display: block;
+  clear: both;
 }
 
 .author-item {


### PR DESCRIPTION
The recent header refactoring introduced a bug where the author list div on press release and weekly digest pages was incorrectly floating to the right of the content body, rather than being stacked below it:

![image](https://cloud.githubusercontent.com/assets/1696495/19358827/74b7f9a2-9145-11e6-90b2-e5581d7fe68f.png)

This fixes that bug. 

Note: this CSS is in the CMS repo because the micropurchase vendor put it there. Eventually we should move it to fec-style, but this fixes the bug in the meantime. 