### PR TITLE
Hotfix/meeting template item audio

### DIFF
--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -49,7 +49,7 @@
           <a class="u-no-border" href="{{ self.live_video_url }}"><img src={% static 'img/thumbnail--video.png' %} alt="Video"></a>
           </div>
         <div class="usa-width-two-thirds">
-          <h3 class="u-no-margin"><a href="{{ self.live_video_url }}">Watch the live meeting now</a></h3>
+          <h3 class="u-no-margin"><a href="{{ self.live_video_url }}">Watch the meeting live at 10:00 a.m. (EDT)</a></h3>
           <p class="u-no-margin">This meeting is currently being streamed{% if self.live_video_captions %} with <a href="{{ self.live_video_captions }}">live captions</a>{% endif %}. The recorded video, audio and captions will be posted on this page after the meeting ends.</p>
         </div>
       </div>
@@ -66,7 +66,7 @@
       {% for block in self.agenda %}
         <li>
             <h3 class="u-no-margin">{{ block.value.item_title }}</h3>
-            {% if block.value.item_audio %}<p class="t-sans u-no-margin"><span class="icon icon--inline--left i-speaker"></span><a href="{{ block.value.item_audio }}">Listen to discussion of this item</a></p>{% endif %}
+            {% if block.value.item_audio %}<p class="t-sans u-no-margin"><span class="icon icon--inline--left i-speaker"></span><a href="{{ block.value.item_audio.file.url }}">Listen to discussion of this item</a></p>{% endif %}
             <div class="agenda__text">
               {{ block.value.item_text }}
             </div>
@@ -111,9 +111,9 @@
         {% endif %}
         {% if self.mtg_transcript_url %}
           <div class="grid__item">
-            <a href="{{ block.value }}" class="u-no-border"><img src={% static 'img/thumbnail--captions.png' %} alt="Captions"></a>
+            <a href="{{ self.mtg_transcript_url }}" class="u-no-border"><img src={% static 'img/thumbnail--captions.png' %} alt="Captions"></a>
             <br>
-            <a href="{{ block.value }}">Full meeting captions</a>
+            <a href="{{ self.mtg_transcript_url }}">Full meeting captions</a>
           </div>
         {% endif %}
       </div>

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -49,8 +49,8 @@
           <a class="u-no-border" href="{{ self.live_video_url }}"><img src={% static 'img/thumbnail--video.png' %} alt="Video"></a>
           </div>
         <div class="usa-width-two-thirds">
-          <h3 class="u-no-margin"><a href="{{ self.live_video_url }}">Watch the meeting live at 10:00 a.m. (EDT)</a></h3>
-          <p class="u-no-margin">This meeting is currently being streamed{% if self.live_video_captions %} with <a href="{{ self.live_video_captions }}">live captions</a>{% endif %}. The recorded video, audio and captions will be posted on this page after the meeting ends.</p>
+          <h3 class="u-no-margin"><a href="{{ self.live_video_url }}">Watch the meeting live</a></h3>
+          <p class="u-no-margin">This meeting will be streamed{% if self.live_video_captions %} with <a href="{{ self.live_video_captions }}">live captions</a>{% endif %}. The recorded video, audio and captions will be posted on this page after the meeting ends.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Item audio file block was just returning name of file:
{{ block.value.item_audio }}, so I changed them to{{ block.value.item_audio.file.url }}, which targets the URL value AND forces it to play in browser instead if just download.

Meeting transcript block was just set to block:value which does not work here. So I changed it to: 
{{ self.mtg_transcript_url }}

Edited some language in the streaming media panel per request from Greg Scott:
"Watch the meeting live at 10:00 a.m. (EDT)"
We could incorporate the meeting time block into this b/c the meeting times do change, but I did not do this yet.