### PR TITLE
Removing setuptools and wheel due to pip warning output

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-setuptools
-wheel
 Django>=1.10,<1.11
 cfenv==0.5.2
 dj-database-url==0.4.2


### PR DESCRIPTION
Turns out that including these two dependencies is something pip warns against - removing them to ensure things work as expected (or break as expected for that matter).