### PR TITLE
[MERGE WITH GITFLOW] Hotfix/remove ravel

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -300,15 +300,6 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--ravel.png" %}" alt="Headshot of Ann M. Ravel">
-            <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/ravel/ravel.shtml">Ann M. Ravel</a></div>
-              <div class="t-sans">Democrat</div>
-            </div>
-          </div>
-        </div>
-        <div class="grid__item">
-          <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--weintraub.png" %}" alt="Headshot of Ellen L. Weintraub">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="http://www.fec.gov/members/weintraub/weintraub.shtml">Ellen L. Weintraub</a></div>


### PR DESCRIPTION
Removes Ravel from the home page now that she's no longer on the commission. 

![image](https://cloud.githubusercontent.com/assets/1696495/23775918/13cc7c44-04e0-11e7-9a4d-3c7787bca68b.png)
