### PR TITLE
[MERGE WITH GITFLOW] Hotfix/ao-process

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -21,14 +21,6 @@
   </head>
 
   <body class="{% block body_class %}{% endblock %}">
-    {% if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION' %}
-    <div class="banner">
-      <div class="container">
-        <span class="t-block t-bold t-centered">{{ settings.FEC_CMS_ENVIRONMENT }}</span>
-        <span class="t-block t-centered">This site is for testing new ideas and code. Access the most accurate data on the <a href="https://beta.fec.gov">live site</a>.</span>
-      </div>
-    </div>
-    {% endif %}
     {% wagtailuserbar %}
     <a href="#main" class="skip-nav">skip navigation</a>
 

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -146,7 +146,7 @@ def ao_process(request):
     'ancestors': ancestors
   }
 
-  return render(request, 'legal/ao_process.html', {
+  return render(request, 'home/legal/ao_process.html', {
     'self': page_context
   })
 


### PR DESCRIPTION
- Fixes the path to the AO process page, which moved into the `home` app
- Removes the out-dated beta warning bar, which we haven't used in ages and I have no idea why it showed up on a random 500 error page