### PR TITLE
Fix/tips in feed

### DIFF
--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -1,9 +1,18 @@
 {% load filters %}
 <ul class="grid grid--4-wide grid--no-margin grid--no-border list--border">
   {% for update in updates %}
-  <li class="grid__item {% if update.homepage_pin == True %}u-no-padding-left u-no-padding-right"{% endif %}">
+  <li class="grid__item {% if update.homepage_pin == True %}u-no-padding-left u-no-padding-right{% endif %}">
     {% if update.homepage_pin == True %}<div class="u-gray-background">{% endif %}
-      <span class="t-sans"><span class="t-bold">{{ update.category|capfirst }}</span>: <a href="{{ update.url }}">{% formatted_title update %}</a></span>
+      <span class="t-sans">
+        <span class="t-bold">
+          {% if update.get_update_type == 'Tips for Treasurers' %}
+            Tips
+          {% else %}
+            {{ update.category|capfirst }}
+          {% endif %}
+        </span>:
+        <a href="{{ update.url }}">{% formatted_title update %}</a>
+      </span>
     {% if update.homepage_pin %}</div>{% endif %}
   </li>
   {% endfor %}

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -6,11 +6,11 @@
       <span class="t-sans">
         <span class="t-bold">
           {% if update.get_update_type == 'Tips for Treasurers' %}
-            Tips
+            Tips:
           {% else %}
-            {{ update.category|capfirst }}
+            {{ update.category|capfirst }}:
           {% endif %}
-        </span>:
+        </span>
         <a href="{{ update.url }}">{% formatted_title update %}</a>
       </span>
     {% if update.homepage_pin %}</div>{% endif %}

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -6,7 +6,7 @@
       <span class="t-sans">
         <span class="t-bold">
           {% if update.get_update_type == 'Tips for Treasurers' %}
-            Tips:
+            Tips for treasurers:
           {% else %}
             {{ update.category|capfirst }}:
           {% endif %}

--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -16,14 +16,8 @@ register = template.Library()
 @register.inclusion_tag('partials/home-page-updates.html')
 def home_page_updates():
     press_releases = PressReleasePage.objects.live().filter(homepage_hide=False).order_by('-date')[:4]
-    if settings.FEATURES['record']:
-        records = RecordPage.objects.live().filter(homepage_hide=False).order_by('-date')[:4]
-    else:
-        records = []
-    if settings.FEATURES['tips']:
-        tips = TipsForTreasurersPage.objects.live().filter().order_by('-date')[:4]
-    else:
-        tips = []
+    records = RecordPage.objects.live().filter(homepage_hide=False).order_by('-date')[:4]
+    tips = TipsForTreasurersPage.objects.live().filter().order_by('-date')[:4]
 
     # combine press release, records and tips queryset
     updates = chain(press_releases, records, tips)


### PR DESCRIPTION
Adds "Tips for treasurers:" before Tips for Treasurers on the home page because they don't have a category:

![image](https://cloud.githubusercontent.com/assets/1696495/25028963/985bedb6-206d-11e7-93a4-543dd547ad76.png)
