### PR TITLE
Feature/transition urls

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -193,6 +193,9 @@ FEC_SERVICE_NOW_API = env.get_credential('FEC_SERVICE_NOW_API')
 FEC_SERVICE_NOW_USERNAME = env.get_credential('FEC_SERVICE_NOW_USERNAME')
 FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
 
+FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'http://www.fec.gov')
+FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://www.fec.gov')
+
 FEATURES = {
     'record': bool(env.get_credential('FEC_FEATURE_RECORD', '')),
     'about': bool(env.get_credential('FEC_FEATURE_ABOUT', '')),

--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -19,7 +19,7 @@
     <span class="t-note t-sans search__example">Examples: filings; 2405</span>
     <div class="message message--info">
       <h3>This feature is still in progress</h3>
-      <p>We're actively building the <strong>MUR search</strong> feature. Results don't include most of the cases closed between 1975 and 1998. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="http://www.fec.gov/MUR/">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
+      <p>We're actively building the <strong>MUR search</strong> feature. Results don't include most of the cases closed between 1975 and 1998. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|transition_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
     </div>
   </div>
 </div>

--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -19,7 +19,7 @@
     <span class="t-note t-sans search__example">Examples: filings; 2405</span>
     <div class="message message--info">
       <h3>This feature is still in progress</h3>
-      <p>We're actively building the <strong>MUR search</strong> feature. Results don't include most of the cases closed between 1975 and 1998. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|transition_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
+      <p>We're actively building the <strong>MUR search</strong> feature. Results don't include most of the cases closed between 1975 and 1998. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|classic_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
     </div>
   </div>
 </div>

--- a/fec/home/templates/home/commissioners.html
+++ b/fec/home/templates/home/commissioners.html
@@ -31,7 +31,7 @@
     <div class="option">
       <h2>Ex officio Commissioners</h2>
 
-      <p>From 1975 through 1993, the Secretary of the Senate and the Clerk of the House were designated as nonvoting, ex officio Commissioners. In 1993, an appeals court ruled that the presence of nonvoting Congressionally appointed ex officio members on the Commission violated the Constitution’s separation of powers. The Supreme Court dismissed the Commission’s appeal for lack of jurisdiction (<span class="t-italic"><a href="http://www.fec.gov/law/litigation/513_US_88.pdf">FEC v. NRA Political Victory Fund</a></span>). Subsequent to the appeals court decision, the Commission reconstituted itself as a six-member body.</p>
+      <p>From 1975 through 1993, the Secretary of the Senate and the Clerk of the House were designated as nonvoting, ex officio Commissioners. In 1993, an appeals court ruled that the presence of nonvoting Congressionally appointed ex officio members on the Commission violated the Constitution’s separation of powers. The Supreme Court dismissed the Commission’s appeal for lack of jurisdiction (<span class="t-italic"><a href="{{ settings.FEC_TRANSITION_URL }}/law/litigation/513_US_88.pdf">FEC v. NRA Political Victory Fund</a></span>). Subsequent to the appeals court decision, the Commission reconstituted itself as a six-member body.</p>
 
       <h3 class="u-padding--top">Clerk of the House</h3>
 

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -145,10 +145,10 @@
       <h2 class="heading--section">Citizen information</h2>
       <div class="billboard">
         <div class="billboard__image__container">
-          <a class="u-no-border" href="http://www.fec.gov/pages/brochures/citizens.shtml" target="_blank">
+          <a class="u-no-border" href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">
           <img class="billboard__image" src={% static 'img/thumbnail--citizens-guide-brochure.png' %} alt="Citizens Guide Brochure"></a>
           <div class="document-thumbnail__description">
-            <a href="http://www.fec.gov/pages/brochures/citizens.shtml" target="_blank">Citizens' guide brochure</a>
+            <a href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">Citizens' guide brochure</a>
           </div>
         </div>
         <div class="billboard__content">
@@ -196,7 +196,7 @@
              <ul class="list--border list--extra-spacious">
                <li>
                  <h3>There are different limits to how much contributors can give to <span class="term" data-term="Candidate">candidates </span>, <span class="term" data-term="Party committee">parties</span> and <span class="term" data-term="Political Action Committee (PAC)">political action committees (PACs)</span></h3>
-                  <a class="t-sans" href="http://www.fec.gov/info/contriblimitschart1718.pdf" target="_blank">Find 2017–2018 contribution limits »</a>
+                  <a class="t-sans" href="{{ settings.FEC_TRANSITION_URL }}/info/contriblimitschart1718.pdf" target="_blank">Find 2017–2018 contribution limits »</a>
                </li>
                <li>
                  <h3>Every state has its own procedures for voting day activities and voter registration</h3>
@@ -225,7 +225,7 @@
           <div class="icon-heading icon-heading--mallet-circle">
             <div class="icon-heading__content">
               <h3>The FEC publishes information about ongoing and closed court cases</h3>
-              <a class="t-sans" href="http://www.fec.gov/law/litigation.shtml">Browse campaign finance litigation »</a>
+              <a class="t-sans" href="/legal-resources/court-cases">Browse campaign finance litigation »</a>
             </div>
           </div>
         </div>
@@ -243,7 +243,7 @@
               <h3>The Commission has a variety of methods for responding to possible election law violations</h3>
               <a class="t-sans" href="/legal-resources/enforcement/">Learn more about enforcement »</a><br>
               <br>
-              <a class="t-sans" href="http://www.fec.gov/pages/brochures/complain.shtml#search=complaint">Read about the process for filing a complaint »</a>
+              <a class="t-sans" href="/legal-resources/enforcement/complaints-process/">Read about the process for filing a complaint »</a>
             </div>
           </div>
         </div>

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -109,7 +109,7 @@
             <p>Learn more about active and past cases involving the FEC.</p>
           </div>
           <div class="option">
-            <h2 id="policy"><a href="http://www.fec.gov/law/policy.shtml">Policy statements and other guidance</a></h2>
+            <h2 id="policy"><a href="{{ settings.FEC_TRANSITION_URL }}/law/policy.shtml">Policy statements and other guidance</a></h2>
             <p>Access statements, interpretive rules and other guidance issued by the FEC.</p>
           </div>
         </section>
@@ -119,7 +119,7 @@
     <div class="container">
       <div class="grid grid--4-wide">
         <div class="grid__item">
-          <a href="http://www.fec.gov/pages/brochures/fecfeca.shtml">
+          <a href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/fecfeca.shtml">
             <aside class="card card--horizontal card--secondary">
               <div class="card__image__container">
                 <span class="card__icon i-notebook"><span class="u-visually-hidden">Icon of a notebook</span></span>

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -46,8 +46,8 @@ def web_app_url(path):
     return "{}{}".format(settings.FEC_APP_URL, path)
 
 @register.filter()
-def transition_url(path):
+def classic_url(path):
     """
-    Appends a path to the transition url as defined in the settings
+    Appends a path to the classic FEC.gov url as defined in the settings
     """
-    return "{}{}".format(settings.FEC_TRANSITION_URL, path)
+    return "{}{}".format(settings.FEC_CLASSIC_URL, path)

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -44,3 +44,10 @@ def web_app_url(path):
     This is useful for StaticBlocks, which don't have access to the entire context
     """
     return "{}{}".format(settings.FEC_APP_URL, path)
+
+@register.filter()
+def transition_url(path):
+    """
+    Appends a path to the transition url as defined in the settings
+    """
+    return "{}{}".format(settings.FEC_TRANSITION_URL, path)


### PR DESCRIPTION
This just does a quick find-and-replace of all the hard-coded links to fec.gov in the CMS and introduces config variables that can be set to point to given URLs. This way, when @patphongs has the new transition pages up, we can just set the variable for transition links to go to those. 

Both the `FEC_TRANSITION_URL` and `FEC_CLASSIC_URL` default to `www.fec.gov` but in the future they'll point to `transition.fec.gov` and `classic.fec.gov` respectively.