### PR TITLE
Adding data-term attribute to whitelist

### DIFF
--- a/fec/fec/wagtail_hooks.py
+++ b/fec/fec/wagtail_hooks.py
@@ -5,7 +5,7 @@ from django.utils.html import format_html
 @hooks.register('construct_whitelister_element_rules')
 def whitelister_element_rules():
     return {
-        'span': attribute_rule({'class': True}),
+        'span': attribute_rule({'class': True, 'data-term': True}),
         'blockquote': attribute_rule({'class': True}),
     }
 


### PR DESCRIPTION
This adds the `data-term` attribute to the `span` attribute whitelist so that glossary terms can be added by editing the HTML of a Wagtail paragraph block. Previously the attributes were stripped out. 