### PR TITLE
Removing the max-length on the committee name field

### DIFF
--- a/fec/fec/forms.py
+++ b/fec/fec/forms.py
@@ -17,15 +17,15 @@ class ContactRAD(forms.Form):
         category_options = [('', 'Choose a subject')] + form_categories()
         super().__init__(*args, **kwargs)
 
-        self.fields['u_contact_first_name'] = forms.CharField(label='First name', max_length=100, required=True)
-        self.fields['u_contact_last_name'] = forms.CharField(label='Last name', max_length=100, required=True)
-        self.fields['u_contact_email'] = forms.EmailField(label='Email', max_length=100, required=True)
+        self.fields['u_contact_first_name'] = forms.CharField(label='First name', required=True)
+        self.fields['u_contact_last_name'] = forms.CharField(label='Last name', required=True)
+        self.fields['u_contact_email'] = forms.EmailField(label='Email', required=True)
         self.fields['committee_name'] = forms.CharField(label='Committee name or ID', required=True, widget=forms.TextInput(attrs={'class': 'js-contact-typeahead'}))
         self.fields['u_committee'] = forms.CharField(widget=forms.HiddenInput())
         self.fields['u_contact_title'] = forms.CharField(label='Your position or title', max_length=100, required=False)
         self.fields['u_category'] = forms.ChoiceField(label='Subject', choices=category_options, required=True)
-        self.fields['u_other_reason'] = forms.CharField(label='Subject', max_length=100, required=False)
-        self.fields['u_description'] = forms.CharField(label='Question', max_length=100, widget=forms.Textarea, required=True)
+        self.fields['u_other_reason'] = forms.CharField(label='Subject', required=False)
+        self.fields['u_description'] = forms.CharField(label='Question', widget=forms.Textarea, required=True)
         self.fields['u_committee_member_certification'] = forms.BooleanField(label='I agree', required=True)
 
     def post_to_service_now(self):

--- a/fec/fec/forms.py
+++ b/fec/fec/forms.py
@@ -20,7 +20,7 @@ class ContactRAD(forms.Form):
         self.fields['u_contact_first_name'] = forms.CharField(label='First name', max_length=100, required=True)
         self.fields['u_contact_last_name'] = forms.CharField(label='Last name', max_length=100, required=True)
         self.fields['u_contact_email'] = forms.EmailField(label='Email', max_length=100, required=True)
-        self.fields['committee_name'] = forms.CharField(label='Committee name or ID', max_length=20, required=True, widget=forms.TextInput(attrs={'class': 'js-contact-typeahead'}))
+        self.fields['committee_name'] = forms.CharField(label='Committee name or ID', required=True, widget=forms.TextInput(attrs={'class': 'js-contact-typeahead'}))
         self.fields['u_committee'] = forms.CharField(widget=forms.HiddenInput())
         self.fields['u_contact_title'] = forms.CharField(label='Your position or title', max_length=100, required=False)
         self.fields['u_category'] = forms.ChoiceField(label='Subject', choices=category_options, required=True)

--- a/fec/fec/forms.py
+++ b/fec/fec/forms.py
@@ -22,7 +22,7 @@ class ContactRAD(forms.Form):
         self.fields['u_contact_email'] = forms.EmailField(label='Email', required=True)
         self.fields['committee_name'] = forms.CharField(label='Committee name or ID', required=True, widget=forms.TextInput(attrs={'class': 'js-contact-typeahead'}))
         self.fields['u_committee'] = forms.CharField(widget=forms.HiddenInput())
-        self.fields['u_contact_title'] = forms.CharField(label='Your position or title', max_length=100, required=False)
+        self.fields['u_contact_title'] = forms.CharField(label='Your position or title', required=False)
         self.fields['u_category'] = forms.ChoiceField(label='Subject', choices=category_options, required=True)
         self.fields['u_other_reason'] = forms.CharField(label='Subject', required=False)
         self.fields['u_description'] = forms.CharField(label='Question', widget=forms.Textarea, required=True)

--- a/fec/home/templates/home/contact-form.html
+++ b/fec/home/templates/home/contact-form.html
@@ -25,7 +25,32 @@
       {% else %}
 
       <p>If you represent a committee or another entity registered with the FEC, RAD staff can help answer your reporting questions. Submit this form, and a RAD analyst will email you, usually within 3 business days.</p>
-      <p>You can also call RAD from 8:30 a.m. to 5:30 p.m. Eastern Time at 1-800-425-9530, extension 5.</p>
+      <p>You can also call the FEC for immediate assistance.</p>
+      <div class="row content__section--narrow">
+        <div class="grid grid--2-wide">
+          <div class="grid__item">
+            <h3 class="label">Authorized representatives</h3>
+            <div class="contact-item contact-item--phone">
+              <div class="contact-item__content">
+                <h5 class="contact-item__title">Reports Analysis Division</h5>
+                <span class="t-block">1-800-425-9530</span>
+                <span class="t-block">Extension 5</span>
+                <span class="t-block">8:30 a.m. to 5:30 p.m. Eastern Time</span>
+              </div>
+            </div>
+          </div>
+          <div class="grid__item">
+            <h3 class="label">All others</h3>
+            <div class="contact-item contact-item--phone">
+              <div class="contact-item__content">
+                <h5 class="contact-item__title">General information</h5>
+                <span class="t-block">1-800-425-9530</span>
+                <span class="t-block">8:30 a.m. to 5:30 p.m. Eastern Time</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
 
       {% if form %}
         {% if form.errors %}


### PR DESCRIPTION
Removes all of the `max_length` attributes from the RAD contact form.