### PR TITLE
Feature/latest updates content

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -186,7 +186,8 @@ CONSTANTS = constants
 
 FEATURES = {
     'record': bool(env.get_credential('FEC_FEATURE_RECORD', '')),
-    'about': bool(env.get_credential('FEC_FEATURE_ABOUT', ''))
+    'about': bool(env.get_credential('FEC_FEATURE_ABOUT', '')),
+    'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', ''))
 }
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -187,7 +187,8 @@ CONSTANTS = constants
 FEATURES = {
     'record': bool(env.get_credential('FEC_FEATURE_RECORD', '')),
     'about': bool(env.get_credential('FEC_FEATURE_ABOUT', '')),
-    'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', ''))
+    'agendas': bool(env.get_credential('FEC_FEATURE_AGENDAS', '')),
+    'tips': bool(env.get_credential('FEC_FEATURE_TIPS', ''))
 }
 
 AUTH_PASSWORD_VALIDATORS = [

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -23,7 +23,7 @@
           <p>Weekly Digests are published every Friday and summarize the week's publicly disclosed activity. Press releases are published as news happens.</p>
           {% if request.user.is_authenticated or settings.FEATURES.record %}
           <h3>For candidates and committees</h3>
-          <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
+          <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. {% if settings.FEATURES.tips %}Tips for Treasurers are published once a week.{% endif %}</p>
           {% endif %}
           {% if request.user.is_authenticated or settings.FEATURES.agendas %}
           <h3>For members of the public</h3>

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -13,9 +13,26 @@
     <header class="heading--main">
       <h1>Latest updates</h1>
     </header>
-    <p class="p--lead">Search or browse the latest information about the Commission and federal campaign finance law.</p>
-    <p class="p--lead">Weekly Digests are published every Friday and summarize the week's publicly disclosed activity, including enforcement matters, litigation, meeting information and advisory opinion actions.</p>
-    <p class="p--lead">Press releases and FEC Record articles are published as news happens. Press releases are written for media professionals. Record articles are written for political committees.</p>
+    <div class="content__section--narrow">
+      <p class="t-lead">Search or browse the latest information about the Commission and federal campaign finance law.</p>
+      <div class="js-accordion accordion--neutral" data-content-prefix="updates">
+        <button type="button" class="js-accordion-trigger accordion__button">About latest updates</button>
+        <div class="accordion__content">
+          <p>The FEC regularly publishes information for media professionals, members of the public and candidates and committees.</p>
+          <h3>For media professionals</h3>
+          <p>Weekly Digests are published every Friday and summarize the week's publicly disclosed activity. Press releases are published as news happens.</p>
+          {% if request.user.is_authenticated or settings.FEATURES.record %}
+          <h3>For candidates and committees</h3>
+          <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
+          {% endif %}
+          {% if request.user.is_authenticated or settings.FEATURES.agendas %}
+          <h3>For members of the public</h3>
+          <p>Meeting agendas are usually published a week before a scheduled meeting.</p>
+          <p>Sunshine Act Notices are announcements of open meetings and executive sessions. Notices for open meetings are published at least a week before a scheduled meeting and announce the date, time and a general list of items for discussion.</p>
+          {% endif %}
+        </div>
+      </div>
+    </div>
   </div>
 </section>
 <section class="main__content--full data-container__wrapper">
@@ -26,7 +43,8 @@
           <select name="update_type">
             <option value="">All</option>
             {% if request.user.is_authenticated or settings.FEATURES.record %}
-              <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>FEC Record</option>
+              <option value="for-committees" {% if 'for-committees' in update_types %}selected{% endif %}>For candidates and committees:</option>
+              <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>- FEC Record</option>
             {% endif %}
             <option value="for-media" {% if 'for-media' in update_types %}selected{% endif %}>For media professionals:</option>
             <option value="press-release" {% if 'press-release' in update_types %}selected{% endif %}>- Press releases</option>
@@ -35,10 +53,20 @@
         </div>
           <div class="filter">
             {% if 'press-release' in update_types or 'for-media' in update_types %}
-              <label class="label" for="record-categories">Press release subjects</label>
-              <select id="record-categories" name="category">
+              <label class="label" for="release-categories">Press release subjects</label>
+              <select id="release-categories" name="category">
                 <option value="">All</option>
                 {% for cat in settings.CONSTANTS.press_release_page_categories.items %}
+                  <option value="{{ cat.0 | slugify }}"
+                    {% if cat.0|slugify in category_list %}selected{% endif %}>
+                    {{ cat.1 }}</option>
+                {% endfor %}
+              </select>
+            {% elif 'fec-record' in update_types or 'for-committees' in update_types %}
+              <label class="label" for="record-categories">FEC Record subjects</label>
+              <select id="record-categories" name="category">
+                <option value="">All</option>
+                {% for cat in settings.CONSTANTS.record_page_categories.items %}
                   <option value="{{ cat.0 | slugify }}"
                     {% if cat.0|slugify in category_list %}selected{% endif %}>
                     {{ cat.1 }}</option>

--- a/fec/home/templates/home/updates/press_release_page.html
+++ b/fec/home/templates/home/updates/press_release_page.html
@@ -11,7 +11,7 @@
     <li class="breadcrumbs__item"><a href="/" class="breadcrumbs__link" rel="Home">Home</a></li>
     <li class="breadcrumbs__item">
       <span class="breadcrumbs__separator">›</span>
-      <a class="breadcrumbs__link" href="/updates?release-category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
+      <a class="breadcrumbs__link" href="/updates?update_type=press-release&category={{self.get_category_display|slugify}}">Press releases: {{ self.get_category_display }}</a>
     </li>
     <li class="breadcrumbs__item breadcrumbs__item--current">
       <span class="breadcrumbs__separator">›</span>

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -76,9 +76,10 @@ def updates(request):
         records = RecordPage.objects.live()
 
       if year:
-        records = records.filter(date__year=year)
         press_releases = press_releases.filter(date__year=year)
         digests = digests.filter(date__year=year)
+        if settings.FEATURES['record']:
+          records = records.filter(date__year=year)
 
     # Chain all the QuerySets together
     # via http://stackoverflow.com/a/434755/1864981


### PR DESCRIPTION
This adds the accordion content from https://github.com/18F/fec-cms/issues/672 . Each content type is behind a feature flag. Because record articles are up next, here's how it looks when those are enabled:

![image](https://cloud.githubusercontent.com/assets/1696495/22004794/6b495348-dc13-11e6-8d7d-9d91d03364b6.png)

And here's what it looks like with everything enabled:

![image](https://cloud.githubusercontent.com/assets/1696495/22004851/c81dcac2-dc13-11e6-8bd5-bc9ce942204a.png)

This also adds the FEC record categories as a filter, fixes a bug where press release breadcrumbs weren't working correctly, and another bug where filtering by year without selecting a category would cause an error.

Resolves https://github.com/18F/fec-cms/issues/672
Resolves https://github.com/18F/fec-cms/issues/710 