### PR TITLE
Cleaning up aspects of the fec record articles

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -137,7 +137,7 @@ $(document).ready(function() {
   // Post feed
   // Move the read more links to be inline with the snippet from the post
   $('.js-post-content').each(function() {
-    var $p = $(this).find('p');
+    var $p = $(this).find('p:last-of-type');
     var $link = $(this).find('.js-read-more');
     if ($p.text() !== 'PDF') {
       $p.append($link);

--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -133,4 +133,16 @@ $(document).ready(function() {
       scrollTop: sectionTop
     });
   });
+
+  // Post feed
+  // Move the read more links to be inline with the snippet from the post
+  $('.js-post-content').each(function() {
+    var $p = $(this).find('p');
+    var $link = $(this).find('.js-read-more');
+    if ($p.text() !== 'PDF') {
+      $p.append($link);
+    } else {
+      $link.remove();
+    }
+  });
 });

--- a/fec/fec/static/scss/fec.scss
+++ b/fec/fec/static/scss/fec.scss
@@ -11,12 +11,6 @@
     @extend .content__section;
   }
 
-  // If the very first block is a paragraph--before any heading--then assume it
-  // should be the lead paragraph. This enlarges the font slightly.
-  .block-paragraph:first-child > .rich-text:first-child > p:first-child {
-    @extend .t-lead;
-  }
-
   .block-heading {
     @extend h2;
   }

--- a/fec/fec/templates/partials/author-list.html
+++ b/fec/fec/templates/partials/author-list.html
@@ -10,10 +10,16 @@
       {% image author.photo fill-40x40 class="author-item__image" %}
       <ul class="author-item__details t-sans">
         <li>
-          <a href="mailto:{{ author.email }}">{{ author.name }}</a>
-          <img class="icon--email--author" src="/static/img/i-email--primary.svg" alt="Icon of email being sent">
+          {% if author.email != 'N/A' %}
+            <a href="mailto:{{ author.email }}">{{ author.name }}</a>
+            <img class="icon--email--author" src="/static/img/i-email--primary.svg" alt="Icon of email being sent">
+          {% else %}
+            {{ author.name }}
+          {% endif %}
         </li>
+        {% if author.title != 'N/A' %}
         <li>{{ author.title }}</li>
+        {% endif %}
         <li>{{ author.phone }}</li>
       </ul>
       {% endspaceless %}

--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -8,15 +8,16 @@
   </div>
   <h3><a href="{{ update.url }}">{% formatted_title update %}</a></h3>
   {% if update.get_update_type != 'Weekly Digest' %}
-    <div class="t-sans row">
+    <div class="t-sans row js-post-content">
       {{ update.body | truncatewords_html:30 }}
+      <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a
     </div>
   {% endif %}
   {% if show_tag %}
     <div class="post__meta">
-      <a class="tag tag--secondary" href="/updates?update_type={{update.get_update_type|slugify}}">{{update.get_update_type}}</a>
+      <a class="tag tag--secondary" href="/updates?update_type={{update.get_update_type|slugify}}#feed">{{update.get_update_type}}</a>
       {% if update.category %}
-        in: <a href="/updates?update_type={{update.get_update_type|slugify}}&category={{update.category|slugify}}">{{ update.category }}</a>
+        in: <a href="/updates?update_type={{update.get_update_type|slugify}}&category={{update.category|slugify}}">{{ update.category|capfirst }}</a>
      {% endif %}
     </div>
   {% endif %}

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -35,7 +35,7 @@
     </div>
   </div>
 </section>
-<section class="main__content--full data-container__wrapper">
+<section class="main__content--full data-container__wrapper" id="feed">
   <div class="filters--horizontal">
     <form action="/updates" class="js-form-nav container">
         <div class="filter">

--- a/fec/home/templates/home/updates/digest_page.html
+++ b/fec/home/templates/home/updates/digest_page.html
@@ -55,6 +55,8 @@
       {% if self.read_next %}
         <h4><a href="{{ self.read_next.url }}">{{ self.read_next.title }}</a></h4>
       {% endif %}
+    </div>
+    <div class="content__section">
       <h4><a href="/updates?update_type=weekly-digest">More Weekly Digests</a> &raquo;</h4>
     </div>
   </div>

--- a/fec/home/templates/home/updates/press_release_page.html
+++ b/fec/home/templates/home/updates/press_release_page.html
@@ -62,6 +62,8 @@
       {% if self.read_next %}
         <h4><a href="{{ self.read_next.url }}">{{ self.read_next.title }}</a></h4>
       {% endif %}
+    </div>
+    <div class="content__section">
       <h4><a href="/updates?release-category=press-release">More press releases</a> &raquo;</h4>
     </div>
   </div>


### PR DESCRIPTION
This makes a few of the clean up changes from https://github.com/18F/fec-style/issues/614

- Adds a "Read more" link (needed to use javascript to get it inline)
- Capitalizes the first letter of the categories
![image](https://cloud.githubusercontent.com/assets/1696495/22168245/31883a7e-df20-11e6-9e9c-a0886503b4fd.png)

- When clicking on a tag, it now takes you to the `#feed` div so that the filters are at the top of the screen. 
- Removes the `p--lead` sizing on the first paragraphs.
- If title and email are 'N/A' then they're not displayed on posts

Last, it adds space between the "next item" and the link back to the latest updates page, resolving https://github.com/18F/fec-cms/issues/712:
![image](https://cloud.githubusercontent.com/assets/1696495/22169743/75b2e9e6-df2b-11e6-91bb-02347d49bca1.png)
