### PR TITLE
Fix/child page count

### DIFF
--- a/fec/home/templates/home/reports_landing_page.html
+++ b/fec/home/templates/home/reports_landing_page.html
@@ -20,7 +20,7 @@
           <h2>{{ blurb.value.page.title }}</h2>
         </div>
         <p>{{ blurb.value.description }}</p>
-        <span class="t-sans card__count">{{ blurb.value.page | document_count }}</span>
+        <span class="t-sans card__count">{{ blurb.value.page | child_page_count }}</span>
       </a>
       {% endfor %}
     </div>

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -31,7 +31,7 @@ def districts(max):
   return districts
 
 @register.filter()
-def document_count(page):
-  """Returns the number of DocumentPages for a particular category"""
-  count = DocumentPage.objects.child_of(page).live().count()
+def child_page_count(page):
+  """Returns the number of pages that are children of a particular page"""
+  count = Page.objects.child_of(page).live().count()
   return "{} {}".format(count, 'result' if count == 1 else 'results')

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -2,7 +2,7 @@ import re
 
 from django import template
 from django.utils.html import format_html
-from home.models import DocumentPage
+from wagtail.wagtailcore.models import Page
 
 register = template.Library()
 


### PR DESCRIPTION
This filter is used to show how many pages are child pages of a particular page. Previously, these children pages were only DocumentPages, but now they may be other types of pages as well. So this just makes it more generic, and thus more accurate. 

Previously:
![image](https://cloud.githubusercontent.com/assets/1696495/24260753/1d5a4098-0fb2-11e7-9ab1-746cba0411ff.png)

Now:
![image](https://cloud.githubusercontent.com/assets/1696495/24260686/f459c600-0fb1-11e7-89c5-66bbb827d3e4.png)
