### PR TITLE
Changing markup so legal citations print

### DIFF
--- a/fec/fec/templates/long_page.html
+++ b/fec/fec/templates/long_page.html
@@ -20,13 +20,13 @@
         {% block sections %}
         {% endblock %}
         {% if self.citations %}
-        <aside id="legal-citations" class="sidebar sidebar--primary">
+        <div id="legal-citations" class="sidebar--primary t-sans">
           <h4 class="sidebar__title">Legal citations</h4>
           <div class="sidebar__content">
             {% block citations %}
             {% endblock %}
           </div>
-        </aside>
+        </div>
         {% endif %}
       </div>
     </div>

--- a/fec/home/templates/home/custom_page.html
+++ b/fec/home/templates/home/custom_page.html
@@ -58,7 +58,7 @@
       </div>
     {% endif %}
     {% if self.citations %}
-      <aside id="legal-citations" class="sidebar sidebar--secondary">
+      <div id="legal-citations" class="sidebar--secondary t-sans">
         <h4 class="sidebar__title">Legal citations</h4>
         <div class="sidebar__content">
           <div class="grid grid--2-wide">
@@ -72,7 +72,7 @@
           {% endfor %}
           </div>
         </div>
-      </aside>
+      </div>
     {% endif %}
   </div>
 </article>


### PR DESCRIPTION
Fixes a small issue where legal citations didn't print. That's because both `<asides>` and `.sidebar` are hidden when printing. So I just removed those from the citations boxes.

Resolves https://github.com/18F/fec-cms/issues/999