### PR TITLE
Specify typeahead selector

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -118,7 +118,7 @@ $(document).ready(function() {
   });
 
   // Initialize typeahead
-  new typeahead.Typeahead($('.js-search-input'), 'candidates', window.FEC_APP_URL + '/');
+  new typeahead.Typeahead($('.js-typeahead'), 'candidates', window.FEC_APP_URL + '/');
 
   // Initialize search toggle
   new Search($('.js-search'));

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -81,7 +81,7 @@
                   <option value="candidates">Candidates</option>
                   <option value="committees">Committees</option>
                 </select>
-                <input name="search" class="js-search-input combo__input" type="text"
+                <input name="search" class="js-typeahead combo__input" type="text"
                 autocorrect="off"
                 autocapitalize="off"
                 spellcheck="false">


### PR DESCRIPTION
This fixes an issue where the typeahead was incorrectly being
initialized for the legal search because it also had `.js-search-input`.
