### PR TITLE
Remove home meeting agendas

### DIFF
--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -48,9 +48,12 @@ def home_page_updates():
     updates_sorted_by_date = sorted(updates_unpin_expired, key=lambda x: x.date, reverse=True)
     updates_sorted_by_homepage_pin = sorted(updates_sorted_by_date, key=lambda x: x.homepage_pin, reverse=True)
 
+    # Figure out how many non-generic updates to show
+    update_limit = 4 - len(generic_updates)
+    
     return {
         'generic_updates': generic_updates,
-        'updates': updates_sorted_by_homepage_pin[:4]
+        'updates': updates_sorted_by_homepage_pin[:update_limit]
     }
 
 @register.inclusion_tag('partials/candidate_committee_services.html')

--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 from itertools import chain
 from datetime import date
 from home.models import (GenericUpdate, DigestPage, RecordPage, PressReleasePage,
-                        TipsForTreasurersPage, ServicesLandingPage, MeetingPage)
+                        TipsForTreasurersPage, ServicesLandingPage)
 
 register = template.Library()
 
@@ -14,18 +14,17 @@ register = template.Library()
 def home_page_updates():
     generic_updates = GenericUpdate.objects.live().filter(homepage_expiration__gte=date.today())
 
-    # get latest press releases, records, tips, meetings that are not pinned
+    # get latest press releases, records, tips, that are not pinned
     press_releases = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     records = RecordPage.objects.live().filter(homepage_hide=False, homepage_pin=False).order_by('-date')[:4]
     tips = TipsForTreasurersPage.objects.live().filter().order_by('-date')[:4]
-    meetings = MeetingPage.objects.live().filter(meeting_type='O', homepage_hide=False).order_by('-date')[:4]
 
     # get ALL press releases and records that are pinned
     press_releases_pinned = PressReleasePage.objects.live().filter(homepage_hide=False, homepage_pin=True).order_by('-date')
     records_pinned = RecordPage.objects.live().filter(homepage_hide=False, homepage_pin=True).order_by('-date')
 
     # combine all the querysets
-    updates = chain(press_releases, records, tips, press_releases_pinned, records_pinned, meetings)
+    updates = chain(press_releases, records, tips, press_releases_pinned, records_pinned)
 
     # remove homepage pin if expiration date has passed
     updates_unpin_expired = []


### PR DESCRIPTION
In order to reduce duplicate content on the home page, this removes the meeting agendas from showing up in the "What's happening" updates feed on the home page, as they're already included in the calendar feed below. 

It also fixes an issue where when adding a generic update to the home page, it would add it as a fifth item, rather than limiting the total number of items to four.