### PR TITLE
Feature/feed images

### DIFF
--- a/fec/fec/static/js/fec.js
+++ b/fec/fec/static/js/fec.js
@@ -137,7 +137,7 @@ $(document).ready(function() {
   // Post feed
   // Move the read more links to be inline with the snippet from the post
   $('.js-post-content').each(function() {
-    var $p = $(this).find('p:last-of-type');
+    var $p = $(this).find('p:first-of-type');
     var $link = $(this).find('.js-read-more');
     if ($p.text() !== 'PDF') {
       $p.append($link);

--- a/fec/fec/static/scss/fec.scss
+++ b/fec/fec/static/scss/fec.scss
@@ -16,13 +16,6 @@
   }
 
   .block-image {
-    @include media($med) {
-      @include span-columns(8);
-      float: none;  // override span-columns
-      margin-right: 0;  // override span-columns
-      margin-left: flex-gutter();
-    }
-
     img {
       height: auto;  // preserve ratio
       border: 2px solid $gray-lightest;

--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -6,19 +6,32 @@
     <div class="post__date">{{ update.date|date:'F j, Y' }}</div>
     <div class="post__byline">From: {% if update.get_update_type == 'FEC Record' %}Information Division{% else %}Press Office{% endif %}</div>
   </div>
-  <h3><a href="{{ update.url }}">{% formatted_title update %}</a></h3>
-  {% if update.get_update_type != 'Weekly Digest' %}
-    <div class="t-sans row js-post-content">
-      {{ update.body | truncatewords_html:30 }}
-      <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
+  <div class="row">
+    <div class="usa-width-three-fourths">
+      <h3><a href="{{ update.url }}">{% formatted_title update %}</a></h3>
+      {% if update.get_update_type != 'Weekly Digest' %}
+      <div class="t-sans row js-post-content">
+          {% for block in update.body %}
+            {% if block.block_type == 'paragraph' %}
+              {{ block | truncatewords_html:30 }}
+              <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% endif %}
+      {% if show_tag %}
+        <div class="post__meta">
+          <a class="tag tag--secondary" href="/updates?update_type={{update.get_update_type|slugify}}#feed">{{update.get_update_type}}</a>
+          {% if update.category %}
+            in: <a href="/updates?update_type={{update.get_update_type|slugify}}&category={{update.category|slugify}}">{{ update.category|capfirst }}</a>
+         {% endif %}
+        </div>
+      {% endif %}
     </div>
-  {% endif %}
-  {% if show_tag %}
-    <div class="post__meta">
-      <a class="tag tag--secondary" href="/updates?update_type={{update.get_update_type|slugify}}#feed">{{update.get_update_type}}</a>
-      {% if update.category %}
-        in: <a href="/updates?update_type={{update.get_update_type|slugify}}&category={{update.category|slugify}}">{{ update.category|capfirst }}</a>
-     {% endif %}
+    <div class="usa-width-one-fourth">
+      {% if update.feed_image %}
+        {% image update.feed_image original %}
+      {% endif %}
     </div>
-  {% endif %}
+  </div>
 </article>


### PR DESCRIPTION
This makes a few changes (along with an upcoming style PR) to clean up the presentation of image thumbnails in the latest updates feed.

![image](https://cloud.githubusercontent.com/assets/1696495/22808590/98a50f0e-eee1-11e6-8ad2-3f14d74cc59a.png)

Editors can now add a "feed image" in the "promote" panel in the editor, which shows up in the post blurb in the feed. 

Also, if there's an image block in the feed (which we're recommending doing going forward, rather than embedding in the rich text field), it won't show up here.