### PR TITLE
Adding AO process page

### DIFF
--- a/fec/fec/templates/long_page.html
+++ b/fec/fec/templates/long_page.html
@@ -21,7 +21,6 @@
         <nav class="sidebar sidebar--neutral sidebar--left side-nav js-toc">
           <ul class="sidebar__content">
               {% block toc %}
-
               {% endblock %}
           </ul>
         </nav>
@@ -31,7 +30,6 @@
       <div class="main__content--right">
         {% block sections %}
         {% endblock %}
-
         <aside id="legal-citations" class="sidebar sidebar--primary">
           <h4 class="sidebar__title">Legal citations</h4>
           <div class="sidebar__content">

--- a/fec/fec/templates/long_page.html
+++ b/fec/fec/templates/long_page.html
@@ -9,7 +9,7 @@
 
 <article class="main">
   <div class="container" id="sections">
-    <h1 class="main__title">{{ self.title }}</h1>
+    <h1 class="heading--main">{{ self.title }}</h1>
     <div class="content__section">
       <div class="main__content">
         {% block intro %}
@@ -45,11 +45,11 @@
 
 </article>
 
-{% endblock %}
-
 <div class="slab slab--neutral footer-disclaimer">
   <div class="container">
     <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
     <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
   </div>
 </div>
+
+{% endblock %}

--- a/fec/fec/templates/long_page.html
+++ b/fec/fec/templates/long_page.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+{% load staticfiles %}
+{% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
+
+{% block content %}
+{% block breadcrumbs %}
+{% endblock %}
+
+<article class="main">
+  <div class="container" id="sections">
+    <h1 class="main__title">{{ self.title }}</h1>
+    <div class="content__section">
+      <div class="main__content">
+        {% block intro %}
+        {% endblock %}
+      </div>
+    </div>
+    <div class="sidebar-container sidebar-container--left">
+      <div class="js-sticky-side" data-sticky-container="sections">
+        <nav class="sidebar sidebar--neutral sidebar--left side-nav js-toc">
+          <ul class="sidebar__content">
+              {% block toc %}
+
+              {% endblock %}
+          </ul>
+        </nav>
+      </div>
+    </div>
+    <div class="row" id="section-container">
+      <div class="main__content--right">
+        {% block sections %}
+        {% endblock %}
+
+        <aside id="legal-citations" class="sidebar sidebar--primary">
+          <h4 class="sidebar__title">Legal citations</h4>
+          <div class="sidebar__content">
+            {% block citations %}
+            {% endblock %}
+          </div>
+        </aside>
+      </div>
+    </div>
+  </div>
+
+</article>
+
+{% endblock %}
+
+<div class="slab slab--neutral footer-disclaimer">
+  <div class="container">
+    <p class="usa-width-one-half">This site is in beta, which means we're testing content that better adheres to legal plain language requirements. This content is not finalized, is not legal advice and is subject to change.</p>
+    <p class="usa-width-one-half">Everything on this site should be read in conjunction with FEC.gov. Please let us know what you think of our new content; use the feedback tool on this page.</p>
+  </div>
+</div>

--- a/fec/fec/templates/partials/breadcrumbs.html
+++ b/fec/fec/templates/partials/breadcrumbs.html
@@ -5,7 +5,7 @@
       {% if link.title != 'Home' and link.title != 'Root' %}
       <li class="breadcrumbs__item breadcrumbs__item--current">
         <span class="breadcrumbs__separator">›</span>
-        <a class="breadcrumbs__link" href="{{ link.url }}">{{ link }}</a>
+        <a class="breadcrumbs__link" href="{{ link.url }}">{{ link.title }}</a>
       </li>
       {% endif %}
       {% if link.title == 'Registration and reporting' %}

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
     url(r'^contact-us/$', home_views.contact),
     url(r'^search/$', search_views.search, name='search'),
     url(r'^legal-resources/$', legal_views.home, name='legal'),
-    url(r'^legal/advisory-opinions/process$', legal_views.ao_process),
+    url(r'^legal/advisory-opinions/process/$', legal_views.ao_process),
 
     url(r'', include(wagtail_urls)),
 ]

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -23,6 +23,7 @@ urlpatterns = [
     url(r'^contact-us/$', home_views.contact),
     url(r'^search/$', search_views.search, name='search'),
     url(r'^legal-resources/$', legal_views.home, name='legal'),
+    url(r'^legal/advisory-opinions/process$', legal_views.ao_process),
 
     url(r'', include(wagtail_urls)),
 ]

--- a/fec/home/templates/home/contact.html
+++ b/fec/home/templates/home/contact.html
@@ -16,15 +16,11 @@
      <div class="usa-width-one-third">
       <h2>General inquiries</h2>
       <ul>
-        <li class="contact-item">
-          <div class="contact-item__icon">
-            <img src="{% static "img/i-phone--primary.svg" %}" alt="Icon of a phone">
-          </div>
+        <li class="contact-item contact-item--phone">
           <div class="contact-item__content">
             <h5 class="contact-item__title">Toll free</h5>
             <span class="t-block">1-800-424-9530</span>
             <span class="t-block">8:30 a.m. to 5:30 p.m. Eastern Time</span>
-
           </div>
         </li>
         <li class="contact-item">
@@ -42,10 +38,7 @@
       </ul>
       <h2>Mailing address</h2>
       <ul>
-        <li class="contact-item">
-          <div class="contact-item__icon">
-            <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
-          </div>
+        <li class="contact-item contact-item--mail">
           <div class="contact-item__content">
             <span class="t-block">Federal Election Commission</span>
             <span class="t-block">999 E St NW</span>
@@ -55,18 +48,12 @@
       </ul>
       <h2>betaFEC feedback</h2>
       <ul>
-        <li class="contact-item">
-          <div class="contact-item__icon">
-            <img src="{% static "img/i-email--primary.svg" %}" alt="Icon of an email envelope">
-          </div>
+        <li class="contact-item contact-item--email">
           <div class="contact-item__content">
             <span class="t-block"><a href="mailto:webmanager@fec.gov">webmanager@fec.gov</a></span>
           </div>
         </li>
-        <li class="contact-item">
-          <div class="contact-item__icon">
-            <img src="{% static "img/i-github--primary.svg" %}" alt="Icon of the GitHub logo">
-          </div>
+        <li class="contact-item contact-item--github">
           <div class="contact-item__content">
             <span class="t-block"><a href="https://github.com/18F/fec/issues">GitHub repository</a></span>
           </div>

--- a/fec/home/templates/home/landing_page.html
+++ b/fec/home/templates/home/landing_page.html
@@ -49,7 +49,8 @@
             <img src="{% static "img/guide--candidates.jpg" %}" alt="Federal Election Commission Campaign Guide: Congressional Candidates and Committees, June 2014">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/candgui.pdf">(PDF)</a>
-          <div class="icon-heading--calendar-circle option__aside__alt-action">
+          <div class="option__aside__alt-action">
+            <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
             <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
           </div>
         </div>
@@ -77,7 +78,8 @@
             <img src="{% static "img/guide--orgs.jpg" %}" alt="Federal Election Commission Campaign Guide: Corporations and Labor Organizations, January 2007">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/colagui.pdf">(PDF)</a>
-          <div class="icon-heading--calendar-circle option__aside__alt-action">
+          <div class="option__aside__alt-action">
+            <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
             <a href="/calendar?category=EC+Periods&category=FEA+Periods&category=IE+Periods&category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
           </div>
         </div>
@@ -101,7 +103,8 @@
             <img src="{% static "img/guide--parties.jpg" %}" alt="Federal Election Commission Campaign Guide: Political Party Committees, August 2013">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/partygui.pdf">(PDF)</a>
-          <div class="icon-heading--calendar-circle  option__aside__alt-action">
+          <div class="option__aside__alt-action">
+            <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
             <a href="/calendar?category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
           </div>
         </div>
@@ -120,7 +123,8 @@
             <img src="{% static "img/guide--nonconnected.jpg" %}" alt="Federal Election Commission Campaign Guide: Nonconnected Committees, May 2008">
           </a>
           <a class="t-sans" href="http://www.fec.gov/pdf/nongui.pdf">(PDF)</a>
-          <div class="icon-heading--calendar-circle option__aside__alt-action">
+          <div class="option__aside__alt-action">
+            <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
             <a href="/calendar?category=EC+Periods&category=FEA+Periods&category=IE+Periods&category=report-E&category=report-M&category=report-Q">Reporting deadlines</a>
           </div>
         </div>

--- a/fec/home/templates/home/press_landing_page.html
+++ b/fec/home/templates/home/press_landing_page.html
@@ -34,10 +34,10 @@
         <h2><a href="/updates?update_type=press-release">Press releases</a></h2>
         <div class="content__section">
           {{ self.release_intro }}
+          <a class="button button--standard button--go" href="/updates?update_type=press-release">All press releases</a>
         </div>
         <div class="post-feed">
           {% press_releases %}
-          <a class="button button--standard button--go" href="/updates?update_type=press-release">All press releases</a>
         </div>
       </div>
 
@@ -45,10 +45,10 @@
         <h2><a href="/updates?update_type=weekly-digest">Weekly Digests</a></h2>
         <div class="content__section">
           {{ self.digest_intro }}
+          <a class="button button--standard button--go" href="/updates?update_type=weekly-digest">All Weekly Digests</a>
         </div>
         <div class="post-feed">
           {% weekly_digests %}
-          <a class="button button--standard button--go" href="/updates?update_type=weekly-digest">All Weekly Digests</a>
         </div>
       </div>
 

--- a/fec/legal/templates/legal/ao_process.html
+++ b/fec/legal/templates/legal/ao_process.html
@@ -52,7 +52,7 @@
     <p>If the request does not qualify as an advisory opinion request, the Office of General Counsel notifies the requestor of the specific deficiencies in the request.</p>
     <p>If the request qualifies as an advisory opinion request, it is assigned an AOR number and made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion requests</a>.</p>
   </div>
-  <div class="option_aside">
+  <div class="option__aside">
     <p class="label">Mail requests for advisory opinions to:</p>
     <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
     <p>
@@ -69,7 +69,7 @@
     <p>Submit comments on the request in writing to the Office of General Counsel within ten days after the advisory opinion request is made public.</p>
     <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>.</p>
   </div>
-  <div class="option_aside">
+  <div class="option__aside">
     <p class="label">Mail comments to:</p>
     <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
     <p>
@@ -93,25 +93,30 @@
           <a href="mailto:ao@fec.gov">ao@fec.gov</a>
         </div>
         <div class="contact-item contact-item--fax">
-          <p class="t-bold">Fax</p>
-          <p>Commission Secretary: (202) 208-3333</p>
-          <p>Office of General Counsel: (202) 219-392</p>
+          <div class="contact-item__content">
+            <p class="t-bold">Fax</p>
+            <p>Commission Secretary: (202) 208-3333</p>
+            <p>Office of General Counsel: (202) 219-392</p>
+          </div>
         </div>
       </div>
       <div class="usa-width-one-half">
         <div class="contact-item contact-item--hand">
-          <p class="t-bold">Hand delivery</p>
-          <p>Shawn Woodhead Werth</p>
-          <p>Office of the Commission Secretary</p>
-          <p>Federal Election Commission</p>
-          <p>999 E Street, NW</p>
-          <p>Washington, DC 20463</p>
+          <div class="contact-item__content">
+            <p class="t-bold">Hand delivery</p>
+            <p>Shawn Woodhead Werth</p>
+            <p>Office of the Commission Secretary</p>
+            <p>Federal Election Commission</p>
+            <p>999 E Street, NW</p>
+            <p>Washington, DC 20463</p>
+          </div>
         </div>
       </div>
     </div>
   </div>
-  <div class="option_aside">
+  <div class="option__aside">
     <p class="label">Related topic:</p>
+    <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
     <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search draft answers to advisory opinion requests</a>
   </div>
 </section>
@@ -123,10 +128,11 @@
     <p>A requestor has the option to appear before the Commission at the open session where the Commission considers his or her advisory opinion request. A requestor can withdraw an advisory opinion request by submitting a written statement of withdrawal before the Commission votes to approve the advisory opinion.</p>
     <p>If at least four Commissioners don’t vote to approve a draft advisory opinion in response to a request, the Commission’s Office of General Counsel will send the requestor a letter stating that the Commission was unable to approve an advisory opinion. This letter is also included in the public record.</p>
   </div>
-  <div class="option_aside">
-    <p class="label">Related topics:</p>
+  <div class="option__aside">
+      <p class="label">Related topics:</p>
+      <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
     <a href="calendar/?category=Open+Meetings">Open meetings calendar</a>
-    <div>
+    <div class="content__section--ruled">
       <p><a class="u-no-border" href="http://www.fec.gov/law/policy/enforcement/2009/ao05-09.pdf"><img src="{% static "img/thumbnail--ao-statistics.png" %}" alt="Image of advisory opinion statistics report"></a></p>
       <a href="http://www.fec.gov/law/policy/enforcement/2009/ao05-09.pdf">Advisory opinion statistics FY 2005 to 2008 (PDF)</a>
     </div>

--- a/fec/legal/templates/legal/ao_process.html
+++ b/fec/legal/templates/legal/ao_process.html
@@ -65,9 +65,9 @@
       </div>
     </div>
   </div>
-  <div class="option__aside">
+  <div class="option__aside is-disabled">
     <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
-    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion requests</a>
+    <span>Search advisory opinion requests</span>
   </div>
 </section>
 <section id="commenting" class="option">
@@ -89,9 +89,9 @@
       </div>
     </div>
   </div>
-  <div class="option__aside">
+  <div class="option__aside is-disabled">
     <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
-    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>
+    <span>Search advisory opinion comments (coming soon)</span>
   </div>
 </section>
 <section id="draft-answers" class="option">
@@ -134,9 +134,9 @@
       </div>
     </div>
   </div>
-  <div class="option__aside">
+  <div class="option__aside is-disabled">
     <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
-    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search draft answers to advisory opinion requests</a>
+    <span>Search draft answers to advisory opinion requests (coming soon)</span>
   </div>
 </section>
 <section id="issuing" class="option">

--- a/fec/legal/templates/legal/ao_process.html
+++ b/fec/legal/templates/legal/ao_process.html
@@ -35,66 +35,84 @@
     <a href="http://www.fec.gov/pages/brochures/ao.shtml">Advisory opinion brochure</a>
   </div>
 </section>
-<section id="requesting" class="content__section">
-  <h2 class="heading--section">Requesting an advisory opinion</h2>
+<section id="requesting" class="option">
+  <h2>Requesting an advisory opinion</h2>
   <div class="option__content">
-    <p>Anyone may request an advisory opinion, as long as the requestor is affected by the question he or she presents. A requestor cannot ask for an advisory opinion about someone else’s activities, hypothetical situations, or general questions of law.</p>
-    <p>Advisory opinion requests must be in writing. The request must include a complete description of all facts relevant to the specific transaction or activity.</p>
-    <p>Within ten days of receiving the request, the Commission’s Office of General Counsel must determine whether it qualifies as a complete advisory opinion request.</p>
-    <p>A request does not qualify as a complete advisory opinion request if it:</p>
-    <ul class="list--bulleted">
-      <li>Asks a general question of interpretation</li>
-      <li>Asks about a hypothetical situation</li>
-      <li>Asks about the activities of someone other than the requestor</li>
-      <li>Asks about past activities that the requestor does not plan to continue in the future</li>
-      <li>Does not contain all of the factual information relevant to the activity that is the subject of the request</li>
-    </ul>
-    <p>If the request does not qualify as an advisory opinion request, the Office of General Counsel notifies the requestor of the specific deficiencies in the request.</p>
-    <p>If the request qualifies as an advisory opinion request, it is assigned an AOR number and made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion requests</a>.</p>
-  </div>
-  <div class="option__aside">
+    <div class="content__section">
+      <p>Anyone may request an advisory opinion, as long as the requestor is affected by the question he or she presents. A requestor cannot ask for an advisory opinion about someone else’s activities, hypothetical situations, or general questions of law.</p>
+      <p>Advisory opinion requests must be in writing. The request must include a complete description of all facts relevant to the specific transaction or activity.</p>
+      <p>Within ten days of receiving the request, the Commission’s Office of General Counsel must determine whether it qualifies as a complete advisory opinion request.</p>
+      <p>A request does not qualify as a complete advisory opinion request if it:</p>
+      <ul class="list--bulleted">
+        <li>Asks a general question of interpretation</li>
+        <li>Asks about a hypothetical situation</li>
+        <li>Asks about the activities of someone other than the requestor</li>
+        <li>Asks about past activities that the requestor does not plan to continue in the future</li>
+        <li>Does not contain all of the factual information relevant to the activity that is the subject of the request</li>
+      </ul>
+      <p>If the request does not qualify as an advisory opinion request, the Office of General Counsel notifies the requestor of the specific deficiencies in the request.</p>
+      <p>If the request qualifies as an advisory opinion request, it is assigned an AOR number and made public.</p>
+    </div>
     <p class="label">Mail requests for advisory opinions to:</p>
-    <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
-    <p>
-      Federal Election Commission<br>
-      Office of General Counsel<br>
-      999 E Street NW<br>
-      Washington, DC 20463
-    </p>
-  </div>
-</section>
-<section id="commenting" class="content__section">
-  <h2 class="heading--section">Commenting on advisory opinion requests</h2>
-  <div class="option__content">
-    <p>Submit comments on the request in writing to the Office of General Counsel within ten days after the advisory opinion request is made public.</p>
-    <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>.</p>
+    <div class="contact-item contact-item--mail">
+      <div class="contact-item__content">
+        <p>
+          Federal Election Commission<br>
+          Office of General Counsel<br>
+          999 E Street NW<br>
+          Washington, DC 20463
+        </p>
+      </div>
+    </div>
   </div>
   <div class="option__aside">
-    <p class="label">Mail comments to:</p>
-    <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
-    <p>
-      Federal Election Commission<br>
-      Office of General Counsel<br>
-      999 E Street NW<br>
-      Washington, DC 20463
-    </p>
+    <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
+    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion requests</a>
   </div>
 </section>
-<section id="draft-answers" class="content__section">
-  <h2 class="heading--section">Draft answers to advisory opinion requests</h2>
+<section id="commenting" class="option">
+  <h2>Commenting on advisory opinion requests</h2>
   <div class="option__content">
-    <p>Before the meeting where the Commission is scheduled to consider an advisory opinion, the Commission will make public any draft answers to the advisory opinion request.</p>
-    <p>Copies of these drafts are emailed to the requestor and made public. Search draft answers. Submit comments on drafts by email, fax or hand delivery.  Generally, the deadline for comments on a draft advisory opinions is the noon on the day before the meeting at which the Commission is scheduled to consider the draft advisory opinion.</p>
+    <div class="content__section">
+      <p>Submit comments on the request in writing to the Office of General Counsel within ten days after the advisory opinion request is made public.</p>
+      <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public.</p>
+    </div>
+    <p class="label">Mail comments to:</p>
+    <div class="contact-item contact-item--mail">
+      <div class="contact-item__content">
+        <p class="address">
+          <span>Federal Election Commission</span>
+          <span>Office of General Counsel</span>
+          <span>999 E Street NW</span>
+          <span>Washington, DC 20463</span>
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="option__aside">
+    <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
+    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>
+  </div>
+</section>
+<section id="draft-answers" class="option">
+  <h2>Draft answers to advisory opinion requests</h2>
+  <div class="option__content">
+    <div class="content__section">
+      <p>Before the meeting where the Commission is scheduled to consider an advisory opinion, the Commission will make public any draft answers to the advisory opinion request.</p>
+      <p>Copies of these drafts are emailed to the requestor and made public. Search draft answers. Submit comments on drafts by email, fax or hand delivery.  Generally, the deadline for comments on a draft advisory opinions is the noon on the day before the meeting at which the Commission is scheduled to consider the draft advisory opinion.</p>
+    </div>
     <p class="label">Submit comments on drafts by:</p>
     <div class="row">
       <div class="usa-width-one-half">
         <div class="contact-item contact-item--email">
-          <p class="t-bold">Email</p>
-          <a href="mailto:ao@fec.gov">ao@fec.gov</a>
+          <div class="contact-item__content">
+            <h5 class="contact-item__title">Email</h5>
+            <a href="mailto:ao@fec.gov">ao@fec.gov</a>
+          </div>
         </div>
         <div class="contact-item contact-item--fax">
           <div class="contact-item__content">
-            <p class="t-bold">Fax</p>
+            <h5 class="contact-item__title">Fax</h5>
             <p>Commission Secretary: (202) 208-3333</p>
             <p>Office of General Counsel: (202) 219-392</p>
           </div>
@@ -103,25 +121,26 @@
       <div class="usa-width-one-half">
         <div class="contact-item contact-item--hand">
           <div class="contact-item__content">
-            <p class="t-bold">Hand delivery</p>
-            <p>Shawn Woodhead Werth</p>
-            <p>Office of the Commission Secretary</p>
-            <p>Federal Election Commission</p>
-            <p>999 E Street, NW</p>
-            <p>Washington, DC 20463</p>
+            <h5 class="contact-item__title">Hand delivery</h5>
+            <p class="address">
+              <span>Shawn Woodhead Werth</span>
+              <span>Office of the Commission Secretary</span>
+              <span>Federal Election Commission</span>
+              <span>999 E Street, NW</span>
+              <span>Washington, DC 20463</span>
+            </p>
           </div>
         </div>
       </div>
     </div>
   </div>
   <div class="option__aside">
-    <p class="label">Related topic:</p>
     <i class="icon-circle--search"><span class="u-visually-hidden">Icon of a magnifying glass</span></i>
     <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search draft answers to advisory opinion requests</a>
   </div>
 </section>
-<section id="issuing" class="content__section">
-  <h2 class="heading--section">Issuing an advisory opinion</h2>
+<section id="issuing" class="option">
+  <h2>Issuing an advisory opinion</h2>
   <div class="option__content">
     <p>The law generally requires the Commission to issue an advisory opinion within 60 days of receiving a complete advisory opinion request. But if the request is submitted by a federal candidate within 60 days before an election, and the request asks about a specific transaction or activity related to that election, then the Commission must respond within 20 days. In addition, the Commission has an informal practice through which it tries to respond to certain significant, time-sensitive requests within 30 days.</p>
     <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve the draft advisory opinion before it. These votes almost always occur during an <a href="/calendar/?category=Open+Meetings">open meeting of the Commission</a>.</p>
@@ -129,8 +148,8 @@
     <p>If at least four Commissioners don’t vote to approve a draft advisory opinion in response to a request, the Commission’s Office of General Counsel will send the requestor a letter stating that the Commission was unable to approve an advisory opinion. This letter is also included in the public record.</p>
   </div>
   <div class="option__aside">
-      <p class="label">Related topics:</p>
-      <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
+    <p class="label">Related topics:</p>
+    <i class="icon-circle--calendar"><span class="u-visually-hidden">Icon of a calendar</span></i>
     <a href="calendar/?category=Open+Meetings">Open meetings calendar</a>
     <div class="content__section--ruled">
       <p><a class="u-no-border" href="http://www.fec.gov/law/policy/enforcement/2009/ao05-09.pdf"><img src="{% static "img/thumbnail--ao-statistics.png" %}" alt="Image of advisory opinion statistics report"></a></p>

--- a/fec/legal/templates/legal/ao_process.html
+++ b/fec/legal/templates/legal/ao_process.html
@@ -75,7 +75,7 @@
   <div class="option__content">
     <div class="content__section">
       <p>Submit comments on a request in writing to the Office of General Counsel within ten days after the advisory opinion request is made public.</p>
-      <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>.</p>
+      <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public.</p>
     </div>
     <p class="label">Mail comments to:</p>
     <div class="contact-item contact-item--mail">

--- a/fec/legal/templates/legal/ao_process.html
+++ b/fec/legal/templates/legal/ao_process.html
@@ -1,0 +1,216 @@
+{% extends "long_page.html" %}
+{% load wagtailcore_tags %}
+{% load staticfiles %}
+{% block title %}The advisory opinion process{% endblock %}
+{% block body_class %}template-{{ self.get_verbose_name | slugify }}{% endblock %}
+
+{% block breadcrumbs %}
+  {% include 'partials/breadcrumbs.html' with page=self links=self.ancestors style='primary' %}
+{% endblock %}
+{% block intro %}
+<p class="t-lead">Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.</p>
+{% endblock %}
+
+{% block toc %}
+  <li class="side-nav__item"><a class="side-nav__link" href="#overview">Overview</a></li>
+  <li class="side-nav__item"><a class="side-nav__link" href="#requesting">Requesting an advisory opinion</a></li>
+  <li class="side-nav__item"><a class="side-nav__link" href="#commenting">Commenting on advisory opinion requests</a></li>
+  <li class="side-nav__item"><a class="side-nav__link" href="#draft-answers">Draft answers to advisory opinion requests</a></li>
+  <li class="side-nav__item"><a class="side-nav__link" href="#issuing">Issuing an advisory opinion</a></li>
+  <li class="side-nav__item"><a class="side-nav__link" href="#legal-citations">Legal citations</a></li>
+{% endblock %}
+
+{% block sections %}
+<section id="overview" class="row">
+  <div class="option__content">
+    <p>Advisory opinions can answer questions about:</p>
+    <ul class="list--bulleted">
+      <li>The Federal Election Campaign Act, which is codified in Title 52 of the U.S. Code, Sections 30101-30146.</li>
+      <li>The laws about public financing of presidential campaigns and conventions, which are codified in Title 26 of the U.S. Code, Chapters 95 and 96.</li>
+      <li>The Commission’s regulations, which are codified at Title 11 of the Code of Federal Regulations. </li>
+    </ul>
+  </div>
+  <div class="option__aside">
+    <a class="u-no-border" href="http://www.fec.gov/pages/brochures/ao.shtml"><img src="{% static "img/thumbnail--ao-brochure.png" %}" alt="Image of advisory opinion brochure cover"></a>
+    <a href="http://www.fec.gov/pages/brochures/ao.shtml">Advisory opinion brochure</a>
+  </div>
+</section>
+<section id="requesting" class="content__section">
+  <h2 class="heading--section">Requesting an advisory opinion</h2>
+  <div class="option__content">
+    <p>Anyone may request an advisory opinion, as long as the requestor is affected by the question he or she presents. A requestor cannot ask for an advisory opinion about someone else’s activities, hypothetical situations, or general questions of law.</p>
+    <p>Advisory opinion requests must be in writing. The request must include a complete description of all facts relevant to the specific transaction or activity.</p>
+    <p>Within ten days of receiving the request, the Commission’s Office of General Counsel must determine whether it qualifies as a complete advisory opinion request.</p>
+    <p>A request does not qualify as a complete advisory opinion request if it:</p>
+    <ul class="list--bulleted">
+      <li>Asks a general question of interpretation</li>
+      <li>Asks about a hypothetical situation</li>
+      <li>Asks about the activities of someone other than the requestor</li>
+      <li>Asks about past activities that the requestor does not plan to continue in the future</li>
+      <li>Does not contain all of the factual information relevant to the activity that is the subject of the request</li>
+    </ul>
+    <p>If the request does not qualify as an advisory opinion request, the Office of General Counsel notifies the requestor of the specific deficiencies in the request.</p>
+    <p>If the request qualifies as an advisory opinion request, it is assigned an AOR number and made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion requests</a>.</p>
+  </div>
+  <div class="option_aside">
+    <p class="label">Mail requests for advisory opinions to:</p>
+    <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
+    <p>
+      Federal Election Commission<br>
+      Office of General Counsel<br>
+      999 E Street NW<br>
+      Washington, DC 20463
+    </p>
+  </div>
+</section>
+<section id="commenting" class="content__section">
+  <h2 class="heading--section">Commenting on advisory opinion requests</h2>
+  <div class="option__content">
+    <p>Submit comments on the request in writing to the Office of General Counsel within ten days after the advisory opinion request is made public.</p>
+    <p>Comments should refer to the AOR number of the request being commented on. Comments on advisory opinion requests are made public. <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search advisory opinion comments</a>.</p>
+  </div>
+  <div class="option_aside">
+    <p class="label">Mail comments to:</p>
+    <img src="{% static "img/i-mail--primary.svg" %}" alt="Icon of a stamp">
+    <p>
+      Federal Election Commission<br>
+      Office of General Counsel<br>
+      999 E Street NW<br>
+      Washington, DC 20463
+    </p>
+  </div>
+</section>
+<section id="draft-answers" class="content__section">
+  <h2 class="heading--section">Draft answers to advisory opinion requests</h2>
+  <div class="option__content">
+    <p>Before the meeting where the Commission is scheduled to consider an advisory opinion, the Commission will make public any draft answers to the advisory opinion request.</p>
+    <p>Copies of these drafts are emailed to the requestor and made public. Search draft answers. Submit comments on drafts by email, fax or hand delivery.  Generally, the deadline for comments on a draft advisory opinions is the noon on the day before the meeting at which the Commission is scheduled to consider the draft advisory opinion.</p>
+    <p class="label">Submit comments on drafts by:</p>
+    <div class="row">
+      <div class="usa-width-one-half">
+        <div class="contact-item contact-item--email">
+          <p class="t-bold">Email</p>
+          <a href="mailto:ao@fec.gov">ao@fec.gov</a>
+        </div>
+        <div class="contact-item contact-item--fax">
+          <p class="t-bold">Fax</p>
+          <p>Commission Secretary: (202) 208-3333</p>
+          <p>Office of General Counsel: (202) 219-392</p>
+        </div>
+      </div>
+      <div class="usa-width-one-half">
+        <div class="contact-item contact-item--hand">
+          <p class="t-bold">Hand delivery</p>
+          <p>Shawn Woodhead Werth</p>
+          <p>Office of the Commission Secretary</p>
+          <p>Federal Election Commission</p>
+          <p>999 E Street, NW</p>
+          <p>Washington, DC 20463</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="option_aside">
+    <p class="label">Related topic:</p>
+    <a href="{{ FEC_APP_URL }}/legal/search/advisory-opinions/">Search draft answers to advisory opinion requests</a>
+  </div>
+</section>
+<section id="issuing" class="content__section">
+  <h2 class="heading--section">Issuing an advisory opinion</h2>
+  <div class="option__content">
+    <p>The law generally requires the Commission to issue an advisory opinion within 60 days of receiving a complete advisory opinion request. But if the request is submitted by a federal candidate within 60 days before an election, and the request asks about a specific transaction or activity related to that election, then the Commission must respond within 20 days. In addition, the Commission has an informal practice through which it tries to respond to certain significant, time-sensitive requests within 30 days.</p>
+    <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve the draft advisory opinion before it. These votes almost always occur during an <a href="/calendar/?category=Open+Meetings">open meeting of the Commission</a>.</p>
+    <p>A requestor has the option to appear before the Commission at the open session where the Commission considers his or her advisory opinion request. A requestor can withdraw an advisory opinion request by submitting a written statement of withdrawal before the Commission votes to approve the advisory opinion.</p>
+    <p>If at least four Commissioners don’t vote to approve a draft advisory opinion in response to a request, the Commission’s Office of General Counsel will send the requestor a letter stating that the Commission was unable to approve an advisory opinion. This letter is also included in the public record.</p>
+  </div>
+  <div class="option_aside">
+    <p class="label">Related topics:</p>
+    <a href="calendar/?category=Open+Meetings">Open meetings calendar</a>
+    <div>
+      <p><a class="u-no-border" href="http://www.fec.gov/law/policy/enforcement/2009/ao05-09.pdf"><img src="{% static "img/thumbnail--ao-statistics.png" %}" alt="Image of advisory opinion statistics report"></a></p>
+      <a href="http://www.fec.gov/law/policy/enforcement/2009/ao05-09.pdf">Advisory opinion statistics FY 2005 to 2008 (PDF)</a>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block citations %}
+<div class="usa-width-one-half">
+  <p><strong>Regulations</strong></p>
+  <ul>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="http://edocket.access.gpo.gov/cfr_2014/janqtr/11cfr112.1.htm">112.1(a)–(f)</a></span>
+        <em>Requests for advisory opinions</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="https://www.gpo.gov/fdsys/pkg/CFR-2014-title11-vol1/xml/CFR-2014-title11-vol1-sec112-2.xml">112.2</a></span>
+        <em>Public availability of requests</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="http://edocket.access.gpo.gov/cfr_2014/janqtr/11cfr112.3.htm">112.3</a></span>
+        <em>Written comments on requests</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="https://www.gpo.gov/fdsys/pkg/CFR-2014-title11-vol1/xml/CFR-2014-title11-vol1-sec112-3.xml">112.3(b), (c)</a></span>
+        <em>Written comments on requests</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="http://edocket.access.gpo.gov/cfr_2014/janqtr/11cfr112.4.htm">112.4(b), (c), (g)</a></span>
+        <em>Issuance of advisory opinions</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">11 CFR <a href="https://www.gpo.gov/fdsys/pkg/CFR-2014-title11-vol1/xml/CFR-2014-title11-vol1-sec112-6.xml">112.6 (a), (b) and (d)</a></span>
+        <em>Reconsideration of advisory opinions</em>
+      </p>
+    </li>
+  </ul>
+</div>
+<div class="usa-width-one-half">
+  <p><strong>Statutes</strong></p>
+  <ul>
+    <li>
+      <p>
+        <span class="t-block">52 USC &sect;30101-30146</span>
+        <em>Disclosure of federal campaign funds</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">52 USC <a href="http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title52-section30108&num=0&edition=prelim">&sect;30108(a)(1), (a)(2)</a></span>
+        <em>Requests by persons, candidates, or authorized committees; subject matter; time for response</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">52 USC <a href="http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title52-section30108&num=0&edition=prelim">&sect;30108(c)</a></span>
+        <em>Persons entitled to rely upon opinions; scope of protection for good faith reliance</em>
+      </p>
+    </li>
+    <li>
+      <p>
+        <span class="t-block">52 USC <a href="http://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title52-section30108&num=0&edition=prelim">&sect;30108(d)</a></span>
+        <em>Requests made public; submission of written comments by interested public</em>
+      </p>
+    </li>
+  </ul>
+  <p><strong>Federal Register Notice</strong></p>
+  <ul>
+    <li>
+      <span class="t-block"><a href="http://www.fec.gov/law/cfr/ej_compilation/2009/notice_2009-11.pdf">74 Fed. Reg. 32160 (July 7, 2009)</a></span>
+      <em>Advisory opinion procedure</em>
+    </li>
+  </ul>
+</div>
+</div
+{% endblock %}

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from django.conf import settings
 
 def home(request):
     search_query = request.GET.get('query', None)
@@ -10,3 +11,23 @@ def home(request):
         'search_query': search_query,
         'self': page_context
     })
+
+def ao_process(request):
+  ancestors = [
+    {
+      'title': 'Legal resources',
+      'url': '/legal-resources/',
+    }, {
+      'title': 'Advisory opinions',
+      'url': settings.FEC_APP_URL + '/legal/advisory-opinions',
+    }
+  ]
+  page_context = {
+    'content_section': 'legal',
+    'title': 'The advisory opinion process',
+    'ancestors': ancestors
+  }
+
+  return render(request, 'legal/ao_process.html', {
+    'self': page_context
+  })


### PR DESCRIPTION
This implements the AO process page as part of https://github.com/18F/fec-eregs/issues/290

This first pass simply implements it as a hard-coded template in the CMS, rather than making a new page model that would allow this to be edited via the admin interface. I'm open to doing that, but want to hear more about if the content here would change enough to warrant it...or if we just want to adopt the approach that everything should be editable via the Wagtail interface.

[Screenshot](https://cloud.githubusercontent.com/assets/1696495/21068080/4c7f19aa-be24-11e6-9a9f-1f140950f4b1.png)

This is ready for visual review. 