### PR TITLE
Putting card links to form behind feature flag

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -56,18 +56,20 @@
   <div class="slab slab--neutral">
     <div class="container">
       <div class="grid grid--4-wide">
-        <div class="grid__item">
-          <a href="{{ self.url }}question-rad">
-            <aside class="card card--horizontal card--secondary">
-              <div class="card__image__container">
-                  <span class="card__icon i-question-bubble"><span class="u-visually-hidden">Icon representing a question</span></span>
-              </div>
-              <div class="card__content">
-                Submit a question to the Reports Analysis Division
-              </div>
-            </aside>
-          </a>
-        </div>
+        {% if settings.FEATURES.radform %}
+          <div class="grid__item">
+            <a href="{{ self.url }}question-rad">
+              <aside class="card card--horizontal card--secondary">
+                <div class="card__image__container">
+                    <span class="card__icon i-question-bubble"><span class="u-visually-hidden">Icon representing a question</span></span>
+                </div>
+                <div class="card__content">
+                  Submit a question to the Reports Analysis Division
+                </div>
+              </aside>
+            </a>
+          </div>
+        {% endif %}
         <div class="grid__item">
           <a href="">
             <aside class="card card--horizontal card--secondary">

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -76,13 +76,13 @@
             <a class="button--cta button--go" href="/legal-resources/enforcement/">Explore enforcement</a>
           </div>
           <div class="option">
-            <h2 id="regulations"><a href="/regulations">Regulations</a></h2>
+            <h2 id="regulations"><a href="/legal-resources/regulations">Regulations</a></h2>
             <p>As part of its role administering campaign finance law,
               the Commission issues regulations,
               which are published every year in Title 11 of the Code of Federal Regulations (CFR).
               This archive contains a full-text version of 11 CFR, as published January 1, 2016.
             </p>
-            <a class="button--cta button--go" href="/regulations">Explore regulations</a>
+            <a class="button--cta button--go" href="/legal-resources/regulations">Explore regulations</a>
           </div>
           <div class="option">
             <h2 id="statutes">Statutes and legislation</h2>

--- a/fec/home/templates/home/registration-and-reporting/landing_page.html
+++ b/fec/home/templates/home/registration-and-reporting/landing_page.html
@@ -164,9 +164,10 @@
               </div>
           </aside>
         </div>
+        {% if settings.FEATURES.radform %}
         <div class="grid__item">
           <aside class="card card--horizontal card--secondary">
-            <a href="/registration-and-reporting/question-RAD">
+            <a href="/candidate-and-committee-services/question-rad">
               <div class="card__image__container">
                 <span class="card__icon i-question-bubble"><span class="u-visually-hidden">Icon of a question bubble</span></span>
               </div>
@@ -177,6 +178,7 @@
           </aside>
           <p class="t-note">For authorized representatives of a committee or another entity registered with the FEC only</p>
         </div>
+        {% endif %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
This puts the links to the contact form behind feature flags so that they won't show up unless the flag is enabled. 