### PR TITLE
Feature/updates-search

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -107,7 +107,7 @@ class ContentPage(Page):
     ]
 
     search_fields =  Page.search_fields + [
-        index.SearchField('body', partial_match=True)
+        index.SearchField('body')
     ]
 
     # Default content section for determining the active nav

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -313,6 +313,11 @@ class RecordPage(ContentPage):
         )
     ]
 
+    search_fields =  ContentPage.search_fields + [
+        index.FilterField('category'),
+        index.FilterField('date')
+    ]
+
     @property
     def content_section(self):
         return ''
@@ -347,6 +352,10 @@ class DigestPage(ContentPage):
     ]
 
     template = 'home/updates/digest_page.html'
+
+    search_fields =  ContentPage.search_fields + [
+        index.FilterField('date')
+    ]
 
     @property
     def content_section(self):
@@ -404,6 +413,11 @@ class PressReleasePage(ContentPage):
         )
     ]
 
+    search_fields =  ContentPage.search_fields + [
+        index.FilterField('category'),
+        index.FilterField('date')
+    ]
+
     @property
     def content_section(self):
         return ''
@@ -459,6 +473,10 @@ class TipsForTreasurersPage(ContentPage):
         FieldPanel('date'),
         PageChooserPanel('read_next')
         ]
+
+    search_fields =  ContentPage.search_fields + [
+        index.FilterField('date')
+    ]
 
     @property
     def get_update_type(self):
@@ -945,6 +963,8 @@ class MeetingPage(Page):
     ]
 
     search_fields =  Page.search_fields + [
+        index.FilterField('meeting_type'),
+        index.FilterField('date'),
         index.SearchField('imported_html'),
         index.SearchField('agenda')
     ]

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -28,6 +28,8 @@ from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 from wagtail.wagtaildocs.edit_handlers import DocumentChooserPanel
 from wagtail.wagtaildocs.models import Document
 
+from wagtail.wagtailsearch import index
+
 from django.db.models.signals import m2m_changed
 
 from wagtail.contrib.table_block.blocks import TableBlock
@@ -102,6 +104,10 @@ class ContentPage(Page):
 
     promote_panels = Page.promote_panels + [
         ImageChooserPanel('feed_image'),
+    ]
+
+    search_fields =  Page.search_fields + [
+        index.SearchField('body', partial_match=True)
     ]
 
     # Default content section for determining the active nav
@@ -936,6 +942,11 @@ class MeetingPage(Page):
 
     promote_panels = Page.promote_panels + [
         FieldPanel('homepage_hide')
+    ]
+
+    search_fields =  Page.search_fields + [
+        index.SearchField('imported_html'),
+        index.SearchField('agenda')
     ]
 
     @property

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -97,7 +97,9 @@
   {% else %}
   <div class="message message--info">
     <h2>No results</h2>
-    <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
+    {% if search %}
+      <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
+    {% endif %}
     <p>Please note that FEC Record articles published before 2011 only exist in PDF format and are not included in these search results.</p>
     <p>
     <div class="message--alert__bottom">

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -100,11 +100,11 @@
     {% if search %}
       <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
     {% endif %}
-    <p>Please note that FEC Record articles published before 2011 only exist in PDF format and are not included in these search results.</p>
+    <p>Please note that FEC Record articles published before 2011 exist only in PDF format and are not included in these search results.</p>
     <p>
     <div class="message--alert__bottom">
-      <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search an archive</a> of the old FEC.gov design.</p>
-      <p>If you'd like to contact our team, we're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
+      <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search the archive</a> of FEC.gov’s previous design.</p>
+      <p>If you’d like to contact our team, we’re available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
     </div>
   </div>
   {% endif %}

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -81,16 +81,29 @@
 {% endblock %}
 
 {% block feed %}
-  {% for update in updates %}
-    {% include 'partials/update.html' with update=update show_tag=True %}
-  {% endfor %}
-  <div class="results-info">
-    <span>Page {{ updates.number }} of {{ updates.paginator.num_pages }}</span>
-    {% if updates.has_previous %}
-        <a class="button button--standard button--previous" href="?page={{ updates.previous_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Previous</span></a>
-    {% endif %}
-    {% if updates.has_next %}
-        <a class="button button--standard button--next" href="?page={{ updates.next_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Next</span></a>
-    {% endif %}
+  {% if updates %}
+    {% for update in updates %}
+      {% include 'partials/update.html' with update=update show_tag=True %}
+    {% endfor %}
+    <div class="results-info">
+      <span>Page {{ updates.number }} of {{ updates.paginator.num_pages }}</span>
+      {% if updates.has_previous %}
+          <a class="button button--standard button--previous" href="?page={{ updates.previous_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Previous</span></a>
+      {% endif %}
+      {% if updates.has_next %}
+          <a class="button button--standard button--next" href="?page={{ updates.next_page_number }}{% for key,value in request.GET.items %}{% ifnotequal key 'page' %}&amp;{{ key }}={{ value }}{% endifnotequal %}{% endfor %}"><span class="u-visually-hidden">Next</span></a>
+      {% endif %}
+    </div>
+  {% else %}
+  <div class="message message--info">
+    <h2>No results</h2>
+    <p>We didn’t find any pages matching <strong>&ldquo;{{search}}&rdquo;</strong>.</p>
+    <p>Please note that FEC Record articles published before 2011 only exist in PDF format and are not included in these search results.</p>
+    <p>
+    <div class="message--alert__bottom">
+      <p>FEC.gov is in the middle of a redesign, and some pages aren’t included in search results yet. Please try another search. Or, <a href="{{ settings.FEC_CLASSIC_URL }}">search an archive</a> of the old FEC.gov design.</p>
+      <p>If you'd like to contact our team, we're available by <a href="mailto:{{ settings.WEBMANAGER_EMAIL }}">email</a> or <a href="https://github.com/18f/fec">GitHub</a>.</p>
+    </div>
   </div>
+  {% endif %}
 {% endblock %}

--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -70,15 +70,13 @@
         <button type="submit" class="combo__button button button--standard button--go"><span class="u-visually-hidden">Filter</span></button>
       </div>
     </div>
-    {% if not 'meetings' in update_types %}
-      <div class="filter">
-        <div class="combo combo--filter--mini">
-          <label for="search" class="label">Search</label>
-          <input id="search" class="combo__input" name="search" type="text" value="{{ search }}">
-          <button type="submit" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
-        </div>
+    <div class="filter">
+      <div class="combo combo--filter--mini">
+        <label for="search" class="label">Search</label>
+        <input id="search" class="combo__input" name="search" type="text" value="{{ search }}">
+        <button type="submit" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
       </div>
-    {% endif %}
+    </div>
 </form>
 {% endblock %}
 

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -89,6 +89,10 @@ def get_meetings(category_list=None, year=False, search=None):
 
     if year:
         meetings = meetings.filter(date__year=year)
+
+    if search:
+        meetings = meetings.search(search)
+
     return meetings
 
 

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -140,6 +140,8 @@ def updates(request):
         meetings = MeetingPage.objects.live()
 
         if year:
+            # Trying to filter using the built-in date__year parameter doesn't
+            # work when chaining filter() and search(), so this uses date_gte and date_lte
             year = int(year)
             press_releases = press_releases.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
             digests = digests.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -1,4 +1,5 @@
 import requests
+from datetime import datetime
 
 from django.shortcuts import render
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -33,7 +34,8 @@ def get_records(category_list=None, year=None, search=None):
             records = records.filter(category=category)
 
     if year:
-        records = records.filter(date__year=year)
+        year = int(year)
+        records = records.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
     if search:
         records = records.search(search)
@@ -44,7 +46,8 @@ def get_records(category_list=None, year=None, search=None):
 def get_digests(year=None, search=None):
     digests = DigestPage.objects.live()
     if year:
-        digests = digests.filter(date__year=year)
+        year = int(year)
+        digests = digests.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
     if search:
         digests = digests.search(search)
@@ -60,7 +63,8 @@ def get_press_releases(category_list=None, year=None, search=None):
             press_releases = press_releases.filter(category=category)
 
     if year:
-        press_releases = press_releases.filter(date__year=year)
+        year = int(year)
+        press_releases = press_releases.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
     if search:
         press_releases = press_releases.search(search)
@@ -72,7 +76,8 @@ def get_tips(year=None, search=None):
     tips = TipsForTreasurersPage.objects.live()
 
     if year:
-        tips = tips.filter(date__year=year)
+        year = int(year)
+        tips = tips.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
     if search:
         tips = tips.search(search)
@@ -88,7 +93,8 @@ def get_meetings(category_list=None, year=False, search=None):
             meetings = meetings.filter(meeting_type=category)
 
     if year:
-        meetings = meetings.filter(date__year=year)
+        year = int(year)
+        meetings = meetings.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
     if search:
         meetings = meetings.search(search)
@@ -134,11 +140,12 @@ def updates(request):
         meetings = MeetingPage.objects.live()
 
         if year:
-            press_releases = press_releases.filter(date__year=year)
-            digests = digests.filter(date__year=year)
-            records = records.filter(date__year=year)
-            tips = tips.filter(date__year=year)
-            meetings = meetings.filter(date__year=year)
+            year = int(year)
+            press_releases = press_releases.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
+            digests = digests.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
+            records = records.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
+            tips = tips.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
+            meetings = meetings.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
         if search:
             press_releases = press_releases.search(search)


### PR DESCRIPTION
This adds the correct search functionality to all latest updates by adding the necessary body fields to the built-in Wagtail search index. Previously only titles were searched.

In the case of no results, it also adds a no search results message.

![image](https://user-images.githubusercontent.com/1696495/27147418-9669483c-50f1-11e7-8f95-26c888c58a47.png)

I added a line about how Record articles before 2011 aren't included in these results since they're only in PDF form, but could use @jameshupp eyes on microcopy.

This also fixes an issue where searching by a combination of filters would result in an error (e.g. year and keyword). 

Resolves https://github.com/18F/fec-cms/issues/1102