### PR TITLE
Meeting feed fix

### DIFF
--- a/fec/fec/static/js/calendar-helpers.js
+++ b/fec/fec/static/js/calendar-helpers.js
@@ -23,7 +23,7 @@ function getGoogleUrl(event) {
 }
 
 function getUrl(path, params) {
-  return URI(window.API_LOCATION)
+  var url = URI(window.API_LOCATION)
     .path(Array.prototype.concat(window.API_VERSION, path || [], '').join('/'))
     .addQuery({
       api_key: window.API_KEY,
@@ -31,6 +31,9 @@ function getUrl(path, params) {
     })
     .addQuery(params || {})
     .toString();
+
+  // Decode in order to preserve + signs
+  return URI.decode(url);
 }
 
 function className(event) {

--- a/fec/fec/static/js/home.js
+++ b/fec/fec/static/js/home.js
@@ -1,9 +1,6 @@
 'use strict';
 
-var $ = require('jquery');
-
 var upcomingEvents = require('./upcoming-events');
-var Search = require('fec-style/js/search');
 
 // accessible tabs for alt sidebar
 require('./vendor/tablist').init();
@@ -12,9 +9,3 @@ require('./vendor/tablist').init();
 
 // - What's Happening section
 new upcomingEvents.UpcomingEvents();
-
-// - Candidate and committee support
-new upcomingEvents.UpcomingDeadlines();
-
-// Initialize search toggle
-new Search($('.js-search'));

--- a/fec/fec/static/js/upcoming-events.js
+++ b/fec/fec/static/js/upcoming-events.js
@@ -15,7 +15,7 @@ function UpcomingEvents() {
   var url = calendarHelpers.getUrl('calendar-dates',
     { 'sort': 'start_date',
       'min_start_date': todaysDate,
-      'category': ['report-M', 'report-Q', 'Open+Meetings', 'Executive+Sessions', 'Public+Hearings', 'Conferences', 'Roundtables']
+      'category': ['report-M', 'report-Q', 'report-MY', 'report-YE', 'Open+Meetings', 'Executive+Sessions', 'Public+Hearings', 'Conferences', 'Roundtables']
     });
 
   $.getJSON(url).done(function(events) {

--- a/fec/gulpfile.js
+++ b/fec/gulpfile.js
@@ -5,8 +5,11 @@ var browserify = require('browserify');
 var source = require('vinyl-source-stream');
 var stringify = require('stringify');
 var hbsfy = require('hbsfy');
-var buffer = require('vinyl-buffer')
-var uglify = require('gulp-uglify')
+var buffer = require('vinyl-buffer');
+var uglify = require('gulp-uglify');
+var gulpif = require('gulp-if');
+
+var production = ['stage', 'prod'].indexOf(process.env.FEC_WEB_ENVIRONMENT) !== -1;
 
 var entries = [
   './fec/static/js/fec.js',
@@ -25,7 +28,8 @@ gulp.task('build-js', function () {
       .bundle()
       .pipe(source(entry))
       .pipe(buffer())
-      .pipe(uglify())
+      .pipe(gulpif(production, uglify()))
       .pipe(gulp.dest('dist'));
   });
 });
+;

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -8,16 +8,9 @@
   <div class="js-accordion accordion--neutral" data-content-prefix="updates">
     <button type="button" class="js-accordion-trigger accordion__button">About latest updates</button>
     <div class="accordion__content">
-      <p>The FEC regularly publishes information for media professionals, members of the public and candidates and committees.</p>
-      <h3>For media professionals</h3>
+      <p>Commission meeting agendas are usually published a week before a scheduled meeting. Sunshine Act Notices are announcements of open meetings and executive sessions. Notices for open meetings are published at least a week before a scheduled meeting and announce the date, time and a general list of items for discussion.</p>
       <p>Weekly Digests are published every Friday and summarize the week's publicly disclosed activity. Press releases are published as news happens.</p>
-      <h3>For candidates and committees</h3>
       <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
-      {% if request.user.is_authenticated or settings.FEATURES.agendas %}
-      <h3>For members of the public</h3>
-      <p>Meeting agendas are usually published a week before a scheduled meeting.</p>
-      <p>Sunshine Act Notices are announcements of open meetings and executive sessions. Notices for open meetings are published at least a week before a scheduled meeting and announce the date, time and a general list of items for discussion.</p>
-      {% endif %}
     </div>
   </div>
 {% endblock %}
@@ -28,15 +21,11 @@
       <label class="label">Publication type</label>
       <select name="update_type">
         <option value="">All</option>
-        <option value="for-committees" {% if 'for-committees' in update_types %}selected{% endif %}>For candidates and committees:</option>
-        <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>- FEC Record</option>
-        <option value="tips-for-treasurers" {% if 'tips-for-treasurers' in update_types %}selected{% endif %}>- Tips for Treasurers</option>
-        <option value="for-media" {% if 'for-media' in update_types %}selected{% endif %}>For media professionals:</option>
-        <option value="press-release" {% if 'press-release' in update_types %}selected{% endif %}>- Press releases</option>
-        <option value="weekly-digest" {% if 'weekly-digest' in update_types %}selected{% endif %}>- Weekly Digests</option>
-        {% if request.user.is_authenticated or settings.FEATURES.agendas %}
         <option value="meetings" {% if 'meetings' in update_types %}selected{% endif %}>Commission meetings</option>
-        {% endif %}
+        <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>FEC Record</option>
+        <option value="press-release" {% if 'press-release' in update_types %}selected{% endif %}>Press releases</option>
+        <option value="tips-for-treasurers" {% if 'tips-for-treasurers' in update_types %}selected{% endif %}>Tips for Treasurers</option>
+        <option value="weekly-digest" {% if 'weekly-digest' in update_types %}selected{% endif %}>Weekly Digests</option>
       </select>
     </div>
       <div class="filter">
@@ -66,7 +55,7 @@
             <option value="">All meetings</option>
             <option value="O"{% if "O" in category_list %} selected{% endif %}>Open meetings</option>
             <option value="E"{% if "E" in category_list %} selected{% endif %}>Executive sessions</option>
-          </select>        
+          </select>
         {% else %}
         <label class="label" for="empty-select">Subjects</label>
         <select id="empty-select" name="category" disabled>
@@ -81,13 +70,15 @@
         <button type="submit" class="combo__button button button--standard button--go"><span class="u-visually-hidden">Filter</span></button>
       </div>
     </div>
-    <div class="filter">
-      <div class="combo combo--filter--mini">
-        <label for="search" class="label">Search</label>
-        <input id="search" class="combo__input" name="search" type="text" value="{{ search }}">
-        <button type="submit" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
+    {% if not 'meetings' in update_types %}
+      <div class="filter">
+        <div class="combo combo--filter--mini">
+          <label for="search" class="label">Search</label>
+          <input id="search" class="combo__input" name="search" type="text" value="{{ search }}">
+          <button type="submit" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
+        </div>
       </div>
-    </div>
+    {% endif %}
 </form>
 {% endblock %}
 

--- a/fec/home/templates/partials/home-page-updates.html
+++ b/fec/home/templates/partials/home-page-updates.html
@@ -18,6 +18,9 @@
         <span class="t-bold">
           {% if update.get_update_type == 'Tips for Treasurers' %}
             Tips for treasurers:
+
+          {% elif update.get_update_type == 'Commission Meetings' %}
+            Commission meeting:
           {% else %}
             {{ update.category|capfirst }}:
           {% endif %}

--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -5,12 +5,8 @@ from django.conf import settings
 from operator import attrgetter
 from itertools import chain
 from datetime import date
-from home.models import GenericUpdate
-from home.models import DigestPage
-from home.models import RecordPage
-from home.models import PressReleasePage
-from home.models import TipsForTreasurersPage
-from home.models import ServicesLandingPage
+from home.models import (GenericUpdate, DigestPage, RecordPage, PressReleasePage,
+                        TipsForTreasurersPage, ServicesLandingPage, MeetingPage)
 
 register = template.Library()
 
@@ -18,17 +14,18 @@ register = template.Library()
 def home_page_updates():
     generic_updates = GenericUpdate.objects.live().filter(homepage_expiration__gte=date.today())
 
-    # get latest press releases, records, tips  that are not pinned
+    # get latest press releases, records, tips, meetings that are not pinned
     press_releases = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     records = RecordPage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     tips = TipsForTreasurersPage.objects.live().filter().order_by('-date')[:4]
+    meetings = MeetingPage.objects.live().filter().order_by('-date')[:4]
 
     # get ALL press releases and records that are pinned
     press_releases_pinned = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=True).order_by('-date')
     records_pinned = RecordPage.objects.live().filter(homepage_hide=False, homepage_pin=True).order_by('-date')
 
     # combine all the querysets
-    updates = chain(press_releases, records, tips, press_releases_pinned, records_pinned)
+    updates = chain(press_releases, records, tips, press_releases_pinned, records_pinned, meetings)
 
     # remove homepage pin if expiration date has passed
     updates_unpin_expired = []

--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -18,7 +18,7 @@ def home_page_updates():
     press_releases = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     records = RecordPage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     tips = TipsForTreasurersPage.objects.live().filter().order_by('-date')[:4]
-    meetings = MeetingPage.objects.live().filter().order_by('-date')[:4]
+    meetings = MeetingPage.objects.live().filter(meeting_type='O').order_by('-date')[:4]
 
     # get ALL press releases and records that are pinned
     press_releases_pinned = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=True).order_by('-date')

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -143,10 +143,6 @@ def updates(request):
             tips = tips.search(search)
             meetings = meetings.search(search)
 
-    # temporary: agenda meetings are only for logged in admin users
-    if not request.user.is_authenticated():
-        meetings = ''
-
     # Chain all the QuerySets together
     # via http://stackoverflow.com/a/434755/1864981
     updates = sorted(

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -109,12 +109,6 @@ def updates(request):
 
     # If there's a query, only get the types in the query
     if update_types:
-        if 'for-media' in update_types:
-            press_releases = get_press_releases(category_list=category_list,
-                                                year=year, search=search)
-            digests = get_digests(year=year, search=search)
-        if 'for-committees' in update_types:
-            records = get_records(category_list=category_list, year=year, search=search)
         if 'fec-record' in update_types:
             records = get_records(category_list=category_list, year=year, search=search)
         if 'press-release' in update_types:

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "browserify-istanbul": "^0.2.1",
     "chai": "^3.4.1",
     "gulp": "^3.9.0",
+    "gulp-if": "^2.0.2",
     "gulp-uglify": "2.1.2",
     "handlebars": "^4.0.5",
     "hbsfy": "2.2.1",


### PR DESCRIPTION
This makes a few final fixes for the meetings to be released tomorrow.

1. It adds the open meeting agendas to the "What's happening" section:
![image](https://cloud.githubusercontent.com/assets/1696495/26226581/c2b2e828-3be1-11e7-8051-c3ba5b4f99da.png)

2. It removes the check on user authentication for showing meetings on latest updates, thus adding it as an option (I also arranged these alphabetically like we discussed @jameshupp ):
![image](https://cloud.githubusercontent.com/assets/1696495/26226622/fe0baab8-3be1-11e7-8091-42f6ebee0495.png)

3. It re-arranges the content in the "About latest updates" box to more closely match the order in the select:
![image](https://cloud.githubusercontent.com/assets/1696495/26226686/68e23a64-3be2-11e7-9e3d-5de6bbfe8b74.png)

4. It fixes a bug that @AmyKort noticed where certain events weren't showing up in the "upcoming events" feed. I figured out that this is because in a case like `category=Open+meeting`, the `+` was being url encoded. I changed the calendar URL builder to decode the URL, but maybe there's a better way?
