### PR TITLE
Eliminates typo in "actively"

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -41,7 +41,7 @@
     <div class="message message--info">
       <h2 class="message__title">This page is still in progress</h2>
       <div class="message__content">
-        <p class="u-no-margin">We're activey reorganizing our content about candidates and committees. If you can't find what you're looking for, you can try browsing this content in <a href="">its previous form</a>.</p>
+        <p class="u-no-margin">We're actively reorganizing our content about candidates and committees. If you can't find what you're looking for, you can try browsing this content in <a href="">its previous form</a>.</p>
       </div>
     </div>
 


### PR DESCRIPTION
Fixes a small misspelling in the disclaimer. Anyone can review, but this definitely needs to be deployed before the `Help for candidates and committees` section can launch. 


