### PR TITLE
Feature/calendar fixes

### DIFF
--- a/fec/fec/static/hbs/calendar/events.hbs
+++ b/fec/fec/static/hbs/calendar/events.hbs
@@ -12,8 +12,9 @@
             <span class="t-block">{{datetime start format="fullDayOfWeek"}}</span>
           </div>
           <div class="cal-list__time">
-            {{#if end}}
-              {{datetime start format="time"}}&ndash;{{datetime end format="time"}}
+            {{#if hasStartTime}}
+              {{datetime start format="time"}}
+              {{#if end}}&ndash;{{datetime end format="time"}}{{/if}}
             {{else}}
               All day
             {{/if}}

--- a/fec/fec/static/js/calendar-helpers.js
+++ b/fec/fec/static/js/calendar-helpers.js
@@ -43,6 +43,14 @@ function className(event) {
   }
 }
 
+function checkStartTime(event) {
+  if (event.start_date) {
+    return moment(event.start_date).hour() ? true : false;
+  } else {
+    return false;
+  }
+}
+
 function mapCategoryTitle(category) {
   if (category.match(/^report-M/) !== null) {
     return 'Monthly deadline';
@@ -76,6 +84,7 @@ function mapCategoryDescription(category) {
 
 module.exports = {
   getGoogleUrl: getGoogleUrl,
+  checkStartTime: checkStartTime,
   getUrl: getUrl,
   className: className,
   mapCategoryTitle: mapCategoryTitle,

--- a/fec/fec/static/js/calendar-list-view.js
+++ b/fec/fec/static/js/calendar-list-view.js
@@ -58,8 +58,15 @@ var chronologicalGroups = function(events, start, end) {
     .filter(function(event) {
       return start <= event.start && event.start < end;
     })
+    .map(function(value) {
+      // Group the events by the formatted value of their start dates,
+      // otherwise events with a time on their date will be grouped separately
+      // from those that just have a date
+      value.groupByValue = value.start.format('MMMM D, YYYY');
+      return value;
+    })
     .sortBy('start')
-    .groupBy('start')
+    .groupBy('groupByValue')
     .map(function(values, key) {
       return {
         title: moment.utc(new Date(key)).format('MMMM D, YYYY'),

--- a/fec/fec/static/js/calendar.js
+++ b/fec/fec/static/js/calendar.js
@@ -168,6 +168,7 @@ Calendar.prototype.success = function(response) {
       summary: event.summary || 'Event summary',
       state: event.state ? event.state.join(', ') : null,
       start: event.start_date ? moment(event.start_date) : null,
+      hasStartTime: calendarHelpers.checkStartTime(event),
       end: event.end_date ? moment(event.end_date) : null,
       className: calendarHelpers.className(event),
       tooltipContent: calendarHelpers.mapCategoryDescription(event.category),

--- a/fec/home/templates/home/legal/legal_resources_landing.html
+++ b/fec/home/templates/home/legal/legal_resources_landing.html
@@ -101,7 +101,7 @@
             <p>As part of its role administering campaign finance law,
               the Commission issues regulations,
               which are published every year in Title 11 of the Code of Federal Regulations (CFR).
-              This archive contains a full-text version of 11 CFR, as published January 1, 2016.
+              This archive contains a full-text version of 11 CFR, as published January 1, 2017.
             </p>
             <a class="button--cta button--go" href="/legal-resources/regulations">Explore regulations</a>
           </div>


### PR DESCRIPTION
This makes two fixes to the calendar display. 

1. As @fechoosier noted in https://github.com/18F/openFEC-web-app/issues/2046, sometimes events on the same day end up grouped in duplicate days. That's because sometimes events have a time attached to their start date and others don't, so they were grouped separately. This adds a new grouping property that ignores time.

2. Previously, we would only show the specific time of an event if there was an end time present, but sometimes events have a start time but no end time. This adds a check to see if there's a time present on the start property and displays it.

![image](https://cloud.githubusercontent.com/assets/1696495/26180388/149436c0-3b1e-11e7-8feb-aa714724faf7.png)


