### PR TITLE
Update README.md for easier install

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ Use `npm` to install JavaScript dependencies:
 ```bash
 npm install
 ```
+### Give default user privileges to create database
+If you would like your default user to create the database, alter their user role:
+```bash
+sudo su - postgres
+psql
+alter user [default_username] createdb;
+\q
+exit
+```
 
 ### Create local databases
 Before you can run this project locally, you'll need a development database:
@@ -109,8 +118,8 @@ project setup by running these commands:
 ```bash
 npm run build
 cd fec/
-./manage.py createsuperuser
 ./manage.py migrate
+./manage.py createsuperuser
 ```
 
 ## Running the application


### PR DESCRIPTION
Went through the installation again and noticed that some users might prefer to run createdb via their default user rather than as the postgres user. Since when you do a fresh install of postgres, the postgres user is the default and the only user able to run any postgres commands. So I added instructions for altering the role for the default user to be able to create database. 

Also noticed that migrate needs to run first in order to have the auth model to run the createsuperuser command.