### PR TITLE
swap out beta references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ the new FEC.gov.
 - [fec-style](https://github.com/18F/fec-style): shared styles and user
   interface components.
 - [fec-cms](https://github.com/18F/fec-cms): the content management system
-  (CMS) for the new FEC>gov. This project uses
+  (CMS) for the new FEC.gov. This project uses
   [Wagtail](https://github.com/torchbox/wagtail), an open source CMS written
   in Python and built on the Django framework.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Are you interested in seeing how much money a candidate raised? Or spent? How
 much debt they took on? Who contributed to their campaign? The FEC is the
 authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It
+The new FEC.gov is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It
 aims to make campaign finance information more accessible (and understandable)
 to all users.
 
@@ -21,18 +21,18 @@ to all users.
 We welcome you to explore, make suggestions, and contribute to our code.
 
 This repository, fec-cms, houses the content management system (CMS) for
-betaFEC.
+the new FEC.gov.
 
 - [FEC](https://github.com/18F/fec): a general discussion forum. We compile
-  [feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget
+  [feedback](https://github.com/18F/fec/issues) from the FEC.gov feedback widget
   here, and this is the best place to submit general feedback.
-- [openFEC](https://github.com/18F/openfec): betaFEC’s API.
-- [openFEC-web-app](https://github.com/18f/openfec-web-app): the betaFEC web
+- [openFEC](https://github.com/18F/openfec): the first RESTful API for the Federal Election Commission
+- [openFEC-web-app](https://github.com/18f/openfec-web-app): the FEC’s web
   app for exploring campaign finance data.
 - [fec-style](https://github.com/18F/fec-style): shared styles and user
   interface components.
 - [fec-cms](https://github.com/18F/fec-cms): the content management system
-  (CMS) for betaFEC. This project uses
+  (CMS) for the new FEC>gov. This project uses
   [Wagtail](https://github.com/torchbox/wagtail), an open source CMS written
   in Python and built on the Django framework.
 


### PR DESCRIPTION
replaces with `FEC.gov`, `the FEC`, or `the new FEC.gov` as appropriate.