### PR TITLE
Home page: Directs Mission link to beta site instead of old site

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -256,7 +256,7 @@
       <h1>Commissioners</h1>
       <div class="content__section content__section--narrow u-padding--top">
         <p>Established in 1975, the FEC is composed of six Commissioners who are appointed by the President and confirmed by the Senate. By law, no more than three can represent the same political party.</p>
-        <a class="t-sans" href="http://www.fec.gov/about.shtml">Learn more about the FEC's history and mission »</a>
+        <a class="t-sans" href="/about/mission-and-history">Learn more about the FEC's history and mission »</a>
       </div>
 
       <div class="grid grid--3-wide grid--no-border">


### PR DESCRIPTION
Since we've released the Mission and history page, this link no longer needs to go to the old FEC site. 

<img width="1068" alt="screen shot 2017-03-16 at 10 58 35 am" src="https://cloud.githubusercontent.com/assets/11636908/24002602/8ec2d1c6-0a37-11e7-891e-aeef17229cd5.png">

cc @emileighoutlaw 