### PR TITLE
Add missing transition URL env var

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -9,3 +9,4 @@ env:
   DJANGO_SETTINGS_MODULE: fec.settings.production
   NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini
   NEW_RELIC_LOG: stdout
+  FEC_TRANSITION_URL: https://transition.fec.gov


### PR DESCRIPTION
This changeset adds a missing env var to our base manifest to ensure that the transition site URL does not get lost on subsequent deploys.