### PR TITLE
Only show the first paragraph block in the latest update preview

### DIFF
--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -11,12 +11,17 @@
       <h3><a href="{{ update.url }}">{% formatted_title update %}</a></h3>
       {% if update.get_update_type != 'Weekly Digest' %}
       <div class="t-sans row js-post-content">
-          {% for block in update.body %}
-            {% if block.block_type == 'paragraph' %}
-              {{ block | truncatewords_html:30 }}
-              <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
-            {% endif %}
-          {% endfor %}
+        {% comment %}
+          This looks for either the first or second block to be a paragraph and then show that text.
+          If it's an image or something else we ignore it.
+        {% endcomment %}
+          {% if update.body.0.block_type == 'paragraph' %}
+            {{ update.body.0 | truncatewords_html:30 }}
+            <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
+          {% elif update.body.2.block_type == 'paragraph' %}
+            {{ update.body.2 | truncatewords_html:30 }}
+            <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
+          {% endif %}
         </div>
       {% endif %}
       {% if show_tag %}

--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -18,8 +18,8 @@
           {% if update.body.0.block_type == 'paragraph' %}
             {{ update.body.0 | truncatewords_html:30 }}
             <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
-          {% elif update.body.2.block_type == 'paragraph' %}
-            {{ update.body.2 | truncatewords_html:30 }}
+          {% elif update.body.1.block_type == 'paragraph' %}
+            {{ update.body.1 | truncatewords_html:30 }}
             <a class="js-read-more post__read-more" href="{{ update.url }}">Read more</a>
           {% endif %}
         </div>


### PR DESCRIPTION
The current behavior is outputting multiple paragraphs if they’re stored as separate blocks in the body streamfield. 

Instead of looping through all body blocks and looking for paragraph block types, this just checks the first two blocks for a paragraph. This way, if the first block is an image, it will be ignored. If the first block is a paragraph, it will just show the one paragraph.