### PR TITLE
Eliminate "view"

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -25,7 +25,7 @@
     <div class="banner">
       <div class="container">
         <span class="t-block t-bold t-centered">{{ settings.FEC_CMS_ENVIRONMENT }}</span>
-        <span class="t-block t-centered">This site is for testing new ideas and code. View the most accurate data on the <a href="https://beta.fec.gov">live site</a>.</span>
+        <span class="t-block t-centered">This site is for testing new ideas and code. Access the most accurate data on the <a href="https://beta.fec.gov">live site</a>.</span>
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
"View" generally isn't an ideal word for interface copy, because it can feel exclusionary to folks who use screenreaders and aren't "viewing" the text. 