### PR TITLE
Spells out month in date display

### DIFF
--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -96,7 +96,7 @@ Calendar.prototype.defaultOpts = function() {
       },
       contentHeight: 'auto',
       dayRender: this.handleDayRender.bind(this),
-      dayPopoverFormat: 'MMM D, YYYY',
+      dayPopoverFormat: 'MMMM D, YYYY',
       defaultView: 'monthTime',
       eventRender: this.handleEventRender.bind(this),
       eventAfterAllRender: this.handleRender.bind(this),


### PR DESCRIPTION
Another small inconsistency. Per our style guide we either display dates as:

`MM/DD/YYYY` or `Full month, day, YYYY`