### PR TITLE
Adding link to transition IG page

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -174,6 +174,9 @@
               <li>
                 <a href="https://www.usa.gov/">USA.gov</a>
               </li>
+              <li>
+                <a href="{{ settings.FEC_TRANSITION_URL }}/fecig/fecig.shtml">Inspector General</a>
+              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
Adds the IG link:

![image](https://cloud.githubusercontent.com/assets/1696495/25407862/d660fffa-29c0-11e7-9cca-b36d6d4e3f99.png)
