### PR TITLE
Feature/social images

### DIFF
--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -16,7 +16,7 @@
 ================================================== -->
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ self.title }} - betaFEC">
-<meta name="twitter:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}}{{ generic_description }}{% endif %}">
+<meta name="twitter:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ generic_description }}{% endif %}">
 <meta name="twitter:image" content="{{ self.content_section | get_social_image }}">
 
 <!-- Facebook
@@ -25,7 +25,7 @@
 <meta property="og:url" content="https://beta.fec.gov" />
 <meta property="og:title" content="{{ self.title }} - betaFEC" />
 <meta property="og:site_name" content="betaFEC" />
-<meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}}{{ generic_description }}{% endif %}" />
+<meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}{{ generic_description }}{% endif %}" />
 <meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ self.content_section | get_social_image }}" />
 
 <!-- Google

--- a/fec/fec/templates/partials/meta-tags.html
+++ b/fec/fec/templates/partials/meta-tags.html
@@ -1,5 +1,6 @@
 {% with "Explore federal campaign finance data with betaFEC, a new site where users can see how much money is raised and spent in federal elections. An official U.S. Government site, betaFEC is a Federal Election Commission project, designed in partnership with 18F." as generic_description %}
 {% load static %}
+{% load filters %}
 
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -16,7 +17,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="{{ self.title }} - betaFEC">
 <meta name="twitter:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}}{{ generic_description }}{% endif %}">
-<meta name="twitter:image" content="{% static "img/beta-fec-tw.png" %}">
+<meta name="twitter:image" content="{{ self.content_section | get_social_image }}">
 
 <!-- Facebook
 ================================================== -->
@@ -25,7 +26,7 @@
 <meta property="og:title" content="{{ self.title }} - betaFEC" />
 <meta property="og:site_name" content="betaFEC" />
 <meta property="og:description" content="{% if self.search_description %}{{ self.search_description }}{% else %}}{{ generic_description }}{% endif %}" />
-<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{% static "img/beta-fec-fb.png" %}" />
+<meta property="og:image" content="{{ request.scheme }}://{{ request.get_host }}{{ self.content_section | get_social_image }}" />
 
 <!-- Google
 ================================================== -->
@@ -38,24 +39,15 @@
 
 <!-- Favicons
 ================================================== -->
-<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{% static "img/favicon/apple-touch-icon-57x57.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{% static "img/favicon/apple-touch-icon-114x114.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{% static "img/favicon/apple-touch-icon-72x72.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{% static "img/favicon/apple-touch-icon-144x144.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="60x60" href="{% static "img/favicon/apple-touch-icon-60x60.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="120x120" href="{% static "img/favicon/apple-touch-icon-120x120.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="76x76" href="{% static "img/favicon/apple-touch-icon-76x76.png" %}" />
-<link rel="apple-touch-icon-precomposed" sizes="152x152" href="{% static "img/favicon/apple-touch-icon-152x152.png" %}" />
-<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-196x196.png" %}" sizes="196x196" />
-<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-96x96.png" %}" sizes="96x96" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'57x57' }}" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'72x72' }}" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'114x114' }}" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'120x120' }}" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'144x144' }}" />
+<link rel="apple-touch-icon-precomposed" sizes="57x57" href="{{ self.content_section|get_touch_icon:'152x152' }}" />
 <link rel="icon" type="image/png" href="{% static "img/favicon/favicon-32x32.png" %}" sizes="32x32" />
 <link rel="icon" type="image/png" href="{% static "img/favicon/favicon-16x16.png" %}" sizes="16x16" />
-<link rel="icon" type="image/png" href="{% static "img/favicon/favicon-128.png" %}" sizes="128x128" />
 <meta name="application-name" content="&nbsp;"/>
 <meta name="msapplication-TileColor" content="#FFFFFF" />
-<meta name="msapplication-TileImage" content="mstile-144x144.png" />
-<meta name="msapplication-square70x70logo" content="mstile-70x70.png" />
-<meta name="msapplication-square150x150logo" content="mstile-150x150.png" />
-<meta name="msapplication-wide310x150logo" content="mstile-310x150.png" />
-<meta name="msapplication-square310x310logo" content="mstile-310x310.png" />
+<meta name="msapplication-TileImage" content="{% static "img/favicon/general/mstile-144x144.png" %}" />
 {% endwith %}

--- a/fec/fec/templates/partials/navigation.html
+++ b/fec/fec/templates/partials/navigation.html
@@ -13,12 +13,12 @@
         </a>
       </li>
       <li class="site-nav__item site-nav__item--secondary" data-submenu="help">
-        <a href="{{ cms_url }}/help-candidates-committees/" tabindex="0" class="site-nav__link {% if parent == 'help' %}is-parent{% endif %}">
+        <a href="{{ cms_url }}/help-candidates-committees/" tabindex="0" class="site-nav__link {% if self.content_section == 'help' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Help for candidates and committees</span>
         </a>
       </li>
       <li class="site-nav__item" data-submenu="legal">
-        <a href="{{ cms_url }}/legal-resources" tabindex="0" class="site-nav__link {% if parent == 'legal' %}is-parent{% endif %}">
+        <a href="{{ cms_url }}/legal-resources" tabindex="0" class="site-nav__link {% if self.content_section == 'legal' %}is-parent{% endif %}">
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -88,7 +88,7 @@ class ContentPage(Page):
     # Default content section for determining the active nav
     @property
     def content_section(self):
-        return 'help'
+        return ''
 '''
 class Person(User):
     objects = User()
@@ -760,7 +760,7 @@ class LegalResourcesLandingPage(ContentPage, UniqueModel):
 
     @property
     def content_section(self):
-        return 'legal-resources'
+        return 'legal'
 
 
 class ServicesLandingPage(ContentPage, UniqueModel):
@@ -789,7 +789,7 @@ class ServicesLandingPage(ContentPage, UniqueModel):
 
     @property
     def content_section(self):
-        return 'candidate-and-committee-services'
+        return 'help'
 
     @property
     def hero_class(self):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -54,6 +54,25 @@ stream_factory = functools.partial(
     ],
 )
 
+def get_content_section(page):
+    """
+    Find the top-level parent in order to highlight
+    the main nav item and set social images.
+    Takes a Page object and returns a string of either 'legal', 'help', or ''
+    """
+    slugs = {
+        'help-candidates-and-committees': 'help',
+        'legal-resources': 'legal'
+    }
+    ancestors = page.get_ancestors()
+    content_sections = [
+        slugs.get(ancestor.slug) for ancestor in ancestors
+        if slugs.get(ancestor.slug) != None
+    ]
+    if len(content_sections):
+        return content_sections[0]
+    else:
+        return ''
 
 class UniqueModel(models.Model):
     """Abstract base class for unique pages."""
@@ -166,10 +185,6 @@ class HomePage(ContentPage, UniqueModel):
     @property
     def content_section(self):
         return ''
-
-
-class LandingPage(ContentPage):
-    template = 'home/registration-and-reporting/landing_page.html'
 
 
 class Author(models.Model):
@@ -503,6 +518,10 @@ class CustomPage(Page):
         )
     ]
 
+    @property
+    def content_section(self):
+        return get_content_section(self)
+
 
 class PressLandingPage(Page):
     hero = stream_factory(null=True, blank=True)
@@ -703,6 +722,9 @@ class CollectionPage(Page):
         StreamFieldPanel('sections'),
     ]
 
+    @property
+    def content_section(self):
+        return get_content_section(self)
 
 class ResourcePage(Page):
     # Class for pages that include a side nav, multiple sections and citations
@@ -752,6 +774,10 @@ class ResourcePage(Page):
     @property
     def display_date(self):
         return self.date.strftime('%B %Y')
+
+    @property
+    def content_section(self):
+        return get_content_section(self)
 
 
 class LegalResourcesLandingPage(ContentPage, UniqueModel):
@@ -864,4 +890,3 @@ class MeetingPage(Page):
     @property
     def get_update_type(self):
         return constants.update_types['commission-meeting']
-

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -5,6 +5,7 @@ from django import template
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.html import format_html
+from django.contrib.staticfiles.templatetags.staticfiles import static
 from wagtail.wagtailcore.models import Page
 
 register = template.Library()
@@ -87,3 +88,25 @@ def splitlines(value):
     return value.splitlines()
 
 
+@register.filter(name='get_social_image')
+def get_social_image(content_section):
+    """
+    Returns a path to a social iamge for the given content section
+    """
+    if content_section in ['legal', 'help']:
+        return static('img/social/{}.png'.format(content_section))
+    else:
+        return static('img/social/general.png')
+
+
+@register.filter(name='get_touch_icon')
+def get_touch_icon(content_section, dimension):
+    """
+    Returns a path to a touch icon for the given dimension and content_section
+    """
+    print('====')
+    print(content_section)
+    if content_section in ['legal', 'help']:
+        return static('img/favicon/{}/apple-touch-icon-{}.png'.format(content_section, dimension))
+    else:
+        return static('img/favicon/general/apple-touch-icon-{}.png'.format(dimension))

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -104,8 +104,6 @@ def get_touch_icon(content_section, dimension):
     """
     Returns a path to a touch icon for the given dimension and content_section
     """
-    print('====')
-    print(content_section)
     if content_section in ['legal', 'help']:
         return static('img/favicon/{}/apple-touch-icon-{}.png'.format(content_section, dimension))
     else:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "aria-accordion": "1.0.0",
     "component-sticky": "1.0.0",
     "es6-weak-map": "2.0.1",
-    "fec-style": "11.0.0",
+    "fec-style": "11.1.0",
     "fullcalendar": "3.3.1",
     "glossary-panel": "1.0.0",
     "jquery": "3.2.1",


### PR DESCRIPTION
Adds custom social images for the different sections of the site, with fallback to a generic one. 

To do this, I had to:

- Make a function for `CustomPage`, `ResourcePage` and `CollectionPage` instances to figure out which section they're in, since they can be used in multiple places.
- Make template filters for generating static paths based on the parent section

It works, but let me know if there's a better way to do this.

Requires https://github.com/18F/fec-style/pull/699