### PR TITLE
Commissioner Page design updates

### DIFF
--- a/fec/home/templates/home/commissioner_page.html
+++ b/fec/home/templates/home/commissioner_page.html
@@ -19,22 +19,22 @@
     {% endif %}
 
       <div class="u-padding--top u-padding--bottom">
-        {% if self.commissioner_title %}
-          <div class="contact-item__title t-italic">{{ self.commissioner_title }}</div>
+        {% if self.commissioner_title  %}
+        <div class="t-lead t-note">{{ self.commissioner_title }}</div>
         {% endif %}
-          <div class="contact-item__title t-sans">
+        <div class="t-sans">{{ self.get_party_affiliation_display }}</div>
+        <div class="t-italic">
         {% if self.term_expiration %}
           {{ self.sworn_in|date:'F Y' }} to {{ self.term_expiration|date:'F Y' }}
           {% if self.reappointed_dates %}
-          </div>
-          <div class="contact-item__title t-sans">
-            ({{ self.reappointed_dates }})
+        </div>
+        <div class="t-italic">
+          ({{ self.reappointed_dates }})
           {% endif %}
         {% else %}
-          Currently serving
+          Currently Serving
         {% endif %}
-          </div>
-        <div class="t-sans">{{ self.get_party_affiliation_display }}</div>
+        </div>
       </div>
 
       {% if self.commissioner_email or self.commissioner_phone or self.commissioner_twitter %}

--- a/fec/home/templates/home/commissioners.html
+++ b/fec/home/templates/home/commissioners.html
@@ -31,26 +31,26 @@
     <div class="option">
       <h2>Ex officio Commissioners</h2>
 
-      <p>From 1975 through 1993, the Secretary of the Senate and the Clerk of the House were designated as nonvoting, ex officio Commissioners. In 1993, an appeals court ruled that the presence of nonvoting Congressionally appointed ex officio members on the Commission violated the Constitution’s separation of powers. The Supreme Court dismissed the Commission’s appeal for lack of jurisdiction (<a href="http://www.fec.gov/law/litigation/513_US_88.pdf">FEC v. NRA Political Victory Fund</a>). Subsequent to the appeals court decision, the Commission reconstituted itself as a six-member body.</p>
+      <p>From 1975 through 1993, the Secretary of the Senate and the Clerk of the House were designated as nonvoting, ex officio Commissioners. In 1993, an appeals court ruled that the presence of nonvoting Congressionally appointed ex officio members on the Commission violated the Constitution’s separation of powers. The Supreme Court dismissed the Commission’s appeal for lack of jurisdiction (<span class="t-italic"><a href="http://www.fec.gov/law/litigation/513_US_88.pdf">FEC v. NRA Political Victory Fund</a></span>). Subsequent to the appeals court decision, the Commission reconstituted itself as a six-member body.</p>
 
       <h3 class="u-padding--top">Clerk of the House</h3>
 
       <div class="grid grid--3-wide">
         <div class="grid__item">
           <div class="t-lead">Donnald K. Anderson</div>
-          <div class="t-sans">January 1987 - October 1993</div>
+          <div class="t-sans">January 1987 to October 1993</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">Benjamin U. Guthrie</div>
-          <div class="t-sans">January 1983 - January 1987</div>
+          <div class="t-sans">January 1983 to January 1987</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">Edmund L. Henshaw, Jr.</div>
-          <div class="t-sans">December 1975 - January 1983</div>
+          <div class="t-sans">December 1975 to January 1983</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">W. Pat Jennings</div>
-          <div class="t-sans">April 1975 - November 1975</div>
+          <div class="t-sans">April 1975 to November 1975</div>
         </div>
       </div>
 
@@ -59,23 +59,23 @@
       <div class="grid grid--3-wide u-padding--bottom">
         <div class="grid__item">
           <div class="t-lead">Walter J. Stewart</div>
-          <div class="t-sans">January 1987 - October 1993</div>
+          <div class="t-sans">January 1987 to October 1993</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">Jo-Anne L. Coe</div>
-          <div class="t-sans">January 1985 - January 1987</div>
+          <div class="t-sans">January 1985 to January 1987</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">William F. Hildenbrand</div>
-          <div class="t-sans">January 1981 - January 1985</div>
+          <div class="t-sans">January 1981 to January 1985</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">Joseph Stanley Kimmitt</div>
-          <div class="t-sans">April 1977 - January 1981</div>
+          <div class="t-sans">April 1977 to January 1981</div>
         </div>
         <div class="grid__item">
           <div class="t-lead">Francis R. Valeo</div>
-          <div class="t-sans">April 1975 - March 1977</div>
+          <div class="t-sans">April 1975 to March 1977</div>
         </div>
       </div>
     </div>

--- a/fec/home/templates/partials/commissioner.html
+++ b/fec/home/templates/partials/commissioner.html
@@ -1,17 +1,20 @@
 {% load wagtailimages_tags %}
+{% load staticfiles %}
 
-<div class="grid__item">
+<div class="grid__item commissioner-height">
   <div class="icon-heading">
     {% if commissioner.picture %}
     {% image commissioner.picture original as commissioner_picture %}
     <img class="icon-heading__image" src="{{ commissioner_picture.url }}" alt="Headshot of {{ commissioner.title }}">
+    {% else %}
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.png" %}" alt="Headshot of {{ commissioner.title }}">
     {% endif %}
     <div class="icon-heading__content">
       <div class="t-lead"><a href="{{ commissioner.url }}">{{ commissioner.title }}</a></div>
       {% if commissioner.commissioner_title  %}
       <div class="t-lead t-note">{{ commissioner.commissioner_title }}</div>
       {% endif %}
-      <div class="u-padding--top t-sans">{{ commissioner.get_party_affiliation_display }}</div>
+      <div class="t-sans">{{ commissioner.get_party_affiliation_display }}</div>
       <div class="t-italic">
       {% if commissioner.term_expiration %}
         {{ commissioner.sworn_in|date:'F Y' }} to {{ commissioner.term_expiration|date:'F Y' }}

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -173,8 +173,8 @@ def commissioners(request):
         'url': '/about/',
       },
       {
-        'title': 'Leadership and Organization',
-        'url': '/about/leadership-and-organization',
+        'title': 'Leadership and structure',
+        'url': '/about/leadership-and-structure',
       },
     ]
   }


### PR DESCRIPTION
- Set min-width for Commissioner listings and tighten up space between title and party
- Some text updates on Ex-officio
- Unify type styles between All Commissioner and Commissioner pages

Requires: https://github.com/18F/fec-style/pull/610