### PR TITLE
Update remaining env var references

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -202,6 +202,7 @@ FEC_SERVICE_NOW_API = env.get_credential('FEC_SERVICE_NOW_API')
 FEC_SERVICE_NOW_USERNAME = env.get_credential('FEC_SERVICE_NOW_USERNAME')
 FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
 FEC_DIGITALGOV_KEY = env.get_credential('FEC_DIGITALGOV_KEY')
+FEC_DIGITALGOV_DRAWER_KEY - env.get_credential('DIGITALGOV_DRAWER_KEY')
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'http://www.fec.gov')
 FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://www.fec.gov')

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -202,7 +202,7 @@ FEC_SERVICE_NOW_API = env.get_credential('FEC_SERVICE_NOW_API')
 FEC_SERVICE_NOW_USERNAME = env.get_credential('FEC_SERVICE_NOW_USERNAME')
 FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
 FEC_DIGITALGOV_KEY = env.get_credential('FEC_DIGITALGOV_KEY')
-FEC_DIGITALGOV_DRAWER_KEY = env.get_credential('DIGITALGOV_DRAWER_KEY')
+FEC_DIGITALGOV_DRAWER_KEY = env.get_credential('DIGITALGOV_DRAWER_KEY', '')
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'http://www.fec.gov')
 FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://www.fec.gov')

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -202,7 +202,7 @@ FEC_SERVICE_NOW_API = env.get_credential('FEC_SERVICE_NOW_API')
 FEC_SERVICE_NOW_USERNAME = env.get_credential('FEC_SERVICE_NOW_USERNAME')
 FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
 FEC_DIGITALGOV_KEY = env.get_credential('FEC_DIGITALGOV_KEY')
-FEC_DIGITALGOV_DRAWER_KEY - env.get_credential('DIGITALGOV_DRAWER_KEY')
+FEC_DIGITALGOV_DRAWER_KEY = env.get_credential('DIGITALGOV_DRAWER_KEY')
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'http://www.fec.gov')
 FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://www.fec.gov')

--- a/fec/fec/wsgi.py
+++ b/fec/fec/wsgi.py
@@ -17,10 +17,7 @@ from whitenoise.django import DjangoWhiteNoise
 from fec.settings.env import env
 
 settings = newrelic.agent.global_settings()
-settings.license_key = (
-    os.getenv('NEW_RELIC_LICENSE_KEY') or
-    env.get_credential('NEW_RELIC_LICENSE_KEY')
-)
+settings.license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
 newrelic.agent.initialize()
 
 application = get_wsgi_application()

--- a/fec/search/management/commands/index_pages.py
+++ b/fec/search/management/commands/index_pages.py
@@ -3,13 +3,14 @@ import os
 import requests
 from bs4 import BeautifulSoup
 
+from django.conf import settings
 from django.core.management import BaseCommand
 
 from home.models import Page
 
 
 DIGITALGOV_DRAWER = 'main'
-DIGITALGOV_DRAWER_KEY = os.getenv('DIGITALGOV_DRAWER_KEY')
+DIGITALGOV_DRAWER_KEY = settings.FEC_DIGITALGOV_DRAWER_KEY
 
 class Command(BaseCommand):
     help = 'Scrapes pages'


### PR DESCRIPTION
This changeset fixes a few more env var references and makes use of the `env.get_credential()` method to ensure that an env var is found.  To recap, that method checks the credential service in Cloud Foundry first for an env var, and if it cannot find it then it falls back to checking the host environment the app is running in.  This method works in both the deployed apps and locally for that reason.