### PR TITLE
new error pages

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -172,8 +172,6 @@ WAGTAIL_SITE_NAME = "fec"
 from fec import constants
 from .env import env
 
-WEBMANAGER_EMAIL = "webmanager@fec.gov"
-CLASSIC_URL = "http://www.fec.gov"
 USAJOBS_API_KEY = env.get_credential('USAJOBS_API_KEY')
 FEC_APP_URL = os.getenv('FEC_APP_URL')
 FEC_API_URL = os.getenv('FEC_API_URL', 'http://localhost:5000')
@@ -187,7 +185,8 @@ ENVIRONMENTS = {
     'prod': 'PRODUCTION',
 }
 FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(os.getenv('FEC_CMS_ENVIRONMENT'), 'LOCAL')
-CONTACT_EMAIL = 'betafeedback@fec.gov';
+CONTACT_EMAIL = 'betafeedback@fec.gov'
+WEBMANAGER_EMAIL = "webmanager@fec.gov"
 CONSTANTS = constants
 
 # Config for the ServiceNow API for contacting RAD

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -172,6 +172,8 @@ WAGTAIL_SITE_NAME = "fec"
 from fec import constants
 from .env import env
 
+WEBMANAGER_EMAIL = "webmanager@fec.gov"
+CLASSIC_URL = "http://www.fec.gov"
 USAJOBS_API_KEY = env.get_credential('USAJOBS_API_KEY')
 FEC_APP_URL = os.getenv('FEC_APP_URL')
 FEC_API_URL = os.getenv('FEC_API_URL', 'http://localhost:5000')

--- a/fec/fec/templates/404.html
+++ b/fec/fec/templates/404.html
@@ -5,16 +5,13 @@
 <section class="content--blank">
   <div class="container">
     <div class="message message--alert message--big">
-      <h1 class="message__title">Oops!</h1>
-      <p>We couldn't find what you're looking for. Please double-check the URL and try again.</p>
-      <div class="message--alert__bottom">
-        <p>Still can't find what you're looking for?</p>
-        <ul class="list--buttons">
-          <li><a class="button button--cta" href="/">Return home</a></li>
-          <li><a class="button button--alt" href="https://github.com/18f/fec/issues">File an issue</a></li>
-          <li><a class="button button--alt" href="mailto:{{ settings.CONTACT_EMAIL }}">Email our team</a></li>
-        </ul>
-      </div>
+      <h1 class="message__title">Page not found</h1>
+      <p>Sorry, we couldn't find the page you're looking for.</p>
+      <p>FEC.gov is in the middle of a redesign. We've worked hard to keep our URLs up to date, but please let us know if you think something is missing or broken. We're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
+      
+        <p><a class="button button--cta" href="/">Return home</a></p>
+        <p>or try searching an archive of the <a href="{{settings.CLASSIC_URL}}">old FEC.gov design.</a></p>
+     
     </div>
   </div>
 </section>

--- a/fec/fec/templates/404.html
+++ b/fec/fec/templates/404.html
@@ -10,7 +10,7 @@
       <p>FEC.gov is in the middle of a redesign. We've worked hard to keep our URLs up to date, but please let us know if you think something is missing or broken. We're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
       
         <p><a class="button button--cta" href="/">Return home</a></p>
-        <p>or try searching an archive of the <a href="{{settings.CLASSIC_URL}}">old FEC.gov design.</a></p>
+        <p>or try searching an archive of the <a href="{{settings.FEC_CLASSIC_URL}}">old FEC.gov design.</a></p>
      
     </div>
   </div>

--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -11,7 +11,7 @@
       <p>If you'd like to contact our team, we're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
       
         <p><a class="button button--cta" href="/">Return home</a></p>
-        <p>or try searching an archive of the <a href="{{settings.CLASSIC_URL}}">old FEC.gov design.</a></p>
+        <p>or try searching an archive of the <a href="{{settings.FEC_CLASSIC_URL}}">old FEC.gov design.</a></p>
       </div>
     </div>
   </div>

--- a/fec/fec/templates/500.html
+++ b/fec/fec/templates/500.html
@@ -6,15 +6,12 @@
 <section class="content--blank">
   <div class="container">
     <div class="message message--alert message--big">
-      <h1 class="message__title">Oops: We messed up</h1>
-      <p>We had trouble processing your request. Please try reloading the page.</p>
-      <div class="message--alert__bottom">
-        <p>Still not working?</p>
-        <ul class="list--buttons">
-          <li><a class="button button--cta" href="/">Return home</a></li>
-          <li><a class="button button--alt" href="https://github.com/18f/fec/issues">File an issue</a></li>
-          <li><a class="button button--alt" href="mailto:{{ settings.CONTACT_EMAIL }}">Email our team</a></li>
-        </ul>
+      <h1 class="message__title">Server error</h1>
+      <p>Sorry, this page failed to load. This happened because of an internal error, and our web team has been notified. Please try again, and thanks for your patience.</p>
+      <p>If you'd like to contact our team, we're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
+      
+        <p><a class="button button--cta" href="/">Return home</a></p>
+        <p>or try searching an archive of the <a href="{{settings.CLASSIC_URL}}">old FEC.gov design.</a></p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
New 404 and 500 pages based on https://github.com/18F/fec-cms/issues/966
It was suggested in the conversation to change "previous FEC.gov" to "old FEC.gov design." If this needs to be changed back, let me know.