### PR TITLE
Feature/fix calendar filters

### DIFF
--- a/fec/home/templates/home/calendar.html
+++ b/fec/home/templates/home/calendar.html
@@ -36,7 +36,7 @@
               </fieldset>
             </div>
             <div class="filter filter--election">
-              <fieldset class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
+              <fieldset class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <legend class="label">Election dates</legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.election_types.items %}
@@ -50,7 +50,7 @@
               </fieldset>
             </div>
             <div class="filter filter--deadline">
-              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Filing deadlines </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.deadline_types.items %}
@@ -63,7 +63,7 @@
               </fieldset>
             </div>
             <div class="filter filter--meeting">
-              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Reporting and compliance periods </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.reporting_periods.items %}
@@ -79,7 +79,7 @@
           <button type="button" class="js-accordion-trigger accordion__button">Meetings and outreach</button>
           <div class="accordion__content">
             <div class="filter filter--meeting">
-              <fieldset class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
+              <fieldset class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <legend class="label">Commission meetings </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.meeting_types.items %}
@@ -92,7 +92,7 @@
               </fieldset>
             </div>
             <div class="filter filter--outreach">
-              <fieldset class="js-filter js-multi-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
                 <legend class="label">Outreach </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.outreach_types.items %}
@@ -108,7 +108,7 @@
           <button type="button" class="js-accordion-trigger accordion__button">Legal</button>
           <div class="accordion__content">
             <div class="filter filter--rules">
-              <div class="js-filter js-multi-filter" data-filter="checkbox" data-filter-group="#category-filters">
+              <div class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
                 <ul>
                   {% for value, label in settings.CONSTANTS.rule_types.items %}
                     <li>

--- a/fec/home/templates/home/calendar.html
+++ b/fec/home/templates/home/calendar.html
@@ -12,7 +12,7 @@
   <div class="data-container__wrapper">
     <div id="filters" class="filters">
       <button type="button" class="filters__header js-filter-toggle">Edit filters</button>
-      <div class="filters__content" aria-hidden="true">
+      <div class="filters__content js-filter" aria-hidden="true"  data-filter="multi" data-name="category">
         <div id="category-filters" class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
           <button type="button" class="js-accordion-trigger accordion__button">Elections, deadlines and compliance</button>
           <div class="accordion__content">
@@ -35,8 +35,8 @@
                 </div>
               </fieldset>
             </div>
-            <div class="filter filter--election">
-              <fieldset class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
+            <div class="filter">
+              <fieldset class="js-sub-filter" data-name="category">
                 <legend class="label">Election dates</legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.election_types.items %}
@@ -49,8 +49,8 @@
                 <span class="t-note">Includes primary, general and special elections as well as caucuses and conventions</span>
               </fieldset>
             </div>
-            <div class="filter filter--deadline">
-              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+            <div class="filter">
+              <fieldset class="js-sub-filter" data-name="category">
                 <legend class="label">Filing deadlines </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.deadline_types.items %}
@@ -63,7 +63,7 @@
               </fieldset>
             </div>
             <div class="filter filter--meeting">
-              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+              <fieldset class="js-sub-filter" data-name="category">
                 <legend class="label">Reporting and compliance periods </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.reporting_periods.items %}
@@ -78,8 +78,8 @@
           </div>
           <button type="button" class="js-accordion-trigger accordion__button">Meetings and outreach</button>
           <div class="accordion__content">
-            <div class="filter filter--meeting">
-              <fieldset class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
+            <div class="filter">
+              <fieldset class="js-sub-filter" data-name="category">
                 <legend class="label">Commission meetings </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.meeting_types.items %}
@@ -91,8 +91,8 @@
                 </ul>
               </fieldset>
             </div>
-            <div class="filter filter--outreach">
-              <fieldset class="js-filter" data-filter="checkbox"  data-filter-group="#category-filters">
+            <div class="filter">
+              <fieldset class="js-sub-filter" data-name="category">
                 <legend class="label">Outreach </legend>
                 <ul>
                   {% for value, label in settings.CONSTANTS.outreach_types.items %}
@@ -107,8 +107,8 @@
           </div>
           <button type="button" class="js-accordion-trigger accordion__button">Legal</button>
           <div class="accordion__content">
-            <div class="filter filter--rules">
-              <div class="js-filter" data-filter="checkbox" data-filter-group="#category-filters">
+            <div class="filter">
+              <div class="js-sub-filter" data-name="category">
                 <ul>
                   {% for value, label in settings.CONSTANTS.rule_types.items %}
                     <li>

--- a/fec/home/templates/home/calendar.html
+++ b/fec/home/templates/home/calendar.html
@@ -12,111 +12,113 @@
   <div class="data-container__wrapper">
     <div id="filters" class="filters">
       <button type="button" class="filters__header js-filter-toggle">Edit filters</button>
-      <div class="filters__content js-filter" aria-hidden="true"  data-filter="multi" data-name="category">
+      <div class="filters__content" aria-hidden="true">
         <div id="category-filters" class="js-accordion accordion--neutral" data-content-prefix="filter" data-open-first="true">
-          <button type="button" class="js-accordion-trigger accordion__button">Elections, deadlines and compliance</button>
-          <div class="accordion__content">
-            <div class="filter">
-              <fieldset class="js-filter js-dropdown" data-filter="checkbox">
-                <legend class="label" for="state">State</legend>
-                <ul class="dropdown__selected"></ul>
-                <div class="dropdown">
-                  <button type="button" class="dropdown__button button--alt">Select</button>
-                  <div class="dropdown__panel" aria-hidden="true">
-                    <ul class="{{ css_class }}">
-                    {% for value, label in settings.CONSTANTS.states.items %}
-                    <li class="dropdown__item">
-                      <input id="state-{{ value }}" name="state" type="checkbox" value="{{ value }}">
-                      <label class="dropdown__value" for="state-{{ value }}">{{ label }}</label>
-                    </li>
-                    {% endfor %}
-                    </ul>
+          <div class="js-filter" data-filter="multi" data-name="category">
+            <button type="button" class="js-accordion-trigger accordion__button" id="label-1">Elections, deadlines and compliance</button>
+            <div class="accordion__content">
+              <div class="filter">
+                <fieldset class="js-filter js-dropdown" data-filter="checkbox">
+                  <legend class="label" for="state">State</legend>
+                  <ul class="dropdown__selected"></ul>
+                  <div class="dropdown">
+                    <button type="button" class="dropdown__button button--alt">Select</button>
+                    <div class="dropdown__panel" aria-hidden="true">
+                      <ul class="{{ css_class }}">
+                      {% for value, label in settings.CONSTANTS.states.items %}
+                      <li class="dropdown__item">
+                        <input id="state-{{ value }}" name="state" type="checkbox" value="{{ value }}">
+                        <label class="dropdown__value" for="state-{{ value }}">{{ label }}</label>
+                      </li>
+                      {% endfor %}
+                      </ul>
+                    </div>
                   </div>
+                </fieldset>
+              </div>
+              <div class="filter">
+                <fieldset class="js-sub-filter" data-name="category" data-filter-label="label-1">
+                  <legend class="label">Election dates</legend>
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.election_types.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                  <span class="t-note">Includes primary, general and special elections as well as caucuses and conventions</span>
+                </fieldset>
+              </div>
+              <div class="filter">
+                <fieldset class="js-sub-filter" data-name="category" data-filter-label="label-1">
+                  <legend class="label">Filing deadlines</legend>
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.deadline_types.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </fieldset>
+              </div>
+              <div class="filter filter--meeting">
+                <fieldset class="js-sub-filter" data-name="category" data-filter-label="label-1">
+                  <legend class="label">Reporting and compliance periods </legend>
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.reporting_periods.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </fieldset>
+              </div>
+            </div>
+            <button type="button" class="js-accordion-trigger accordion__button" id="label-2">Meetings and outreach</button>
+            <div class="accordion__content">
+              <div class="filter">
+                <fieldset class="js-sub-filter" data-name="category" data-filter-label="label-2">
+                  <legend class="label">Commission meetings </legend>
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.meeting_types.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </fieldset>
+              </div>
+              <div class="filter">
+                <fieldset class="js-sub-filter" data-name="category" data-filter-label="label-2">
+                  <legend class="label">Outreach </legend>
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.outreach_types.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                </fieldset>
+              </div>
+            </div>
+            <button type="button" class="js-accordion-trigger accordion__button" id="label-3">Legal</button>
+            <div class="accordion__content">
+              <div class="filter">
+                <div class="js-sub-filter" data-name="category" data-filter-label="label-3">
+                  <ul>
+                    {% for value, label in settings.CONSTANTS.rule_types.items %}
+                      <li>
+                        <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
+                        <label for="{{ value | clean_whitespace }}">{{ label }}</label>
+                      </li>
+                    {% endfor %}
+                  </ul>
                 </div>
-              </fieldset>
-            </div>
-            <div class="filter">
-              <fieldset class="js-sub-filter" data-name="category">
-                <legend class="label">Election dates</legend>
-                <ul>
-                  {% for value, label in settings.CONSTANTS.election_types.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
-                <span class="t-note">Includes primary, general and special elections as well as caucuses and conventions</span>
-              </fieldset>
-            </div>
-            <div class="filter">
-              <fieldset class="js-sub-filter" data-name="category">
-                <legend class="label">Filing deadlines </legend>
-                <ul>
-                  {% for value, label in settings.CONSTANTS.deadline_types.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </fieldset>
-            </div>
-            <div class="filter filter--meeting">
-              <fieldset class="js-sub-filter" data-name="category">
-                <legend class="label">Reporting and compliance periods </legend>
-                <ul>
-                  {% for value, label in settings.CONSTANTS.reporting_periods.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-          <button type="button" class="js-accordion-trigger accordion__button">Meetings and outreach</button>
-          <div class="accordion__content">
-            <div class="filter">
-              <fieldset class="js-sub-filter" data-name="category">
-                <legend class="label">Commission meetings </legend>
-                <ul>
-                  {% for value, label in settings.CONSTANTS.meeting_types.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </fieldset>
-            </div>
-            <div class="filter">
-              <fieldset class="js-sub-filter" data-name="category">
-                <legend class="label">Outreach </legend>
-                <ul>
-                  {% for value, label in settings.CONSTANTS.outreach_types.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
-              </fieldset>
-            </div>
-          </div>
-          <button type="button" class="js-accordion-trigger accordion__button">Legal</button>
-          <div class="accordion__content">
-            <div class="filter">
-              <div class="js-sub-filter" data-name="category">
-                <ul>
-                  {% for value, label in settings.CONSTANTS.rule_types.items %}
-                    <li>
-                      <input id="{{ value | clean_whitespace }}" type="checkbox" name="category" value="{{ value }}" />
-                      <label for="{{ value | clean_whitespace }}">{{ label }}</label>
-                    </li>
-                  {% endfor %}
-                </ul>
               </div>
             </div>
           </div>


### PR DESCRIPTION
This makes the markup changes necessary to support the fix in https://github.com/18F/fec-style/pull/577

- It wraps all of the calendar filters in `div` that becomes the element of the `MultiFilter`
- It adds the `js-sub-filter` class to each checkbox so they're not initialized as top-level filters
- It removes some old, unnecessary classes