### PR TITLE
Correcting youtube link

### DIFF
--- a/fec/fec/templates/partials/site-orientation.html
+++ b/fec/fec/templates/partials/site-orientation.html
@@ -31,7 +31,7 @@
           <li class="tour-candidate-committee-services">
             <a href="/help-candidates-and-committees?tour=true">
               <span class="tour__header__page--number t-bold">3</span>
-              <span class="tour__header__page">Candidate and committee services</span>
+              <span class="tour__header__page">Help for candidates and committees</span>
             </a>
           </li>
           <li class="tour-legal-resources">

--- a/fec/home/templates/partials/candidate_committee_services.html
+++ b/fec/home/templates/partials/candidate_committee_services.html
@@ -118,7 +118,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch a <a href="https://www.youtube.com/watch?v=ZCHSFPUxat8&feature=youtu.be">free video</a> about SSF registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">free video</a> about SSF registration.</p>
                   </div>
                 </aside>
               </div>
@@ -161,7 +161,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch <a href="https://www.youtube.com/watch?v=pEDbBXRr5BY&feature=youtu.be">a free video</a> about PAC registration.</p>
+                    <p>Watch <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">a free video</a> about PAC registration.</p>
                   </div>
                 </aside>
               </div>
@@ -205,7 +205,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch <a href="https://www.youtube.com/watch?v=yRPRsREca_E&feature=youtu.be">a free video</a> about political party registration.</p>
+                    <p>Watch <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">a free video</a> about political party registration.</p>
                   </div>
                 </aside>
               </div>

--- a/fec/home/templates/partials/candidate_committee_services.html
+++ b/fec/home/templates/partials/candidate_committee_services.html
@@ -74,7 +74,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch a <a href="https://www.youtube.com/watch?v=xWY7MyUFVSs">free video</a> about candidate registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">free video</a> about candidate registration.</p>
                   </div>
                 </aside>
               </div>


### PR DESCRIPTION
Corrects the training link on the home page

<img width="245" alt="screen shot 2017-04-14 at 12 19 47 pm" src="https://cloud.githubusercontent.com/assets/11636908/25048842/ae258482-210c-11e7-9238-2c248881563b.png">
