### PR TITLE
Feature/link-block

### DIFF
--- a/fec/fec/static/css/customize-editor.css
+++ b/fec/fec/static/css/customize-editor.css
@@ -6,6 +6,14 @@ li.sequence-member .struct-block .sequence-container {
   width: 83%;
 }
 
+li.sequence-member .struct-block .sequence-container .field-content {
+  width: 100%;
+}
+
 li.sequence-member .sequence-member-inner .sequence-type-list .sequence-container-inner {
   width: 100%;
+}
+
+.t-sans {
+  font-family: sans-serif;
 }

--- a/fec/fec/static/js/hallo-edit-html.js
+++ b/fec/fec/static/js/hallo-edit-html.js
@@ -12,13 +12,6 @@
             populateToolbar: function(toolbar) {
                 var button, widget;
 
-                var getEnclosing = function(tag) {
-                    var node;
-
-                    node = widget.options.editable.getSelection().commonAncestorContainer;
-                    return $(node).parents(tag).get(0);
-                };
-
                 widget = this;
 
                 button = $('<span></span>');

--- a/fec/fec/static/js/hallo-sans-serif.js
+++ b/fec/fec/static/js/hallo-sans-serif.js
@@ -1,0 +1,46 @@
+(function() {
+  (function($) {
+    return $.widget('IKS.sansSerifButton', {
+      options: {
+        uuid: '',
+        editable: null
+      },
+      populateToolbar: function(toolbar) {
+        var button,
+            widget = this;
+
+        var checkClass = function() {
+            var node = widget.options.editable.getSelection().commonAncestorContainer;
+            var parent = $(node).parents('span').get(0);
+            if (parent) {
+                return parent.classList.contains('t-sans');
+            } else {
+                return false;
+            }
+        };
+
+        button = $('<span></span>');
+        button.hallobutton({
+          uuid: this.options.uuid,
+          editable: this.options.editable,
+          label: 'Sans-serif link',
+          icon: 'icon-edit',
+          command: null,
+          queryState: function(e) {
+            // Show the active state if it has the t-sans class already
+            return button.hallobutton('checked', checkClass());
+          }
+        });
+
+        toolbar.append(button);
+
+        button.on('click', function() {
+            // Get the selected node, find it's parent element and wrap it in a t-sans span
+            var node = widget.options.editable.getSelection().commonAncestorContainer;
+            var parent = $(node).parents('a').get(0);
+            $(parent).wrap('<span class="t-sans"></span>');
+        });
+      }
+    });
+  })(jQuery);
+}).call(this);

--- a/fec/fec/static/js/hallo-sans-serif.js
+++ b/fec/fec/static/js/hallo-sans-serif.js
@@ -39,6 +39,7 @@
             var node = widget.options.editable.getSelection().commonAncestorContainer;
             var parent = $(node).parents('a').get(0);
             $(parent).wrap('<span class="t-sans"></span>');
+            widget.options.editable.setModified();
         });
       }
     });

--- a/fec/fec/wagtail_hooks.py
+++ b/fec/fec/wagtail_hooks.py
@@ -24,6 +24,7 @@ def whitelister_element_rules():
         'li': allow_without_attributes,
         'ol': allow_without_attributes,
         'p': allow_without_attributes,
+        'span': attribute_rule({'class': True}),
         'strong': allow_without_attributes,
         'sub': allow_without_attributes,
         'sup': allow_without_attributes,
@@ -37,6 +38,7 @@ def editor_js():
         <script src="/static/js/vendor/rangy-core.js"></script>
         <script src="/static/js/vendor/rangy-selectionsaverestore.js"></script>
         <script src="/static/js/hallo-edit-html.js"></script>
+        <script src="/static/js/hallo-sans-serif.js"></script>
         <script src="/static/js/customize-editor.js"></script>
         <script src="/static/js-beautify/js/lib/beautify-html.js"></script>
         <script src="/static/ace-builds/src-noconflict/ace.js"></script>
@@ -44,6 +46,7 @@ def editor_js():
         <script>
             registerHalloPlugin('editHtmlButton');
             registerHalloPlugin('hallocleanhtml');
+            registerHalloPlugin('sansSerifButton');
         </script>
     ''')
 

--- a/fec/fec/wagtail_hooks.py
+++ b/fec/fec/wagtail_hooks.py
@@ -5,30 +5,7 @@ from django.utils.html import format_html
 @hooks.register('construct_whitelister_element_rules')
 def whitelister_element_rules():
     return {
-        # Commenting out disallowed tags so its easier to remember & revert
-        'a': attribute_rule({'href': check_url}),
-        'b': allow_without_attributes,
-        # 'br': allow_without_attributes,
-        # 'div': allow_without_attributes,
-        'em': allow_without_attributes,
-        'h1': allow_without_attributes,
-        'h2': allow_without_attributes,
-        'h3': allow_without_attributes,
-        'h4': allow_without_attributes,
-        'h5': allow_without_attributes,
-        'h6': allow_without_attributes,
-        'hr': allow_without_attributes,
-        'i': allow_without_attributes,
-        'img': attribute_rule({'src': check_url, 'width': True, 'height': True,
-                               'alt': True}),
-        'li': allow_without_attributes,
-        'ol': allow_without_attributes,
-        'p': allow_without_attributes,
         'span': attribute_rule({'class': True}),
-        'strong': allow_without_attributes,
-        'sub': allow_without_attributes,
-        'sup': allow_without_attributes,
-        'ul': allow_without_attributes,
     }
 
 @hooks.register('insert_editor_js')

--- a/fec/home/blocks.py
+++ b/fec/home/blocks.py
@@ -92,6 +92,7 @@ class ResourceBlock(blocks.StructBlock):
         ('contact_info', ContactInfoBlock()),
         ('internal_button', InternalButtonBlock()),
         ('external_button', ExternalButtonBlock()),
+        ('page', blocks.PageChooserBlock(template='blocks/page-links.html')),
         ('document_list', blocks.ListBlock(FeedDocumentBlock(), template='blocks/document-list.html', icon='doc-empty'))
     ])
 

--- a/fec/home/templates/blocks/page-links.html
+++ b/fec/home/templates/blocks/page-links.html
@@ -1,0 +1,5 @@
+{% load wagtailcore_tags %}
+
+<p class="usa-width-one-half">
+  <a class="t-sans"  href="{{ self.url }}">{{ self }} &raquo;</a>
+</p>


### PR DESCRIPTION
This adds a couple more capabilities to the CMS. 

First, it adds a new button to the rich text controls that is used to make a link sans-serif:

![demo](http://g.recordit.co/VqDuFYMU9E.gif)

Which gets us this:
![image](https://cloud.githubusercontent.com/assets/1696495/21836133/8e627a76-d777-11e6-8f32-ca28e9041b45.png)

Second, it adds a new block to the `section` StreamField to insert links to other pages, which will be used to get this sort of component on the new Candidate and Committee Services page (ignore the copy...these are just random pages in a random place for illustration purposes):
![image](https://cloud.githubusercontent.com/assets/1696495/21836198/107382b2-d778-11e6-8570-03a45904d147.png)
