### PR TITLE
Replacing citizens' brochure with video

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -109,7 +109,7 @@
               <a class="t-sans" href="/introduction-campaign-finance/getting-involved-federal-campaigns/">Learn about getting involved<br>in the election process »</a>
             </span>
           {% endcomment %}
-          <a class="u-no-border" href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">
+          <a class="u-no-border" href="https://youtu.be/yIH_kBQdmdQ" target="_blank">
           <img class="billboard__image" src={% static 'img/thumbnail--video.png' %} alt="Video icon"></a>
           <div class="document-thumbnail__description">
             <a href="https://youtu.be/yIH_kBQdmdQ" target="_blank">A Citizen's Guide to Supporting Candidates</a>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -110,9 +110,9 @@
             </span>
           {% endcomment %}
           <a class="u-no-border" href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">
-          <img class="billboard__image" src={% static 'img/thumbnail--citizens-guide-brochure.png' %} alt="Citizens Guide Brochure"></a>
+          <img class="billboard__image" src={% static 'img/thumbnail--video.png' %} alt="Video icon"></a>
           <div class="document-thumbnail__description">
-            <a href="{{ settings.FEC_TRANSITION_URL }}/pages/brochures/citizens.shtml" target="_blank">Citizens' guide brochure</a>
+            <a href="https://youtu.be/yIH_kBQdmdQ" target="_blank">A Citizen's Guide to Supporting Candidates</a>
           </div>
         </div>
         <div class="billboard__content">


### PR DESCRIPTION
Dependent on image in https://github.com/18F/fec-style/pull/702

Replaces the outdated brochure with the brand new video.

@noahmanger, could you please run this locally to check and post a screenshot?
I ran into errors getting my local env up and running but didn't want to block the progress of a quick item. 