### PR TITLE
Removing unneeded buttons from legal home

### DIFF
--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -98,18 +98,15 @@
             </div>
             <h3><a href="/legal-resources/legislation/">Legislation</a></h3>
             <p>Browse selected amendments to the <em>Federal Election Campaign Act</em> and Commission recommendations to Congress.</p>
-            <a class="button--cta button--go" href="/legal-resources/legislation/">Explore legislation</a>
           </div>
           <div class="option">
             <h2 id="court-and-policy">Court cases and policy statements</h2>
             <div class="content__section">
               <h3><a href="/legal-resources/court-cases">Court cases</a></h3>
               <p>Learn more about active and past cases involving the FEC.</p>
-              <a class="button--cta button--go" href="/legal-resources/court-cases">Explore court cases</a>
             </div>
             <h3><a href="http://www.fec.gov/law/policy.shtml">Policy statements</a></h3>
             <p>Access statements, interpretive rules and other guidance issued by the FEC.</p>
-            <a class="button--cta button--go" href="http://www.fec.gov/law/policy.shtml">Explore policy statements</a>
           </div>
         </section>
       </div>


### PR DESCRIPTION
# Summary
Removes the call to action buttons from Legislation, Court cases, and Policy statements because 
1. These buttons should only be used when a call to action is needed
2. If everything gets a call to action, then they compete with one another
3. These sections are the least fleshed out, and less-used at the moment.

## Screenshot:
![screen shot 2017-03-27 at 2 46 08 pm](https://cloud.githubusercontent.com/assets/11636908/24372610/888f690e-12fc-11e7-8d40-7929b4e4b822.png)

cc @emileighoutlaw or  @noahmanger for review