### PR TITLE
[MERGE WITH GIT FLOW] Add dataType to ajax request

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aria-accordion": "0.1.1",
     "component-sticky": "1.0.0",
     "es6-weak-map": "2.0.1",
-    "fec-style": "7.7.2",
+    "fec-style": "7.7.3",
     "fullcalendar": "2.5.0",
     "glossary-panel": "0.2.1",
     "jquery": "2.2.4",


### PR DESCRIPTION
**MERGE WITH GIT FLOW**

This changeset addresses the jQuery vulnerability we encountered a bit further by ensuring that a dataType parameter is set on our ajax requests.  We cannot do an upgrade to the 3.x series of jQuery just yet, so to help mitigate any potential threat we are ensuring our requests do not accept scripts to be executed.  We will update jQuery to the latest release in the near future after we have had a bit more time to test the changes and address any compatability issues.