### PR TITLE
changed "Purhcases" to "Purchases"

### DIFF
--- a/fec/search/templates/search/search.html
+++ b/fec/search/templates/search/search.html
@@ -68,7 +68,7 @@
                   </li>
                   <li>
                     <a class="t-bold" href="{{ settings.FEC_APP_URL }}/disbursements?recipient_name={{search_query}}">Disbursements</a>
-                    <span class="t-note t-block t-sans">Purhcases and payments made by committees</span>
+                    <span class="t-note t-block t-sans">Purchases and payments made by committees</span>
                   </li>
                   <li>
                     <a class="t-bold" href="{{ settings.FEC_APP_URL }}/legal/search?search_type=all&amp;search={{ search_query}}">Legal resources</a>


### PR DESCRIPTION
Correcting a misspelling pointed out to Judith Ingram by a user:
**Judith wrote via email:**
Hi.
We got a message flagging a misspelling of the word purchase on the page here:https://www.fec.gov/search/
It's under Other Search Tools, Disbursements
Thanks.
Judith Ingram
Press Officer
Federal Election Commission
