### PR TITLE
Feature/indent outdent

### DIFF
--- a/fec/fec/static/css/customize-editor.css
+++ b/fec/fec/static/css/customize-editor.css
@@ -24,3 +24,46 @@ blockquote {
 	 margin-left: 0;
 	 font-style: italic;
 }
+
+.richtext ul ul,
+.richtext ul ol,
+.richtext ol ol,
+.richtext ol ul {
+  margin-left: 15px;
+}
+
+.richtext ul ul li:last-of-type {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.richtext ol li:last-of-type {
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.richtext ul ul li {
+  list-style-type: circle;
+}
+
+.richtext ul ul ul li {
+  list-style-type: square;
+}
+
+.richtext ul ul {
+  margin-bottom: 0;
+  margin-left: 15px;
+}
+
+.richtext ol ul li,
+.richtext ol ol ul li {
+  list-style-type: circle;
+}
+
+.richtext ol ol li {
+  list-style-type: lower-alpha;
+}
+
+.richtext ol ol ol li {
+  list-style-type: lower-roman;
+}

--- a/fec/fec/static/js/hallo-indent.js
+++ b/fec/fec/static/js/hallo-indent.js
@@ -33,7 +33,12 @@
               var $sibling = $(parent).prev('li');
               if ($sibling.length) {
                 // Create a new UL with this as the first item
-                $sibling.append('<ul>' + parent.outerHTML + '</ul>');
+                if ($sibling.closest('ol').length) {
+                  // If it's in an OL, create as a OL
+                  $sibling.append('<ol>' + parent.outerHTML + '</ol>');
+                } else {
+                  $sibling.append('<ul>' + parent.outerHTML + '</ul>');
+                }
                 $(parent).remove();
                 widget.options.editable.setModified();
               }

--- a/fec/fec/static/js/hallo-indent.js
+++ b/fec/fec/static/js/hallo-indent.js
@@ -1,0 +1,46 @@
+/* Indent button for hallo.js
+ * Takes a list item and wraps it in another list and puts that list in the
+ * previous list item. This is how you make nested lists!
+ */
+
+(function() {
+  (function($) {
+    return $.widget('IKS.indentButton', {
+      options: {
+        uuid: '',
+        editable: null
+      },
+      populateToolbar: function(toolbar) {
+        var button, widget;
+
+        widget = this;
+        button = $('<span></span>');
+        button.hallobutton({
+          uuid: this.options.uuid,
+          editable: this.options.editable,
+          label: 'Indent list',
+          icon: 'icon-arrow-right',
+          command: null
+        });
+        toolbar.append(button);
+
+        button.on('click', function() {
+            var node = widget.options.editable.getSelection();
+            var text = node.endContainer;
+            var parent = text.parentElement;
+            if (parent.nodeName === 'LI') {
+              // Find the previous LI
+              var $sibling = $(parent).prev('li');
+              if ($sibling.length) {
+                // Create a new UL with this as the first item
+                $sibling.append('<ul>' + parent.outerHTML + '</ul>');
+                $(parent).remove();
+                widget.options.editable.setModified();
+              }
+            }
+        });
+      }
+    });
+  })(jQuery);
+
+}).call(this);

--- a/fec/fec/static/js/hallo-outdent.js
+++ b/fec/fec/static/js/hallo-outdent.js
@@ -1,0 +1,40 @@
+/* Outdent button for hallo.js
+ * If a list is indented, this outdents it. This is how you destroy a nested list
+ */
+
+(function() {
+  (function($) {
+    return $.widget('IKS.outdentButton', {
+      options: {
+        uuid: '',
+        editable: null
+      },
+      populateToolbar: function(toolbar) {
+        var button, widget;
+
+        widget = this;
+        button = $('<span></span>');
+        button.hallobutton({
+          uuid: this.options.uuid,
+          editable: this.options.editable,
+          label: 'Outdent list',
+          icon: 'icon-arrow-left',
+          command: null
+        });
+        toolbar.append(button);
+
+        button.on('click', function() {
+            var node = widget.options.editable.getSelection();
+            var $li = $(node.endContainer.parentElement);
+            if ($li.parent('ul ul').length) {
+              // Remove the wrapping UL and move the LI after the current LI
+              $li.unwrap();
+              $li.parent('li').after($li);
+              widget.options.editable.setModified();
+            }
+        });
+      }
+    });
+  })(jQuery);
+
+}).call(this);

--- a/fec/fec/static/js/hallo-outdent.js
+++ b/fec/fec/static/js/hallo-outdent.js
@@ -26,7 +26,7 @@
         button.on('click', function() {
             var node = widget.options.editable.getSelection();
             var $li = $(node.endContainer.parentElement);
-            if ($li.parent('ul ul').length) {
+            if ($li.parent('ul ul').length || $li.parent('ol ol').length) {
               // Remove the wrapping UL and move the LI after the current LI
               $li.unwrap();
               $li.parent('li').after($li);

--- a/fec/fec/wagtail_hooks.py
+++ b/fec/fec/wagtail_hooks.py
@@ -19,6 +19,8 @@ def editor_js():
         <script src="/static/js/hallo-edit-html.js"></script>
         <script src="/static/js/hallo-sans-serif.js"></script>
         <script src="/static/js/hallo-blockquote.js"></script>
+        <script src="/static/js/hallo-indent.js"></script>
+        <script src="/static/js/hallo-outdent.js"></script>
         <script src="/static/js/customize-editor.js"></script>
         <script src="/static/ace-builds/src-noconflict/ace.js"></script>
         <script src="/static/ace-builds/src-noconflict/mode-html.js"></script>
@@ -27,6 +29,8 @@ def editor_js():
             registerHalloPlugin('hallocleanhtml');
             registerHalloPlugin('sansSerifButton');
             registerHalloPlugin('blockquotebutton');
+            registerHalloPlugin('outdentButton');
+            registerHalloPlugin('indentButton');
         </script>
     ''')
 


### PR DESCRIPTION
This adds support for indenting/outdenting lists in Wagtail so that you can create nested lists:

![image](https://user-images.githubusercontent.com/1696495/27060294-9a7ce6c0-4f90-11e7-80d6-a0f08f87747d.png)

Here's how it looks in the editor:
![image](https://user-images.githubusercontent.com/1696495/27060161-c8a701d0-4f8f-11e7-8d83-f22ba38361ae.png)

There's no built-in icons for indent/outdent, so I just used the arrow icons (the ones on the far right of the toolbar). They have hover title text that say "indent" or "outdent".

Resolves https://github.com/18F/fec-style/issues/693