### PR TITLE
Removes recruiting message from legal home page

### DIFF
--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -30,7 +30,7 @@
       <span class="t-note t-sans search__example search__example--with-select">Examples: 102.2; electioneering</span>
     </div>
   </div>
-  <div class="container">
+  <div class="main container">
       <div class="row">
         <div class="sidebar-container sidebar-container--left">
           <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">

--- a/fec/legal/templates/legal/home.html
+++ b/fec/legal/templates/legal/home.html
@@ -31,9 +31,6 @@
     </div>
   </div>
   <div class="container">
-      <div class="message message--no-icon">We&rsquo;re designing a new way to get legal resources.
-        We could use your help! Let us know if you&rsquo;re interested in <a id="share-feedback-link" href="#">
-          sharing feedback</a> as we build them.</div>
       <div class="row">
         <div class="sidebar-container sidebar-container--left">
           <nav class="sidebar sidebar--neutral side-nav js-sticky" data-sticky-container="main">


### PR DESCRIPTION
## Summary

Removes unique instance of recruiting message, since we have recruiting streams going specifically to recruit legal users for upcoming sprints, and we have no way to prove that this message has actually resulted in any volunteering from users.

## Screenshots

<img width="1433" alt="screen shot 2016-12-23 at 1 31 42 pm" src="https://cloud.githubusercontent.com/assets/11636908/21460265/5005b30e-c914-11e6-89f4-e4ae973a23d2.png">


