### PR TITLE
Updated Chairman and Vice Chair titles for Commissioners

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -202,21 +202,21 @@
       <div class="grid grid--3-wide grid--no-border">
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--petersen.png" %}" alt="Headshot of Matthew S. Petersen">
+            <img class="icon-heading__image" src="{% static "img/headshot--walther.png" %}" alt="Headshot of Steven T. Walther">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/petersen/petersen.shtml">Matthew S. Petersen</a></div>
+              <div class="t-lead"><a href="http://www.fec.gov/members/walther/walther.shtml">Steven T. Walther</a></div>
               <div class="t-note">Chairman</div>
-              <div class="t-sans">Republican</div>
+              <div class="t-sans">Independent</div>
             </div>
           </div>
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--walther.png" %}" alt="Headshot of Steven T. Walther">
+            <img class="icon-heading__image" src="{% static "img/headshot--hunter.png" %}" alt="Headshot of Caroline C. Hunter">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/walther/walther.shtml">Steven T. Walther</a></div>
-              <div class="t-note">Vice Chairman</div>
-              <div class="t-sans">Independent</div>
+              <div class="t-lead"><a href="http://www.fec.gov/members/hunter/hunter.shtml">Caroline C. Hunter</a></div>
+              <div class="t-note">Vice Chair</div>
+              <div class="t-sans">Republican</div>
             </div>
           </div>
         </div>
@@ -231,9 +231,9 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--hunter.png" %}" alt="Headshot of Caroline C. Hunter">
+            <img class="icon-heading__image" src="{% static "img/headshot--petersen.png" %}" alt="Headshot of Matthew S. Petersen">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/hunter/hunter.shtml">Caroline C. Hunter</a></div>
+              <div class="t-lead"><a href="http://www.fec.gov/members/petersen/petersen.shtml">Matthew S. Petersen</a></div>
               <div class="t-sans">Republican</div>
             </div>
           </div>


### PR DESCRIPTION
Based on Commissioner seat rotations, the Chairman and Vice Chair titles have been updated on the homepage. This was also recently updated on the current FEC website (http://www.fec.gov/members/members.shtml).

![screen shot 2017-01-03 at 10 36 43 am](https://cloud.githubusercontent.com/assets/12799132/21612819/a2579976-d1a0-11e6-90c9-4e66d2249a1e.png)