### PR TITLE
Remove arrow and width class from page link blocks

### DIFF
--- a/fec/home/templates/blocks/disabled-page-links.html
+++ b/fec/home/templates/blocks/disabled-page-links.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
-<p class="usa-width-one-half">
-  <span class="t-sans is-disabled">{{ self }} &raquo;</span>
+<p>
+  <span class="t-sans is-disabled">{{ self }}</span>
 </p>

--- a/fec/home/templates/blocks/page-links.html
+++ b/fec/home/templates/blocks/page-links.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
-<p class="usa-width-one-half">
-  <a class="t-sans"  href="{{ self.url }}">{{ self }} &raquo;</a>
+<p>
+  <a class="t-sans"  href="{{ self.url }}">{{ self }}</a>
 </p>


### PR DESCRIPTION
This removes the `usa-width-one-half` class and right arrow quote mark from the page link blocks, as that will now all be controlled by separate CSS:

![image](https://user-images.githubusercontent.com/1696495/27247279-e4fa2762-52ab-11e7-8e4c-0368ead82b95.png)
