### PR TITLE
Fixes agenda page template

### DIFF
--- a/fec/home/templates/home/agenda_page.html
+++ b/fec/home/templates/home/agenda_page.html
@@ -28,7 +28,7 @@
       </header>
    <div class="main__content">
        <div>
-           {% self.imported_html  %}
+           {% include_block self.imported_html  %}
        </div>
 
       <ol class="list--numbered--alt">


### PR DESCRIPTION
The agenda page template is missing a Wagtail tag within one of the template instructions, the `include_block`: http://docs.wagtail.io/en/v1.9/topics/streamfield.html#template-rendering

This fix enables the template to render properly in both the preview and live view modes.