### PR TITLE
Use env.get_credential

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -179,19 +179,19 @@ from fec import constants
 from .env import env
 
 USAJOBS_API_KEY = env.get_credential('USAJOBS_API_KEY')
-FEC_APP_URL = os.getenv('FEC_APP_URL')
-FEC_API_URL = os.getenv('FEC_API_URL', 'http://localhost:5000')
-FEC_API_KEY = os.getenv('FEC_WEB_API_KEY')
-FEC_API_VERSION = os.getenv('FEC_API_VERSION', 'v1')
+FEC_APP_URL = env.get_credential('FEC_APP_URL')
+FEC_API_URL = env.get_credential('FEC_API_URL', 'http://localhost:5000')
+FEC_API_KEY = env.get_credential('FEC_WEB_API_KEY')
+FEC_API_VERSION = env.get_credential('FEC_API_VERSION', 'v1')
 FEC_API_KEY_PUBLIC = env.get_credential('FEC_WEB_API_KEY_PUBLIC', '')
-FEC_CMS_ROBOTS = os.getenv('FEC_CMS_ROBOTS')
+FEC_CMS_ROBOTS = env.get_credential('FEC_CMS_ROBOTS')
 ENVIRONMENTS = {
     'local': 'LOCAL',
     'dev': 'DEVELOPMENT',
     'stage': 'STAGING',
     'prod': 'PRODUCTION',
 }
-FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(os.getenv('FEC_CMS_ENVIRONMENT'), 'LOCAL')
+FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT'), 'LOCAL')
 CONTACT_EMAIL = 'betafeedback@fec.gov'
 WEBMANAGER_EMAIL = "webmanager@fec.gov"
 CONSTANTS = constants


### PR DESCRIPTION
Using `env.get_credential` instead of `os.getenv` in the hopes that it fixes the broken API calls.