### PR TITLE
Adds Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Master**
+[![Dependency Status](https://gemnasium.com/badges/github.com/18F/fec-cms.svg)](https://gemnasium.com/github.com/18F/fec-cms)
 
 ## Campaign finance for everyone
 


### PR DESCRIPTION
We recently configured Gemnasium to watch this repository in addition to the other openFEC-related repositories.  This changeset adds the badge to our `README.md` file.

/cc @LindsayYoung 