### PR TITLE
Conditional check on section button for about page

### DIFF
--- a/fec/home/templates/home/about_landing_page.html
+++ b/fec/home/templates/home/about_landing_page.html
@@ -38,10 +38,12 @@
 
         {{ section.value.intro }}
 
-        {% if section.value.related_page %}
-          <a href="{{ section.value.related_page.url }}" class="button button--cta button--go">{{ section.value.button_text }}</a>
-        {% else %}
-          <span class="button button--cta button--go is-disabled">Coming soon</a>
+        {% if section.value.button_text %}
+          {% if section.value.related_page %}
+            <a href="{{ section.value.related_page.url }}" class="button button--cta button--go">{{ section.value.button_text }}</a>
+          {% else %}
+            <span class="button button--cta button--go is-disabled">{{ section.value.button_text }}</a>
+          {% endif %}
         {% endif %}
       </div>
       {% endfor %}


### PR DESCRIPTION
This just adds a check on the About landing page so that if there's no `button_text` value set, the button won't display:

![image](https://cloud.githubusercontent.com/assets/1696495/24915622/aa4f98a2-1ea5-11e7-8c52-e74caaa0f877.png)

Resolves https://github.com/18F/fec-cms/issues/893