### PR TITLE
Restyling "What's happening" section of the home page

### DIFF
--- a/fec/fec/static/hbs/calendar/details.hbs
+++ b/fec/fec/static/hbs/calendar/details.hbs
@@ -22,7 +22,7 @@
       <span class="t-block"><a class="t-bold" href="{{detailUrl}}">Learn more</a></span>
     {{/if}}
     <div class="cal-details__add dropdown">
-      <button class="button button--alt dropdown__button button--calendar">Add to calendar</button>
+      <button class="button button--alt dropdown__button button--add-calendar">Add to calendar</button>
       <ul class="dropdown__panel" aria-hidden="true">
         <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Apple Calendar</a></li>
         <li class="dropdown__item"><a class="dropdown__value" href="{{google}}" target="_blank">Google Calendar</a></li>

--- a/fec/fec/static/hbs/calendar/events.hbs
+++ b/fec/fec/static/hbs/calendar/events.hbs
@@ -47,7 +47,7 @@
         </div>
         <div class="cal-list__add">
           <div class="dropdown">
-            <button class="button button--alt dropdown__button dropdown__button--mini button--calendar--mini" aria-describedby="cal-description-{{@index}}"><span class="u-visually-hidden">Download calendar</span></button>
+            <button class="button button--alt dropdown__button dropdown__button--mini button--add-calendar--mini" aria-describedby="cal-description-{{@index}}"><span class="u-visually-hidden">Download calendar</span></button>
             <ul class="dropdown__panel dropdown__panel--right" aria-hidden="true">
               <li class="dropdown__item"><a class="dropdown__value" href="{{download}}">Apple Calendar</a></li>
               <li class="dropdown__item"><a class="dropdown__value" href="{{google}}" target="_blank">Google Calendar</a></li>

--- a/fec/fec/static/js/upcoming-events.js
+++ b/fec/fec/static/js/upcoming-events.js
@@ -33,7 +33,7 @@ function UpcomingEvents() {
         eventSummary = event.summary;
       }
 
-      $('.js-homepage-upcoming-events').append('<li>' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
+      $('.js-homepage-upcoming-events').append('<li class="grid__item">' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
 
       return i < 3;
     });

--- a/fec/fec/static/js/upcoming-events.js
+++ b/fec/fec/static/js/upcoming-events.js
@@ -33,8 +33,10 @@ function UpcomingEvents() {
         eventSummary = event.summary;
       }
 
-      $('.js-homepage-upcoming-events').append('<li class="grid__item">' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
-
+      $('.js-homepage-upcoming-events').append(
+          '<li class="grid__item t-sans"><span class="t-bold">' +
+            startDateMonth + ' ' + startDateDay +
+          '</span>: ' + eventSummary + '</li>');
       return i < 3;
     });
   });

--- a/fec/fec/static/js/upcoming-events.js
+++ b/fec/fec/static/js/upcoming-events.js
@@ -35,7 +35,7 @@ function UpcomingEvents() {
 
       $('.js-homepage-upcoming-events').append('<li>' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
 
-      return i < 2;
+      return i < 3;
     });
   });
 }

--- a/fec/fec/static/js/upcoming-events.js
+++ b/fec/fec/static/js/upcoming-events.js
@@ -33,7 +33,7 @@ function UpcomingEvents() {
         eventSummary = event.summary;
       }
 
-      $('.homepage-upcoming-events').append('<li>' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
+      $('.js-homepage-upcoming-events').append('<li>' + startDateMonth + ' ' + startDateDay + ': ' + eventSummary + '</li>');
 
       return i < 2;
     });

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -49,20 +49,11 @@
   <section class="slab slab--neutral slab--home">
     <div class="container">
       <h6>What's happening</h6>
-      <div class="grid grid--2-wide grid--no-margin grid--no-border">
-        {% home_page_updates %}
-        <div class="grid__item">
-          <div class="icon icon-circle--updates--inline--left"></div>
-          <a class="t-sans" href="/updates">All latest updates »</a>
-        </div>
-      </div>
+      {% home_page_updates %}
       <h6>Upcoming Events</h6>
+      <ul class="grid grid--2-wide grid--no-margin grid--no-border list--border js-homepage-upcoming-events"></ul>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
-        <div class="grid__item">
-        <ul class="list--border js-homepage-upcoming-events"></ul>
-        </div>
-      </div>
-      <div class="grid grid--2-wide grid--no-margin grid--no-border">
+        <div class="grid__item"></div>
         <div class="grid__item">
           <div class="icon icon-circle--calendar--inline--left"></div>
           <a class="t-sans" href="/calendar">Full calendar »</a>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -48,17 +48,17 @@
 
   <section class="slab slab--neutral slab--home">
     <div class="container">
-      <h6>What's happening</h6>
-      {% home_page_updates %}
-      <h6>Upcoming Events</h6>
-      <ul class="grid grid--2-wide grid--no-margin grid--no-border list--border js-homepage-upcoming-events"></ul>
-      <div class="grid grid--2-wide grid--no-margin grid--no-border">
-        <div class="grid__item"></div>
-        <div class="grid__item">
-          <div class="icon icon-circle--calendar--inline--left"></div>
-          <a class="t-sans" href="/calendar">Full calendar »</a>
-        </div>
+      <div class="heading--section heading--with-action">
+        <h3 class="heading__left">What's happening</h3>
+        <a class="button button--alt heading__right button--updates" href="/updates">All latest updates</a>
       </div>
+      {% home_page_updates %}
+
+      <div class="heading--section heading--with-action">
+        <h3 class="heading__left">Upcoming Events</h3>
+        <a class="button button--alt heading__right button--calendar" href="/calendar">All events</a>
+      </div>
+      <ul class="grid grid--4-wide grid--no-margin grid--no-border list--border js-homepage-upcoming-events"></ul>
     </div>
   </section>
 

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -57,7 +57,11 @@
         </div>
       </div>
       <h6>Upcoming Events</h6>
-      <ul class="list--border js-homepage-upcoming-events"></ul>
+      <div class="grid grid--2-wide grid--no-margin grid--no-border">
+        <div class="grid__item">
+        <ul class="list--border js-homepage-upcoming-events"></ul>
+        </div>
+      </div>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
         <div class="grid__item">
           <div class="icon icon-circle--calendar--inline--left"></div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -51,17 +51,17 @@
       <h6>What's happening</h6>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
         {% home_page_updates %}
-      <div class="grid__item">
-        <div class="icon icon-circle--updates--inline--left"></div>
-        <a class="t-sans" href="/updates">All latest updates »</a>
+        <div class="grid__item">
+          <div class="icon icon-circle--updates--inline--left"></div>
+          <a class="t-sans" href="/updates">All latest updates »</a>
+        </div>
       </div>
-    </div>
       <h6>Upcoming Events</h6>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
-      <div class="grid__item">
-        <div class="icon icon-circle--calendar--inline--left"></div>
-        <a class="t-sans" href="/calendar">Full calendar »</a>
-      </div>
+        <div class="grid__item">
+          <div class="icon icon-circle--calendar--inline--left"></div>
+          <a class="t-sans" href="/calendar">Full calendar »</a>
+        </div>
       </div>
     </div>
   </section>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -55,7 +55,7 @@
       {% home_page_updates %}
 
       <div class="heading--section heading--with-action">
-        <h3 class="heading__left">Upcoming Events</h3>
+        <h3 class="heading__left">Upcoming events</h3>
         <a class="button button--alt heading__right button--calendar" href="/calendar">All events</a>
       </div>
       <ul class="grid grid--4-wide grid--no-margin grid--no-border list--border js-homepage-upcoming-events"></ul>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -49,16 +49,11 @@
   <section class="slab slab--neutral slab--home">
     <div class="container">
       <h6>What's happening</h6>
-      <div class="grid grid--3-wide grid--no-margin grid--no-border">
+      <div class="grid grid--2-wide grid--no-margin grid--no-border">
         {% home_page_updates %}
-        <div class="grid__item">
-          <h6 class="t-no-rules">Upcoming Events</h6>
-          <ul class="list--border homepage-upcoming-events u-border-top-gray">
-          </ul>
-        </div>
       </div>
-      <div class="grid grid--3-wide grid--no-margin grid--no-border">
-        <div class="grid__item"></div>
+      <h6>Upcoming Events</h6>
+      <div class="grid grid--2-wide grid--no-margin grid--no-border">
         <div class="grid__item">
           <div class="icon icon-circle--updates--inline--left"></div>
           <a class="t-lead" href="/updates">All latest updates »</a>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -57,6 +57,7 @@
         </div>
       </div>
       <h6>Upcoming Events</h6>
+      <ul class="list--border js-homepage-upcoming-events"></ul>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
         <div class="grid__item">
           <div class="icon icon-circle--calendar--inline--left"></div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -51,17 +51,17 @@
       <h6>What's happening</h6>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
         {% home_page_updates %}
+      <div class="grid__item">
+        <div class="icon icon-circle--updates--inline--left"></div>
+        <a class="t-sans" href="/updates">All latest updates »</a>
       </div>
+    </div>
       <h6>Upcoming Events</h6>
       <div class="grid grid--2-wide grid--no-margin grid--no-border">
-        <div class="grid__item">
-          <div class="icon icon-circle--updates--inline--left"></div>
-          <a class="t-lead" href="/updates">All latest updates »</a>
-        </div>
-        <div class="grid__item">
-          <div class="icon icon-circle--calendar--inline--left"></div>
-          <a class="t-lead" href="/calendar">Full calendar »</a>
-        </div>
+      <div class="grid__item">
+        <div class="icon icon-circle--calendar--inline--left"></div>
+        <a class="t-sans" href="/calendar">Full calendar »</a>
+      </div>
       </div>
     </div>
   </section>

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -1,15 +1,10 @@
 {% load filters %}
-<ul class="grid grid--2-wide grid--no-margin grid--no-border list--border">
+<ul class="grid grid--4-wide grid--no-margin grid--no-border list--border">
   {% for update in updates %}
   <li class="grid__item {% if update.homepage_pin == True %}u-no-padding-left u-no-padding-right"{% endif %}">
     {% if update.homepage_pin == True %}<div class="u-gray-background">{% endif %}
-      <a href="{{ update.url }}">{% formatted_title update %}</a> — <span class="t-sans">{{ update.get_update_type }}</span>
+      <span class="t-sans"><span class="t-bold">{{ update.category|title }}</span>: <a href="{{ update.url }}">{% formatted_title update %}</a></span>
     {% if update.homepage_pin %}</div>{% endif %}
   </li>
   {% endfor %}
-  <li class="grid__item"></li>
-  <li class="grid__item">
-    <div class="icon icon-circle--updates--inline--left"></div>
-    <a class="t-sans" href="/updates">All latest updates »</a>
-  </li>
 </ul>

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -3,7 +3,7 @@
   {% for update in updates %}
   <li class="grid__item {% if update.homepage_pin == True %}u-no-padding-left u-no-padding-right"{% endif %}">
     {% if update.homepage_pin == True %}<div class="u-gray-background">{% endif %}
-      <span class="t-sans"><span class="t-bold">{{ update.category|title }}</span>: <a href="{{ update.url }}">{% formatted_title update %}</a></span>
+      <span class="t-sans"><span class="t-bold">{{ update.category|capfirst }}</span>: <a href="{{ update.url }}">{% formatted_title update %}</a></span>
     {% if update.homepage_pin %}</div>{% endif %}
   </li>
   {% endfor %}

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -1,17 +1,15 @@
 {% load filters %}
-
-{% for update in updates %}
-  {% if forloop.counter == 1 or forloop.counter == 3 %}
-  <div class="grid__item">
-    <ul class="list--border">
-  {% endif %}
-      <li{% if update.homepage_pin == True %} class="u-no-padding-left u-no-padding-right"{% endif %}>
-      {% if update.homepage_pin == True %}<div class="u-gray-background">{% endif %}
-        <a href="{{ update.url }}">{% formatted_title update %}</a> — <span class="t-sans">{{ update.get_update_type }}</span>
-      {% if update.homepage_pin %}</div>{% endif %}
-      </li>
-  {% if forloop.counter == 2 or forloop.counter == 4 %}
-    </ul>
-  </div>
-  {% endif %}
-{% endfor %}
+<ul class="grid grid--2-wide grid--no-margin grid--no-border list--border">
+  {% for update in updates %}
+  <li class="grid__item {% if update.homepage_pin == True %}u-no-padding-left u-no-padding-right"{% endif %}">
+    {% if update.homepage_pin == True %}<div class="u-gray-background">{% endif %}
+      <a href="{{ update.url }}">{% formatted_title update %}</a> — <span class="t-sans">{{ update.get_update_type }}</span>
+    {% if update.homepage_pin %}</div>{% endif %}
+  </li>
+  {% endfor %}
+  <li class="grid__item"></li>
+  <li class="grid__item">
+    <div class="icon icon-circle--updates--inline--left"></div>
+    <a class="t-sans" href="/updates">All latest updates »</a>
+  </li>
+</ul>


### PR DESCRIPTION
## Summary
These changes are designed to make the layout more flexible for fewer items. When items have fewer columns to fill, there are fewer gaps left by different item/line lengths.

**Changes:**
- Moves layout to two-column grid and splits "Upcoming events" into it's own item, instead of being part of "What's happening"

<img width="1274" alt="screen shot 2017-02-10 at 1 36 54 pm" src="https://cloud.githubusercontent.com/assets/11636908/22839302/d4a92eda-ef96-11e6-9ae3-eb720103dc78.png">



### Important note for review: ⚠️ 
I wasn't able to get data or events to populate these fields when I was running it locally, so it MUST be reviewed by someone who can prove that I didn't accidentally break the functionality.

Through inspector, I was able to simulate what I think the changes will do, but it really needs to be run to prove it!

<img width="1279" alt="screen shot 2017-02-10 at 1 37 11 pm" src="https://cloud.githubusercontent.com/assets/11636908/22839364/13429988-ef97-11e6-8976-b21bd51fe105.png">

### Related issues
This is a partial improvement toward https://github.com/18F/fec-style/issues/602