### PR TITLE
Hotfix/Home page about and commissioner links

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -256,7 +256,7 @@
       <h1>Commissioners</h1>
       <div class="content__section content__section--narrow u-padding--top">
         <p>Established in 1975, the FEC is composed of six Commissioners who are appointed by the President and confirmed by the Senate. By law, no more than three can represent the same political party.</p>
-        <a class="t-sans" href="http://www.fec.gov/about.shtml">Learn more about the FEC's history and mission »</a>
+        <a class="t-sans" href="/about/mission-and-history">Learn more about the FEC's history and mission »</a>
       </div>
 
       <div class="grid grid--3-wide grid--no-border">
@@ -298,7 +298,7 @@
             </div>
           </div>
         </div>
-        
+
         <div class="grid__item">
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--weintraub.png" %}" alt="Headshot of Ellen L. Weintraub">

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -264,7 +264,7 @@
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--walther.png" %}" alt="Headshot of Steven T. Walther">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/walther/walther.shtml">Steven T. Walther</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
               <div class="t-note">Chairman</div>
               <div class="t-sans">Independent</div>
             </div>
@@ -274,7 +274,7 @@
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--hunter.png" %}" alt="Headshot of Caroline C. Hunter">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/hunter/hunter.shtml">Caroline C. Hunter</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
               <div class="t-note">Vice Chair</div>
               <div class="t-sans">Republican</div>
             </div>
@@ -284,7 +284,7 @@
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--goodman.png" %}" alt="Headshot of Lee E. Goodman">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/goodman/goodman.shtml">Lee E. Goodman</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/lee-e-goodman">Lee E. Goodman</a></div>
               <div class="t-sans">Republican</div>
             </div>
           </div>
@@ -293,17 +293,16 @@
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--petersen.png" %}" alt="Headshot of Matthew S. Petersen">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/petersen/petersen.shtml">Matthew S. Petersen</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/mathew-s-petersen">Matthew S. Petersen</a></div>
               <div class="t-sans">Republican</div>
             </div>
           </div>
         </div>
-
         <div class="grid__item">
           <div class="icon-heading">
             <img class="icon-heading__image" src="{% static "img/headshot--weintraub.png" %}" alt="Headshot of Ellen L. Weintraub">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="http://www.fec.gov/members/weintraub/weintraub.shtml">Ellen L. Weintraub</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub">Ellen L. Weintraub</a></div>
               <div class="t-sans">Democrat</div>
             </div>
           </div>


### PR DESCRIPTION
⚠️  I THINK THIS NEEDS TO BE MERGED WITH GITFLOW ⚠️ 

**Summary**
Links the About and Commissioner bios on the home page to the beta site instead of the fec.gov

