### PR TITLE
Removing links to citizens info

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -110,9 +110,11 @@
       <h2 class="heading--section">Introduction to campaign finance and elections</h2>
       <div class="billboard">
         <div class="billboard__image__container">
-          <!-- <span class="t-block u-padding--bottom">
-            <a class="t-sans" href="/introduction-campaign-finance/getting-involved-federal-campaigns/">Learn about getting involved<br>in the election process »</a>
-          </span> -->
+          {% comment %}
+            <span class="t-block u-padding--bottom">
+              <a class="t-sans" href="/introduction-campaign-finance/getting-involved-federal-campaigns/">Learn about getting involved<br>in the election process »</a>
+            </span>
+          {% endcomment %}
           <a class="u-no-border" href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">
           <img class="billboard__image" src={% static 'img/thumbnail--citizens-guide-brochure.png' %} alt="Citizens Guide Brochure"></a>
           <div class="document-thumbnail__description">
@@ -160,9 +162,11 @@
                    </fieldset>
                  </div>
 
-                 <!-- <div class="u-float-left u-padding--top">
-                   <a class="t-sans" href="/introduction-campaign-finance/campaign-finance-and-fec-research/">Learn how to start researching financial data »</a>
-                 </div> -->
+                 {% comment %}
+                   <div class="u-float-left u-padding--top">
+                     <a class="t-sans" href="/introduction-campaign-finance/campaign-finance-and-fec-research/">Learn how to start researching financial data »</a>
+                   </div>
+                 {% endcomment %}
                </div>
              </form>
              <ul class="list--border list--extra-spacious">
@@ -173,7 +177,9 @@
                <li>
                  <h3>Every state has its own procedures for voting day activities and voter registration</h3>
                  <a class="t-sans" href="https://www.vote.gov">Find voting guidance by state » </a>
-                 <!-- <a class="t-sans" href="/introduction-campaign-finance/election-and-voting-information/">Information about voting and elections »</a> -->
+                 {% comment %}
+                   <a class="t-sans" href="/introduction-campaign-finance/election-and-voting-information/">Information about voting and elections »</a>
+                 {% endcomment %}
                </li>
              </ul>
           </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -110,9 +110,9 @@
       <h2 class="heading--section">Introduction to campaign finance and elections</h2>
       <div class="billboard">
         <div class="billboard__image__container">
-          <span class="t-block u-padding--bottom">
+          <!-- <span class="t-block u-padding--bottom">
             <a class="t-sans" href="/introduction-campaign-finance/getting-involved-federal-campaigns/">Learn about getting involved<br>in the election process »</a>
-          </span>
+          </span> -->
           <a class="u-no-border" href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">
           <img class="billboard__image" src={% static 'img/thumbnail--citizens-guide-brochure.png' %} alt="Citizens Guide Brochure"></a>
           <div class="document-thumbnail__description">
@@ -160,9 +160,9 @@
                    </fieldset>
                  </div>
 
-                 <div class="u-float-left u-padding--top">
+                 <!-- <div class="u-float-left u-padding--top">
                    <a class="t-sans" href="/introduction-campaign-finance/campaign-finance-and-fec-research/">Learn how to start researching financial data »</a>
-                   </div>
+                 </div> -->
                </div>
              </form>
              <ul class="list--border list--extra-spacious">
@@ -172,7 +172,8 @@
                </li>
                <li>
                  <h3>Every state has its own procedures for voting day activities and voter registration</h3>
-                 <a class="t-sans" href="/introduction-campaign-finance/election-and-voting-information/">Information about voting and elections »</a>
+                 <a class="t-sans" href="https://www.vote.gov">Find voting guidance by state » </a>
+                 <!-- <a class="t-sans" href="/introduction-campaign-finance/election-and-voting-information/">Information about voting and elections »</a> -->
                </li>
              </ul>
           </div>


### PR DESCRIPTION
Small thing I noticed: since we're not launching the public info pages, we need to remove the links on the home page.