### PR TITLE
Adding mid-year and year-end filters

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -8,8 +8,8 @@ deadline_types = OrderedDict([
     ('report-M', 'Monthly'),
     ('report-Q', 'Quarterly'),
     ('report-E', 'Pre- and post-election'),
-    ('report-MY', 'Mid-year'),
-    ('report-YE', 'Year-end')
+    ('report-MY', 'Mid-Year'),
+    ('report-YE', 'Year-End')
 ])
 
 reporting_periods = OrderedDict([

--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -7,7 +7,9 @@ election_types = OrderedDict([
 deadline_types = OrderedDict([
     ('report-M', 'Monthly'),
     ('report-Q', 'Quarterly'),
-    ('report-E', 'Pre- and post-election')
+    ('report-E', 'Pre- and post-election'),
+    ('report-MY', 'Mid-year'),
+    ('report-YE', 'Year-end')
 ])
 
 reporting_periods = OrderedDict([

--- a/fec/home/templates/partials/candidate_committee_services.html
+++ b/fec/home/templates/partials/candidate_committee_services.html
@@ -1,3 +1,4 @@
+{% with '/calendar/?category=report-E&category=report-M&category=report-Q&category=report-MY&category=report-YE' as calendar_url %}
   <section id="homepage-help-candidate-and-committees" class="slab tab-interface">
     <div class="container">
       <h1 class="u-padding--bottom"><a href="/help-candidates-and-committees/">Help for candidates and committees</a></h1>
@@ -66,7 +67,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--calendar-circle u-no-margin">Upcoming deadlines</h5>
                   <div class="card__content--full-width">
-                    <p>View upcoming <a href="/calendar/?category=report-E&category=report-M&category=report-Q">dates and deadlines</a>.</p>
+                    <p>View upcoming <a href="{{ calendar_url }}">dates and deadlines</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -110,7 +111,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--calendar-circle u-no-margin">Upcoming deadlines</h5>
                   <div class="card__content--full-width">
-                    <p>View upcoming <a href="/calendar/?category=report-E&category=report-M&category=report-Q">dates and deadlines</a>.</p>
+                    <p>View upcoming <a href="{{ calendar_url }}">dates and deadlines</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -153,7 +154,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--calendar-circle u-no-margin">Upcoming deadlines</h5>
                   <div class="card__content--full-width">
-                    <p>View upcoming <a href="/calendar/?category=report-E&category=report-M&category=report-Q">dates and deadlines</a>.</p>
+                    <p>View upcoming <a href="{{ calendar_url }}">dates and deadlines</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -197,7 +198,7 @@
                 <aside class="card card--horizontal card--secondary">
                   <h5 class="icon-heading--calendar-circle u-no-margin">Upcoming deadlines</h5>
                   <div class="card__content--full-width">
-                    <p>View upcoming <a href="/calendar/?category=report-E&category=report-M&category=report-Q">dates and deadlines</a>.</p>
+                    <p>View upcoming <a href="{{ calendar_url }}">dates and deadlines</a>.</p>
                   </div>
                 </aside>
               </div>
@@ -224,3 +225,4 @@
       </div>
     </div>
   </section>
+{% endwith %}


### PR DESCRIPTION
It turns out the calendar data was correctly coded all along, we just weren't exposing the filters on the front-end. 

This adds them here:
![image](https://cloud.githubusercontent.com/assets/1696495/25877950/fa9557ec-34db-11e7-8b88-d57879b0976c.png)

And also adds them in the URLs from the home page.

cc @llienfec @AmyKort @anthonygarvan 
