### PR TITLE
Deletes "free" from video 

### DIFF
--- a/fec/home/templates/partials/candidate_committee_services.html
+++ b/fec/home/templates/partials/candidate_committee_services.html
@@ -74,7 +74,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">free video</a> about candidate registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">video about candidate registration</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -118,7 +118,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">free video</a> about SSF registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">video about SSF registration</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -161,7 +161,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">a free video</a> about PAC registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">video about PAC registration</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -205,7 +205,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--training-circle u-no-margin">Featured training</h5>
                   <div class="card__content--full-width">
-                    <p>Watch <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">a free video</a> about political party registration.</p>
+                    <p>Watch a <a href="https://www.youtube.com/watch?v=AcJ52LuEhEw">video about political party registration</a>.</p>
                   </div>
                 </aside>
               </div>


### PR DESCRIPTION
Eliminates "free," from video links, so that we don't accidentally imply that some videos are paid.

Also updates which words we wrap in our `<a href>` to make the links more clear for screenreaders.

🔍  🎩  h/t @fechoosier for the copyedit find. 

Content only; anyone can review. 