### PR TITLE
View PDF documents in browser instead of force-download

### DIFF
--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -14,7 +14,6 @@ from search import views as search_views
 
 
 urlpatterns = [
-     # override default wagtail view
     url(r'^documents/(\d+)/(.*)$', home_views.serve_wagtail_doc, name='wagtaildocs_serve'),
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^auth/', include(uaa_urls)),

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -14,6 +14,8 @@ from search import views as search_views
 
 
 urlpatterns = [
+     # override default wagtail view
+    url(r'^documents/(\d+)/(.*)$', home_views.serve_wagtail_doc, name='wagtaildocs_serve'),
     url(r'^django-admin/', include(admin.site.urls)),
     url(r'^auth/', include(uaa_urls)),
     url(r'^admin/', include(wagtailadmin_urls)),

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -267,3 +267,16 @@ def contact_rad(request):
         'self': page_context,
         'form': form
     })
+
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from wagtail.wagtaildocs.models import Document
+
+def serve_wagtail_doc(request, document_id, document_filename):
+    """
+    Replacement for ``wagtail.wagtaildocs.views.serve.serve``
+    Wagtail's default document view serves everything as an attachment.
+    We'll bounce back to the URL and let the media server serve it.
+    """
+    doc = get_object_or_404(Document, id=document_id)
+    return HttpResponseRedirect(doc.file.url)

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -6,6 +6,10 @@ from django.conf import settings
 from itertools import chain
 from operator import attrgetter
 
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from wagtail.wagtaildocs.models import Document
+
 from fec.forms import ContactRAD, form_categories
 from home.models import (
     CommissionerPage,
@@ -267,10 +271,6 @@ def contact_rad(request):
         'self': page_context,
         'form': form
     })
-
-from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
-from wagtail.wagtaildocs.models import Document
 
 def serve_wagtail_doc(request, document_id, document_filename):
     """


### PR DESCRIPTION
**Background**: It seems that Django's default is to serve documents as "attachments".  So clicking on links to PDFs forces download instead of using the built in PDF viewer available in most modern browsers.
 
Documents added to the CMS either by pasting a URL into a text type fields (URLField, TextField, etc) or documents uploaded to the documents tab of the CMS via the document option in a RichTextBlock interface are force-downloaded instead of viewed in browser.

Documents added via a DocumentChooserBlock can be configured at the template-level to view in browser, instead of download by adding "file" before the URL in the template block, like this example:
Change ```block.value.item_audio.url``` to  ```block.value.item_audio.file.url``` (https://github.com/18F/fec-cms/pull/1086)

But the above solution does not work for text type fields and any similar per-template solution like this would be tedious to implement and likely cumbersome to maintain.

**Proposed Solution**: So the solution in this PR is to override Wagtail's default document view and redirect to the real file URL by adding a view to views.py  and a URL pattern to urls.py.

Tested this locally and it seems to work for all types of fields.

Based on this wagtail issue https://github.com/wagtail/wagtail/issues/1407