### PR TITLE
Adding support for automatic search indexing

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -202,3 +202,19 @@ report_parent_categories = OrderedDict((x, x.replace('_', ' ')) for x in report_
 report_child_categories = OrderedDict()
 for category in report_category_groups.keys():
     report_child_categories.update(report_category_groups[category])
+
+
+# Search index constants
+# These are the parent pages for which we want *all* descendants of, not just direct children
+SEARCH_DESCENDANTS_OF = [
+    '/home/legal-resources/',
+    '/home/help-candidates-and-committees/',
+    '/home/press/'
+]
+
+# These are the parent pages for which we want *only* direct children
+SEARCH_CHILDREN_OF = [
+    '/home/',
+    '/home/about/',
+    '/home/about/leadership-and-structure/'
+]

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -204,6 +204,8 @@ FEC_SERVICE_NOW_PASSWORD = env.get_credential('FEC_SERVICE_NOW_PASSWORD')
 FEC_DIGITALGOV_KEY = env.get_credential('FEC_DIGITALGOV_KEY')
 FEC_DIGITALGOV_DRAWER_KEY_MAIN = env.get_credential('DIGITALGOV_DRAWER_KEY_MAIN', '')
 FEC_DIGITALGOV_DRAWER_KEY_TRANSITION = env.get_credential('DIGITALGOV_DRAWER_KEY_TRANSITION', '')
+DIGITALGOV_BASE_API_URL = 'https://i14y.usa.gov/api/v1'
+DIGITALGOV_DRAWER_HANDLE = 'main'
 
 FEC_TRANSITION_URL = env.get_credential('FEC_TRANSITION_URL', 'http://www.fec.gov')
 FEC_CLASSIC_URL = env.get_credential('FEC_CLASSIC_URL', 'http://www.fec.gov')

--- a/fec/home/utils/search_indexing.py
+++ b/fec/home/utils/search_indexing.py
@@ -1,0 +1,153 @@
+import requests
+
+from bs4 import BeautifulSoup
+from django.conf import settings
+
+from wagtail.wagtailcore.models import Page
+
+# Only use the real search engine if we're on production
+if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':
+    URL_BASE = settings.CANONICAL_BASE
+    DIGITALGOV_BASE_URL = 'https://i14y.usa.gov/api/v1'
+    DIGITALGOV_DRAWER_KEY = settings.FEC_DIGITALGOV_DRAWER_KEY_MAIN
+    DIGITALGOV_DRAWER_HANDLE = 'main'
+else:
+    URL_BASE = 'http://localhost:8000'
+    DIGITALGOV_BASE_URL = 'http://localhost:3000'
+    DIGITALGOV_DRAWER_KEY = ''
+    DIGITALGOV_DRAWER_HANDLE = ''
+
+
+def scrape_page_content(url):
+    """
+    Scrapes the content for a given URL
+
+    :arg str url: The url (in production) of the page to scrape_page_content
+    :returns str : Returns the content scraped from that page
+    """
+    r  = requests.get(url)
+    data = r.text
+    soup = BeautifulSoup(data, 'lxml')
+    text = ''
+
+    # First look for an article. If that's not there, look for this section
+    article = soup.find_all('article', class_="main")
+    if not article:
+        main = soup.find_all('section', class_="main__content--right")
+
+    content = article if article else main
+
+    for tag in content:
+        text = text + tag.get_text().replace('\n', ' ')
+    return text
+
+
+def create_search_index_doc(page):
+    """
+    Creates a dict in the format required to POST/PUT to i14y
+
+    :arg obj page: A page object returned from a database query
+    :returns a dictionary
+    """
+    # Build the live URL of this page in production
+    live_url = page.url_path.replace('/home', URL_BASE)
+    doc = {
+      "document_id": page.id,
+      "title": page.title,
+      "path": live_url,
+      "created": page.first_published_at.strftime("%Y-%m-%d-%H%M%S"),
+      "promote": "false",
+      "language": "en",
+    }
+
+    # Go scrape the content
+    doc['content'] = scrape_page_content(live_url)
+
+    # If we've added a custom search description, add that
+    if page.search_description:
+        doc['description'] = page.search_description
+
+    # If the page has been edited, add the date changed
+    if page.latest_revision_created_at:
+        doc['changed'] = page.latest_revision_created_at.strftime("%Y-%m-%d-%H%M%S"),
+
+    return doc
+
+
+def add_document(page):
+    """
+    Makes a POST request to i14y to add a new document with the information
+    of the edited page
+
+    :arg obj page: A page object returned from a database query
+    """
+    print('====Adding to index====')
+    document = create_search_index_doc(page)
+    url = '{}/documents'.format(DIGITALGOV_BASE_URL)
+    r = requests.post(url, auth=(DIGITALGOV_DRAWER_HANDLE, DIGITALGOV_DRAWER_KEY), data=document)
+    # A 422 means the page already exists,
+    if r.status_code == 422:
+        print('{} already exists'.format(document['document_id']))
+        update_document(document_id)
+    elif r.status_code == 201:
+        print('Created {}'.format(document['document_id']))
+    else:
+        print('Could not create {}'.format(document['document_id']))
+        print(r.__dict__)
+
+
+def update_document(page):
+    """
+    Makes a PUT request to i14y to update the information of the edited page
+
+    :arg obj page: A page object returned from a database query
+    """
+    print('====Updating in index====')
+    document = create_search_index_doc(page)
+    url = '{}/documents/{}'.format(DIGITALGOV_BASE_URL, document.get('document_id'))
+    r = requests.put(url, auth=(DIGITALGOV_DRAWER_HANDLE, DIGITALGOV_DRAWER_KEY), data=document)
+    if r.status_code == 200:
+        print('Updated {}'.format(document['document_id']))
+    else:
+        print('Could not update {}'.format(document['document_id']))
+        print(r.__dict__)
+
+
+def handle_page_edit_or_create(page, method):
+    """
+    When a page is created or edited, this will check to make sure it's live and
+    public and then call the correct add/update function based on
+    the method provided.
+
+    :arg dict page: A dict representing the page that was just added or updated
+    :arg str method: "add" or "update", determines which i14y endpoint is called
+    """
+    if settings.FEC_CMS_ENVIRONMENT != 'PRODUCTION':
+        return
+    else:
+        # Make sure the page is live and public
+        try:
+            p = Page.objects.live().public().get(id=page.id)
+        except:
+            p = None
+        if p:
+            print('===Page is public and live===')
+            if method == 'add':
+                add_document(p)
+            elif method == 'update':
+                update_document(p)
+
+
+def handle_page_delete(page_id):
+    """
+    When a page is deleted on production, this will delete it from the i14y index
+
+    :arg int page_id: The ID of the page to deleted
+    """
+    if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':
+        url = '{}/documents/{}'.format(DIGITALGOV_BASE_URL, page_id)
+        r = requests.delete(url, auth=(DIGITALGOV_DRAWER_HANDLE, DIGITALGOV_DRAWER_KEY))
+        if r.status_code == '200':
+            print('Deleted {}'.format(page_id))
+        else:
+            print('Could not delete {}'.format(page_id))

--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -19,17 +19,14 @@ modeladmin_register(AuthorAdmin)
 
 @hooks.register('after_create_page')
 def search_add(request, page):
-    print('====Page created====')
     handle_page_edit_or_create(page, 'add')
 
 
 @hooks.register('after_edit_page')
 def search_update(request, page):
-    print('====Page edited====')
     handle_page_edit_or_create(page, 'update')
 
 
 @hooks.register('after_delete_page')
 def remove_page(request, page):
-    print('===Page deleted===')
     handle_page_delete(page.id)

--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -1,6 +1,8 @@
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from .models import Author
+from wagtail.wagtailcore import hooks
 
+from .models import Author
+from home.utils.search_indexing import handle_page_edit_or_create, handle_page_delete
 
 class AuthorAdmin(ModelAdmin):
     model = Author
@@ -13,3 +15,21 @@ class AuthorAdmin(ModelAdmin):
 
 
 modeladmin_register(AuthorAdmin)
+
+
+@hooks.register('after_create_page')
+def search_add(request, page):
+    print('====Page created====')
+    handle_page_edit_or_create(page, 'add')
+
+
+@hooks.register('after_edit_page')
+def search_update(request, page):
+    print('====Page edited====')
+    handle_page_edit_or_create(page, 'update')
+
+
+@hooks.register('after_delete_page')
+def remove_page(request, page):
+    print('===Page deleted===')
+    handle_page_delete(page.id)

--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -2,7 +2,7 @@ from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.wagtailcore import hooks
 
 from .models import Author
-from home.utils.search_indexing import handle_page_edit_or_create, handle_page_delete
+from search.utils.search_indexing import handle_page_edit_or_create, handle_page_delete
 
 class AuthorAdmin(ModelAdmin):
     model = Author

--- a/fec/search/management/commands/index_pages.py
+++ b/fec/search/management/commands/index_pages.py
@@ -9,11 +9,9 @@ from django.core.management import BaseCommand
 from home.models import Page
 
 
-DIGITALGOV_DRAWER_KEY_MAIN = settings.FEC_DIGITALGOV_DRAWER_KEY_MAIN
 DIGITALGOV_DRAWER_KEY_TRANSITION = settings.FEC_DIGITALGOV_DRAWER_KEY_TRANSITION
-
-drawer = 'main'
-key = DIGITALGOV_DRAWER_KEY_MAIN
+drawer = settings.DIGITALGOV_DRAWER_HANDLE
+key = settings.FEC_DIGITALGOV_DRAWER_KEY_MAIN
 
 class Command(BaseCommand):
     help = 'Indexes pages'

--- a/fec/search/management/commands/scrape_cms_pages.py
+++ b/fec/search/management/commands/scrape_cms_pages.py
@@ -15,21 +15,9 @@ from home.models import (
     TipsForTreasurersPage
 )
 
+from fec import constants
+
 BASE_URL = settings.CANONICAL_BASE
-
-# These are the parent pages for which we want *all* descendants of, not just direct children
-descendents_of = [
-    '/home/legal-resources/',
-    '/home/help-candidates-and-committees/',
-    '/home/press/'
-]
-
-# These are the parent pages for which we want *only* direct children
-children_of = [
-    '/home/',
-    '/home/about/',
-    '/home/about/leadership-and-structure/'
-]
 
 class Command(BaseCommand):
     help = 'Scrapes pages from the CMS into JSON for indexing on DigitalGov Search'
@@ -77,11 +65,11 @@ class Command(BaseCommand):
             # If no specific pages were requested, just get them all
             pages = []
             # Get all the pages that are descendants of pages
-            for p in descendents_of:
+            for p in constants.SEARCH_DESCENDANTS_OF:
                 parent = Page.objects.live().public().get(url_path=p)
                 pages += Page.objects.descendant_of(parent).live().public()
             # Get all the pages that are direct children of pages
-            for p in children_of:
+            for p in constants.SEARCH_CHILDREN_OF:
                 parent = Page.objects.live().public().get(url_path=p)
                 pages += Page.objects.child_of(parent).live().public()
 

--- a/fec/search/tests/test_indexing.py
+++ b/fec/search/tests/test_indexing.py
@@ -1,0 +1,154 @@
+import requests_mock
+import search.utils.search_indexing as search
+
+from wagtail.wagtailcore.models import Page
+from unittest import mock
+from django.test import Client, TestCase, override_settings
+from django.conf import settings
+from datetime import datetime
+
+# Only use the real search engine if we're on production
+if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':
+    URL_BASE = settings.CANONICAL_BASE
+    DIGITALGOV_BASE_URL = 'https://i14y.usa.gov/api/v1'
+    DIGITALGOV_DRAWER_KEY = settings.FEC_DIGITALGOV_DRAWER_KEY_MAIN
+    DIGITALGOV_DRAWER_HANDLE = 'main'
+else:
+    URL_BASE = 'http://localhost:8000'
+    DIGITALGOV_BASE_URL = 'http://localhost:3000'
+    DIGITALGOV_DRAWER_KEY = ''
+    DIGITALGOV_DRAWER_HANDLE = ''
+
+
+class MockPage(object):
+    id = 123
+    title = 'Mock page'
+    url_path = '/home/mock/'
+    first_published_at = datetime(2017, 6, 1, 0, 0)
+    search_description = None
+    latest_revision_created_at = None
+
+    def __init__(self, add_description=False, add_latest_revision=False):
+        if add_description:
+            self.search_description = 'Fake description'
+        if add_latest_revision:
+            self.latest_revision_created_at = datetime(2017, 6, 2, 0, 0)
+
+# Override settings so the env will be treated as prod but we'll send to a nonexistent API url
+@override_settings(
+    FEC_CMS_ENVIRONMENT='PRODUCTION',
+    DIGITALGOV_BASE_URL='http://localhost:3000',
+    CANONICAL_BASE='https://www.fec.gov')
+@mock.patch.object(search, 'scrape_page_content')
+class TestSearchIndexing(TestCase):
+    def setUp(self):
+        self.page = MockPage()
+
+    def test_create_search_index_doc(self, scrape):
+        # It builds the base doc object
+        scrape.return_value = 'Fake content'
+        doc = search.create_search_index_doc(self.page)
+        self.assertEqual(doc, {
+          'document_id': 123,
+          'title': 'Mock page',
+          'path': 'https://www.fec.gov/mock/',
+          'content': 'Fake content',
+          'created': '2017-06-01-000000',
+          'promote': 'false',
+          'language': 'en',
+        })
+
+        # It calls scrape_page_content with the correct url
+        scrape.assert_called_with('https://www.fec.gov/mock/')
+
+    def test_create_index_doc_with_description(self, scrape):
+        # It adds description if the page has one
+        page = MockPage(add_description=True)
+        doc = search.create_search_index_doc(page)
+        self.assertEqual(doc['description'], 'Fake description')
+
+
+    def test_create_index_doc_edited(self, scrape):
+        # It adds doc['changed'] if the page was edited
+        page = MockPage(add_latest_revision=True)
+        doc = search.create_search_index_doc(page)
+        self.assertEqual(doc['changed'], '2017-06-02-000000')
+
+
+    @requests_mock.Mocker()
+    def test_add_document(self, scrape, m):
+        # It makes a POST to the add endpoint
+        m.register_uri('POST', 'http://localhost:3000/documents', status_code=201)
+        search.add_document(self.page)
+        self.assertTrue(m.called)
+
+
+    @mock.patch.object(search, 'update_document')
+    @requests_mock.Mocker()
+    def test_add_existing_document(self, update_document, scrape, m):
+        # It handles a 422 if the doc already exists
+        m.register_uri('POST', 'http://localhost:3000/documents', status_code=422)
+        search.add_document(self.page)
+        update_document.assert_called_with(self.page)
+
+
+    @requests_mock.Mocker()
+    def test_update_document(self, scrape, m):
+        # It makes a PUT to the update endpoint
+        m.register_uri('PUT', 'http://localhost:3000/documents/123', status_code=200)
+        search.update_document(self.page)
+        self.assertTrue(m.called)
+
+
+    @requests_mock.Mocker()
+    def test_delete_document_in_prod(self, scrape, m):
+        # It makes a PUT to the update endpoint in production
+        m.register_uri('DELETE', 'http://localhost:3000/documents/123', status_code=200)
+        search.handle_page_delete(123)
+        self.assertTrue(m.called)
+
+
+    @override_settings(FEC_CMS_ENVIRONMENT='LOCAL')
+    @requests_mock.Mocker()
+    def test_delete_document_off_prod(self, scrape, m):
+        # It does nothing if not on production
+        m.register_uri('DELETE', 'http://localhost:3000/documents/123', status_code=200)
+        search.handle_page_delete(123)
+        self.assertFalse(m.called)
+
+
+    @override_settings(FEC_CMS_ENVIRONMENT='LOCAL')
+    @mock.patch.object(search, 'add_document')
+    @mock.patch.object(Page, 'objects')
+    def test_handle_page_edit_or_create_off_prod(self, objects, add, scrape):
+        # It doesn't do anything if the environment is production
+        objects.live.return_value.public.return_value.get.return_value = 'page'
+        search.handle_page_edit_or_create(self.page, 'add')
+        self.assertFalse(add.called)
+
+
+    @mock.patch.object(search, 'add_document')
+    @mock.patch.object(Page, 'objects')
+    def test_handle_page_create_on_prod(self, objects, add, scrape):
+        # It calls add_document if the method is 'add'
+        objects.live.return_value.public.return_value.get.return_value = self.page
+        search.handle_page_edit_or_create(self.page, 'add')
+        add.assert_called_with(self.page)
+
+
+    @mock.patch.object(search, 'update_document')
+    @mock.patch.object(Page, 'objects')
+    def test_handle_page_edit_on_prod(self, objects, update, scrape):
+        # It calls update_document if the method is 'update'
+        objects.live.return_value.public.return_value.get.return_value = self.page
+        search.handle_page_edit_or_create(self.page, 'update')
+        update.assert_called_with(self.page)
+
+
+    @mock.patch.object(search, 'add_document')
+    @mock.patch.object(Page, 'objects')
+    def test_handle_page_not_published(self, objects, add, scrape):
+        # It does nothing if the page isn't live and public
+        objects.live.return_value.public.return_value.get.return_value = None
+        search.handle_page_edit_or_create(self.page, 'add')
+        self.assertFalse(add.called)

--- a/fec/search/tests/test_indexing.py
+++ b/fec/search/tests/test_indexing.py
@@ -115,7 +115,7 @@ class TestSearchIndexing(TestCase):
 
     @requests_mock.Mocker()
     def test_delete_document_in_prod(self, scrape, m):
-        # It makes a PUT to the update endpoint in production
+        # It makes a DELETE to the update endpoint in production
         m.register_uri('DELETE', 'http://localhost:3000/documents/123', status_code=200)
         search.handle_page_delete(123)
         self.assertTrue(m.called)

--- a/fec/search/utils/search_indexing.py
+++ b/fec/search/utils/search_indexing.py
@@ -90,8 +90,9 @@ def add_document(page):
         print('{} already exists'.format(document['document_id']))
         update_document(page)
     elif r.status_code == 201:
+        print('Search index: created {}'.format(document['document_id']))
     else:
-        print('Could not create {}'.format(document['document_id']))
+        print('Search index: could not create {}'.format(document['document_id']))
         print(r.__dict__)
 
 

--- a/fec/search/utils/search_indexing.py
+++ b/fec/search/utils/search_indexing.py
@@ -98,16 +98,19 @@ def add_document(page):
 def update_document(page):
     """
     Makes a PUT request to i14y to update the information of the edited page
+    If the request results in a 400, then the page needs to be added
 
     :arg obj page: A page object returned from a database query
     """
     document = create_search_index_doc(page)
     url = '{}/documents/{}'.format(DIGITALGOV_BASE_URL, document.get('document_id'))
     r = requests.put(url, auth=(DIGITALGOV_DRAWER_HANDLE, DIGITALGOV_DRAWER_KEY), data=document)
-    if r.status_code == 200:
-        print('Updated {}'.format(document['document_id']))
+    if r.status_code == 400:
+        add_document(page)
+    elif r.status_code == 200:
+        print('Search index: updated {}'.format(document['document_id']))
     else:
-        print('Could not update {}'.format(document['document_id']))
+        print('Search index: could not update {}'.format(document['document_id']))
         print(r.__dict__)
 
 

--- a/fec/search/utils/search_indexing.py
+++ b/fec/search/utils/search_indexing.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 
 from wagtail.wagtailcore.models import Page
+from fec import constants
 
 # Only use the real search engine if we're on production
 if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':

--- a/fec/search/utils/search_indexing.py
+++ b/fec/search/utils/search_indexing.py
@@ -90,7 +90,6 @@ def add_document(page):
         print('{} already exists'.format(document['document_id']))
         update_document(page)
     elif r.status_code == 201:
-        print('Created {}'.format(document['document_id']))
     else:
         print('Could not create {}'.format(document['document_id']))
         print(r.__dict__)
@@ -145,7 +144,7 @@ def handle_page_delete(page_id):
     if settings.FEC_CMS_ENVIRONMENT == 'PRODUCTION':
         url = '{}/documents/{}'.format(DIGITALGOV_BASE_URL, page_id)
         r = requests.delete(url, auth=(DIGITALGOV_DRAWER_HANDLE, DIGITALGOV_DRAWER_KEY))
-        if r.status_code == '200':
-            print('Deleted {}'.format(page_id))
+        if r.status_code == 200:
+            print('Search index: deleted {}'.format(page_id))
         else:
-            print('Could not delete {}'.format(page_id))
+            print('Search index: could not delete {}'.format(page_id))


### PR DESCRIPTION
This adds Wagtail hooks for automatically adding, updating and deleting pages from the DigitalGov search engine. I basically took the same methods used for manually updating the index, refactored slightly and then added to Wagtail hooks on page creation, editing and deletion.

Still to do:
- [x] Add tests
- [x] Test with a dummy search engine (still waiting for a sandbox account to use)
- [x] Remove print statements