### PR TITLE
Separating court cases and policy statement sections

### DIFF
--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -53,8 +53,13 @@
                 </a>
               </li>
               <li class="side-nav__item">
-                <a class="side-nav__link" href="#court-and-policy">
-                Court cases and policy statements
+                <a class="side-nav__link" href="#court-cases">
+                Court cases
+                </a>
+              </li>
+              <li class="side-nav__item">
+                <a class="side-nav__link" href="#policy">
+                Policy statements and other guidance
                 </a>
               </li>
             </ul>
@@ -100,12 +105,11 @@
             <p>Browse selected amendments to the <em>Federal Election Campaign Act</em> and Commission recommendations to Congress.</p>
           </div>
           <div class="option">
-            <h2 id="court-and-policy">Court cases and policy statements</h2>
-            <div class="content__section">
-              <h3><a href="/legal-resources/court-cases">Court cases</a></h3>
-              <p>Learn more about active and past cases involving the FEC.</p>
-            </div>
-            <h3><a href="http://www.fec.gov/law/policy.shtml">Policy statements</a></h3>
+            <h2 id="court-cases"><a href="/legal-resources/court-cases">Court cases</a></h2>
+            <p>Learn more about active and past cases involving the FEC.</p>
+          </div>
+          <div class="option">
+            <h2 id="policy"><a href="http://www.fec.gov/law/policy.shtml">Policy statements and other guidance</a></h2>
             <p>Access statements, interpretive rules and other guidance issued by the FEC.</p>
           </div>
         </section>


### PR DESCRIPTION
Per discussion with @AmyKort in Slack, this separates the court cases and policy statements sections, as they're not actually related. 

I'm suggesting leaving off the button-style call-to-action links for these sections though in order to keep emphasis on the above sections.

![image](https://cloud.githubusercontent.com/assets/1696495/24417955/41e853c8-139f-11e7-97f7-9eecb4d469e3.png)

![image](https://cloud.githubusercontent.com/assets/1696495/24417947/3ddc2200-139f-11e7-8e8f-72ceb5203081.png)
