### PR TITLE
Fix session timeout issue with cloud.gov

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -72,6 +72,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ beautifulsoup4==4.5.1
 django-storages==1.5.2
 boto3==1.4.4
 
-cg-django-uaa==0.0.1
+cg-django-uaa==1.0.1


### PR DESCRIPTION
This changeset addresses an issue we have been having with the cloud.gov session/token timeout being reduced to 10 - 15 minutes.  The underlying UAA client we are using, cg-django-uaa, required an update to support refreshing tokens so that sessions remain valid while a user logs in.

A huge thank you to @toolness for providing the fix in cg-django-uaa and helping us address this issue!