### PR TITLE
Removes "Report a violation"

### DIFF
--- a/fec/home/templates/home/legal/enforcement.html
+++ b/fec/home/templates/home/legal/enforcement.html
@@ -32,14 +32,7 @@
       <div class="grid__item">
         <h3><a href="/legal-resources/enforcement/complaints-process/">Complaints</a></h3>
         <p>Learn how complaints are filed, processed and made public.</p>
-      </div>
-      <div class="grid__item">
-        <h3>Report a violation</h3>
-        <p class="t-italic">
-          Coming soon: How to file a complaint with the Commission and how
-          complaints are processed.
-        </p>
-      </div>
+        </div>
     </div>
     </div>
     <div class="sidebar-container">


### PR DESCRIPTION
Our content strategy has shifted so that all complaints content is included in the "Complaints" section. We're no longer planning to develop a "Report a violation" page, so I'm removing the option and its "Coming soon."


Content only. 