### PR TITLE
Hide draft posts on Homepage

### DIFF
--- a/fec/home/templatetags/updates.py
+++ b/fec/home/templatetags/updates.py
@@ -23,7 +23,7 @@ def weekly_digests():
 
 @register.inclusion_tag('partials/home-page-updates.html')
 def home_page_updates():
-    press_releases = PressReleasePage.objects.filter(homepage_hide=False).order_by('-date')[:4]
+    press_releases = PressReleasePage.objects.filter(homepage_hide=False, has_unpublished_changes=False).order_by('-date')[:4]
     if settings.FEATURES['record']:
         records = RecordPage.objects.filter(homepage_hide=False).order_by('-date')[:4]
     else:


### PR DESCRIPTION
Only show published posts on the "Whats Happening" section on the homepage. This updated PR is made off of master this time. 😅