### PR TITLE
Adding script and data to import executive sessions

### DIFF
--- a/fec/data_loader/management/commands/import_executive_sessions.py
+++ b/fec/data_loader/management/commands/import_executive_sessions.py
@@ -1,0 +1,53 @@
+import datetime
+import json
+import os
+
+from dateutil import parser
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.utils import timezone
+
+from data_loader.utils import ImporterMixin
+from home.models import MeetingPage, Page
+
+
+class Command(ImporterMixin, BaseCommand):
+    help = 'Imports Meeting Agenda pages from JSON'
+    requires_migrations_checks = True
+    requires_system_checks = True
+
+    def handle(self, *args, **options):
+
+        file_name = os.path.join(settings.REPO_DIR, 'fec/data_loader/management/executive_sessions.json')
+        with open(file_name, 'r') as json_contents:
+            self._create_pages(json_contents, self._parent_page(), options)
+
+    def _log(self, message):
+        self.stdout.write(repr(message))
+
+    def _parent_page(self):
+        return Page.objects.get(url_path='/home/updates/')
+
+    def _create_pages(self, json_text, parent_page, options):
+        self._log('Creating new pages...')
+        for meeting_struct in json.load(json_text):
+            self._create_agenda_page(meeting_struct, parent_page)
+
+    def _create_agenda_page(self, meeting, parent_page):
+        if meeting['second_notice_link']:
+            notice_links = '\n'.join([meeting['notice_link'], meeting['second_notice_link']])
+        else:
+            notice_links = meeting['notice_link']
+
+        new_page = MeetingPage(
+            date=datetime.datetime.strptime(meeting['start_date'], '%m/%d/%Y').date(),
+            end_date=datetime.datetime.strptime(meeting['end_date'], '%m/%d/%Y').date() if meeting['end_date'] else None,
+            meeting_type='E',
+            sunshine_act_links= notice_links,
+            depth=2,
+            numchild=0,
+            live=1,
+            title=meeting['title']
+        )
+        parent_page.add_child(instance=new_page)

--- a/fec/data_loader/management/executive_sessions.json
+++ b/fec/data_loader/management/executive_sessions.json
@@ -1,0 +1,2676 @@
+[
+  {
+    "title": "December 6, 2016 executive session",
+    "start_date": "12/6/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20161206.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 15, 2016 executive session",
+    "start_date": "11/15/2016",
+    "end_date": "12/6/2016",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20161115.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20161115a.pdf"
+  },
+  {
+    "title": "October 25, 2016 executive session",
+    "start_date": "10/25/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20161025.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 18, 2016 executive session",
+    "start_date": "10/18/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20161018.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 29, 2016 executive session",
+    "start_date": "9/29/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160929.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 13, 2016 executive session",
+    "start_date": "9/13/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160913.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 16, 2016 executive session",
+    "start_date": "8/16/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160816.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 12, 2016 executive session",
+    "start_date": "7/12/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160712.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 28, 2016 executive session",
+    "start_date": "6/28/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160628.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 14, 2016 executive session",
+    "start_date": "6/14/2016",
+    "end_date": "6/16/2016",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160614.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160614a.pdf"
+  },
+  {
+    "title": "May 24, 2016 executive session",
+    "start_date": "5/24/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160524.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 26, 2016 executive session",
+    "start_date": "4/26/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160426.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 12, 2016 executive session",
+    "start_date": "4/12/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160412.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160412a.pdf"
+  },
+  {
+    "title": "March 15 and 16, 2016 executive session",
+    "start_date": "3/15/2016",
+    "end_date": "4/12/2016",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160315.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160315a.pdf,https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160315b.pdf"
+  },
+  {
+    "title": "February 23 and 25, 2016 executive session",
+    "start_date": "2/23/2016",
+    "end_date": "2/25/2016",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160223.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 26, 2016 executive session",
+    "start_date": "1/26/2016",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2016/executive/notice20160126.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 10, 2015, December 15, 2015 and December 17, 2015 executive session",
+    "start_date": "12/10/2015",
+    "end_date": "12/15/2017",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20151210.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 17, 2015 and November 19, 2015 executive session",
+    "start_date": "11/17/2015",
+    "end_date": "11/19/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20151117.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 27, 2015 and October 29, 2015 executive session",
+    "start_date": "10/27/2015",
+    "end_date": "10/29/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20151027.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 5, 2015 executive session",
+    "start_date": "10/5/2015",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20151005.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 29, 2015 and October 1, 2015 executive session",
+    "start_date": "9/29/2015",
+    "end_date": "10/01/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150929.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 15, 2015 and September 17, 2015 executive session",
+    "start_date": "9/15/2015",
+    "end_date": "9/17/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150915.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 11, 2015 and August 13, 2015 executive session",
+    "start_date": "8/11/2015",
+    "end_date": "8/13/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150811.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 14, 2015 and July 16, 2015 executive session",
+    "start_date": "7/14/2015",
+    "end_date": "7/16/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150714.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 16, 2015 and June 18, 2015 executive session",
+    "start_date": "6/16/2015",
+    "end_date": "6/23/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150616.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150616a.pdf"
+  },
+  {
+    "title": "May 19, 2015 and May 21, 2015 executive session",
+    "start_date": "5/19/2015",
+    "end_date": "5/21/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150519.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 13, 2015 executive session",
+    "start_date": "5/13/2015",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150513.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 06, 2015 executive session",
+    "start_date": "5/6/2015",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150506.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 21, 2015 and April 23, 2015 executive session",
+    "start_date": "4/21/2015",
+    "end_date": "4/22/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150421.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150421a.pdf"
+  },
+  {
+    "title": "March 17, 2015 and March 19, 2015 executive session",
+    "start_date": "3/17/2015",
+    "end_date": "3/19/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150317.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150317a.pdf"
+  },
+  {
+    "title": "March 3, 2015 and March 5, 2015 executive session",
+    "start_date": "3/3/2015",
+    "end_date": "3/5/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150303.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 10, 2015 and February 12, 2015 executive session",
+    "start_date": "2/10/2015",
+    "end_date": "2/12/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150210.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 13, 2015 and January 15, 2015 executive session",
+    "start_date": "1/13/2015",
+    "end_date": "2/10/2015",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150113.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150113a.pdf, https://www.fec.gov/resources/updates/sunshine-notices/2015/executive/notice20150113b.pdf"
+  },
+  {
+    "title": "December 16, 2014 executive session",
+    "start_date": "12/16/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141216.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 9, 2014 executive session",
+    "start_date": "12/9/2014",
+    "end_date": "12/11/2014",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141209.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141209a.pdf"
+  },
+  {
+    "title": "November 18, 2014 executive session",
+    "start_date": "11/18/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141118.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 13, 2014 executive session",
+    "start_date": "11/13/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141113.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 6, 2014 executive session",
+    "start_date": "11/6/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141106.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 21, 2014 executive session",
+    "start_date": "10/21/2014",
+    "end_date": "10/23/2014",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141021.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141021a.pdf"
+  },
+  {
+    "title": "October 7, 2014 executive session",
+    "start_date": "10/7/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20141007.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 16, 2014 executive session",
+    "start_date": "9/16/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140916.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140916a.pdf"
+  },
+  {
+    "title": "September 9, 2014 executive session",
+    "start_date": "9/9/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140909.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 26, 2014 executive session",
+    "start_date": "8/26/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140826.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 22, 2014 executive session",
+    "start_date": "7/22/2014",
+    "end_date": "8/14/2014",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140722.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140722a.pdf, https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140722b.pdf, https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140722c.pdf"
+  },
+  {
+    "title": "July 10, 2014 executive session",
+    "start_date": "7/10/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140710.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140710a.pdf"
+  },
+  {
+    "title": "June 24, 2014 executive session",
+    "start_date": "6/24/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140624.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140624a.pdf"
+  },
+  {
+    "title": "June 10, 2014 executive session",
+    "start_date": "6/10/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140610.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140610a.pdf"
+  },
+  {
+    "title": "May 20, 2014 executive session",
+    "start_date": "5/20/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140520.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140520a.pdf"
+  },
+  {
+    "title": "May 6, 2014 executive session",
+    "start_date": "5/6/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140506.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 22, 2014 executive session",
+    "start_date": "4/22/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140422.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 1, 2014 executive session",
+    "start_date": "4/1/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140401.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 20, 2014 executive session",
+    "start_date": "3/20/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140320.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 11, 2014 executive session",
+    "start_date": "3/11/2014",
+    "end_date": "3/18/2014",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140311.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140318.pdf"
+  },
+  {
+    "title": "March 6, 2014 executive session",
+    "start_date": "3/6/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140306.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 4, 2014 executive session (canceled)",
+    "start_date": "5/4/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140304.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140304a.pdf"
+  },
+  {
+    "title": "February 25, 2014 executive session",
+    "start_date": "2/25/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140225.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 4, 2014 executive session",
+    "start_date": "2/4/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140204.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140204a.pdf"
+  },
+  {
+    "title": "January 28, 2014 executive session",
+    "start_date": "1/28/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140128.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 16, 2014 executive session",
+    "start_date": "1/16/2014",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2014/executive/notice20140116.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 17 & 19, 2013 executive session (December 19, 2013 canceled)",
+    "start_date": "12/17/2013",
+    "end_date": "12/19/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131210.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131210a.pdf"
+  },
+  {
+    "title": "December 3, 2013 executive session",
+    "start_date": "12/3/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131203.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 19, 2013 executive session",
+    "start_date": "11/19/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131119.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131119a.pdf"
+  },
+  {
+    "title": "November 7, 2013 executive session",
+    "start_date": "11/7/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131107.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 22, 2013 executive session",
+    "start_date": "10/22/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20131022.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 24, 2013 executive session (canceled)",
+    "start_date": "09/24/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130926.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 22, 2013 executive session",
+    "start_date": "9/22/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130924.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130924.pdf"
+  },
+  {
+    "title": "September 10, 2013 executive session",
+    "start_date": "9/10/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130910.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 23, 2013 executive session",
+    "start_date": "7/23/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130716.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 9, 2013 executive session",
+    "start_date": "7/9/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130702.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 27, 2013 executive session",
+    "start_date": "6/27/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130628.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 25, 2013 executive session",
+    "start_date": "6/25/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130625.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130625a.pdf"
+  },
+  {
+    "title": "June 11, 2013 executive session",
+    "start_date": "6/11/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130611.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 21, 2013 executive session",
+    "start_date": "5/21/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130521.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 7, 2013 executive session",
+    "start_date": "5/7/2013",
+    "end_date": "5/9/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130507.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130507a.pdf"
+  },
+  {
+    "title": "April 23, 2013 executive session",
+    "start_date": "4/23/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130423.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 12, 2013 executive session",
+    "start_date": "3/12/2013",
+    "end_date": "3/14/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130312.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130312a.pdf"
+  },
+  {
+    "title": "March 7, 2013 executive session",
+    "start_date": "3/7/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130311.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 26, 2013 executive session",
+    "start_date": "2/26/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130226.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 5, 2013 executive session",
+    "start_date": "2/5/2013",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130205.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 31, 2013 executive session",
+    "start_date": "1/29/2013",
+    "end_date": "1/31/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130122.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 29, 2013 executive session",
+    "start_date": "1/29/2013",
+    "end_date": "1/31/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130122.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 8, 2013 executive session",
+    "start_date": "1/8/2013",
+    "end_date": "1/10/2013",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20121228.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2013/notice20130104.pdf"
+  },
+  {
+    "title": "December 18, 2012 executive session",
+    "start_date": "12/18/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20121211.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 28, 2012 executive session",
+    "start_date": "11/28/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20121121.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 8, 2012 executive session",
+    "start_date": "11/8/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20121101.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 30, 2012 executive session",
+    "start_date": "10/30/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20121023.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 16, 2012 executive session",
+    "start_date": "10/16/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20121009.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 2, 2012 executive session",
+    "start_date": "9/27/2012",
+    "end_date": "10/2/2012",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120920.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 27, 2012 executive session",
+    "start_date": "9/27/2012",
+    "end_date": "10/2/2012",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120920.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 31, 2012 executive session",
+    "start_date": "7/31/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120724.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 10, 2012 executive session",
+    "start_date": "7/10/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120702.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 19, 2012 executive session (canceled)",
+    "start_date": "6/19/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120612.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120618.pdf"
+  },
+  {
+    "title": "June 5, 2012 executive session",
+    "start_date": "6/5/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120529.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 22, 2012 executive session",
+    "start_date": "5/22/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120515.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 8, 2012 executive session",
+    "start_date": "5/8/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120501.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 24, 2012 executive session",
+    "start_date": "4/24/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120417.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 10, 2012 executive session",
+    "start_date": "4/10/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120403.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 20, 2012 executive session",
+    "start_date": "3/20/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120313.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 28, 2012 executive session",
+    "start_date": "2/28/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120221.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120227.pdf"
+  },
+  {
+    "title": "February 13, 2012 executive session",
+    "start_date": "2/13/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120210.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 24, 2012 executive session",
+    "start_date": "1/24/2012",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2012/notice20120117.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 14, 2011 executive session",
+    "start_date": "12/14/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111207.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 13, 2011 executive session",
+    "start_date": "12/13/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111206.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 29, 2011 executive session",
+    "start_date": "11/29/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111129.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 17, 2011 executive session",
+    "start_date": "11/16/2011",
+    "end_date": "11/17/2011",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111116.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 16, 2011 executive session",
+    "start_date": "11/16/2011",
+    "end_date": "11/17/2011",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111116.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 15, 2011 executive session",
+    "start_date": "11/15/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111118.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111114_a.pdf"
+  },
+  {
+    "title": "November 9, 2011 executive session",
+    "start_date": "11/9/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111110.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 18, 2011 executive session",
+    "start_date": "10/18/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20111011.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 4, 2011 executive session",
+    "start_date": "10/4/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110927.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 13 & 15, 2011 executive session (September 13, 2011 meeting canceled)",
+    "start_date": "9/15/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110906.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110913.pdf"
+  },
+  {
+    "title": "August 30, 2011 executive session",
+    "start_date": "8/30/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110824.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 02, 2011 executive session",
+    "start_date": "8/2/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110725.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 19, 2011 executive session",
+    "start_date": "7/19/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110712.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 28, 2011 executive session",
+    "start_date": "6/28/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110621.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 14, 2011 executive session",
+    "start_date": "6/14/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110607.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 24, 2011 executive session",
+    "start_date": "5/24/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110517.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 3, 2011 executive session",
+    "start_date": "5/3/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110426.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 26, 2011 executive session",
+    "start_date": "4/26/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110419.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 5, 2011 executive session",
+    "start_date": "4/5/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110330.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 15, 2011 executive session",
+    "start_date": "3/15/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110308.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 16, 2011 executive session",
+    "start_date": "2/16/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110210.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 1, 2011 executive session",
+    "start_date": "2/1/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110125.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 19, 2011 executive session",
+    "start_date": "1/19/2011",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2011/notice20110111.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 14, 2010 executive session",
+    "start_date": "12/14/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20101210_Apdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 9, 2010 executive session",
+    "start_date": "12/9/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20101210pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 1, 2010 executive session",
+    "start_date": "12/1/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20101126pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 16, 2010 executive session",
+    "start_date": "11/16/2010",
+    "end_date": "",
+    "notice_link": "http://classic.fec.gov/sunshine/2010/notice20101112pdf.pdf (link is broken however, and filename doesn't work in the new directory)",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 19, 2010 executive session",
+    "start_date": "10/19/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20101014pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 5, 2010 executive session",
+    "start_date": "10/5/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100930pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 21, 2010 executive session",
+    "start_date": "9/21/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100916pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 24, 2010 executive session",
+    "start_date": "8/24/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100823pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 27, 2010 executive session",
+    "start_date": "7/27/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100721pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 14, 2010 executive session",
+    "start_date": "7/14/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100714pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 29, 2010 executive session",
+    "start_date": "6/29/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100622pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 15, 2010 executive session",
+    "start_date": "6/15/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100608pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 25, 2010 executive session",
+    "start_date": "5/25/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100518pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 27, 2010 executive session",
+    "start_date": "4/27/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100420pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 13, 2010 executive session",
+    "start_date": "4/13/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100406pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 17, 2010 executive session",
+    "start_date": "3/17/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100308pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 24, 2010 executive session",
+    "start_date": "2/24/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100217pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 2, 2010 executive session",
+    "start_date": "2/2/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100126pdf.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 12, 2010 executive session",
+    "start_date": "1/12/2010",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2010/notice20100112.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 15, 2009 executive session",
+    "start_date": "12/15/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091208.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 1. 2009 executive session",
+    "start_date": "12/1/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091125.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 19, 2009 executive session",
+    "start_date": "11/19/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091117.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 17, 2009 executive session",
+    "start_date": "11/17/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091110.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 3, 2009 executive session",
+    "start_date": "11/3/2009",
+    "end_date": "11/4/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091027.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 20, 2009 executive session",
+    "start_date": "10/20/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20091013.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 6, 2009 executive session",
+    "start_date": "10/6/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090917.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 23, 2009 executive session",
+    "start_date": "9/23/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090917.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 1, 2009 executive session",
+    "start_date": "9/1/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090831.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 25 & 26, 2009 executive session",
+    "start_date": "8/25/2009",
+    "end_date": "8/26/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090820.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 29, 2009 executive session",
+    "start_date": "7/28/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090722.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 14 and 15, 2009 executive session",
+    "start_date": "7/14/2009",
+    "end_date": "7/15/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090709.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 24, 2009 executive session",
+    "start_date": "6/24/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090617.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 12 and 13, 2009 executive session",
+    "start_date": "5/12/2009",
+    "end_date": "5/13/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090506.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 5 and 6, 2009 executive session",
+    "start_date": "5/5/2009",
+    "end_date": "5/6/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090428.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 30, 2009 executive session",
+    "start_date": "4/30/2009",
+    "end_date": "5/5/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090428.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 28 and 29, 2009 executive session (canceled)",
+    "start_date": "4/28/2009",
+    "end_date": "4/29/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090421.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090428.pdf"
+  },
+  {
+    "title": "April 21, and 22, 2009 executive session",
+    "start_date": "4/21/2009",
+    "end_date": "4/22/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090414.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 14 and 15, 2009 executive session",
+    "start_date": "4/14/2009",
+    "end_date": "4/15/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090406.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 18, 2009 executive session",
+    "start_date": "3/18/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090313.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 10 and 11, 2009 executive session",
+    "start_date": "3/10/2009",
+    "end_date": "3/11/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090303.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 4 and 5, 2009 executive session",
+    "start_date": "3/4/2009",
+    "end_date": "3/5/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090227.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 3, 2009 executive session (canceled)",
+    "start_date": "3/3/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090227.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 24, 2009 executive session (canceled)",
+    "start_date": "2/24/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090213.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090227.pdf"
+  },
+  {
+    "title": "February 24 and 25,2009 executive session",
+    "start_date": "2/25/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090213.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 10 and 11, 2009 executive session",
+    "start_date": "2/10/2009",
+    "end_date": "2/11/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090203.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 3, 2009 executive session",
+    "start_date": "2/3/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090127.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 27, 2009 executive session",
+    "start_date": "1/27/2009",
+    "end_date": "1/28/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090116.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 28, 2009 executive session",
+    "start_date": "1/27/2009",
+    "end_date": "1/28/2009",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090116.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 13, 2009 executive session",
+    "start_date": "1/13/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2009/notice20090107.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 9, 2009 executive session",
+    "start_date": "1/9/2009",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081231.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 16, 2008 executive session",
+    "start_date": "12/16/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081209.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 2, 2008 executive session",
+    "start_date": "12/2/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081125.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 18, 2008 executive session",
+    "start_date": "11/18/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081110.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 7, 2008 executive session",
+    "start_date": "11/7/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081031.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 21, 2008 executive session",
+    "start_date": "10/21/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20081009.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 7, 2008 executive session",
+    "start_date": "10/7/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20080925.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 10.2008 executive session",
+    "start_date": "9/10/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20080903.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 19, 2008 executive session",
+    "start_date": "8/19/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20080812.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 15, 2008 executive session",
+    "start_date": "7/15/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice20080715.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 17, 2008 executive session",
+    "start_date": "6/17/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice061608.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 6, 2008 executive session",
+    "start_date": "5/6/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice04302008.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 18, 2008 executive session",
+    "start_date": "3/18/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice2008-03-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 20, 2008 executive session",
+    "start_date": "2/20/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice021408.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 23, 2008 executive session",
+    "start_date": "1/23/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice2008-01-23.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 8, 2008 executive session",
+    "start_date": "1/8/2008",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2008/notice01022008.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 18, 2007 executive session",
+    "start_date": "12/18/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-12-10.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 6, 2007 executive session",
+    "start_date": "12/6/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-12-03.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 14, 2007 executive session",
+    "start_date": "11/14/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-11-07.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 23, 2007 executive session",
+    "start_date": "10/23/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-10-18.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 10, 2007 executive session",
+    "start_date": "10/10/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-10-03.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 20, 2007 executive session",
+    "start_date": "9/20/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-09-14.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 1, 2007 executive session",
+    "start_date": "8/1/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-07-27.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 24, 2007 executive session",
+    "start_date": "7/24/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-07-19.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 12, 2007 executive session",
+    "start_date": "7/12/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-07-11.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 26, 2007 executive session",
+    "start_date": "6/26/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-06-21.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 1, 2007 executive session",
+    "start_date": "5/1/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-04-26.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 17, 2007 executive session",
+    "start_date": "4/17/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-04-10-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 10, 2007 executive session",
+    "start_date": "4/10/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-04-05-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 20, 2007 executive session",
+    "start_date": "3/20/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-03-15-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 6, 2007 executive session",
+    "start_date": "3/6/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-03-01-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 21, 2007 executive session",
+    "start_date": "2/21/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-02-20a-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 6, 2007 executive session",
+    "start_date": "2/6/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-02-01-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 23, 2007 executive session",
+    "start_date": "1/11/2007",
+    "end_date": "1/23/2007",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2007/notice2007-01-18-.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 9, 2007 executive session",
+    "start_date": "1/9/2007",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-12-20.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 12, 2006 executive session",
+    "start_date": "12/12/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-12-07.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 28, 2006 executive session",
+    "start_date": "11/28/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-11-16.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 8, 2006 executive session",
+    "start_date": "11/8/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-11-03.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 17, 2006 executive session",
+    "start_date": "10/17/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-10-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 3, 2006 executive session",
+    "start_date": "10/3/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-09-28.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 3, 2006 executive session",
+    "start_date": "8/1/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-07-27.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 19, 2006 executive session",
+    "start_date": "7/18/2006",
+    "end_date": "7/19/2006",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-07-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 18, 2006 executive session",
+    "start_date": "7/18/2006",
+    "end_date": "7/19/2006",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-07-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 11 , 2006 executive session",
+    "start_date": "7/11/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-07-06.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 20, 2006 executive session",
+    "start_date": "6/20/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-06-15.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 13, 2006 executive session",
+    "start_date": "6/13/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-06-09.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 6, 2006 executive session",
+    "start_date": "6/6/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-06-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 16, 2006 executive session",
+    "start_date": "5/16/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-05-11.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 2, 2006 executive session",
+    "start_date": "5/2/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-04-27.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 19, 2006 executive session",
+    "start_date": "4/19/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-04-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 18, 2006 executive session",
+    "start_date": "4/18/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-04-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 4, 2006 executive session",
+    "start_date": "4/4/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-03-24.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 21, 2006 executive session",
+    "start_date": "3/21/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-03-10.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 14, 2006 executive session",
+    "start_date": "3/14/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-03-17.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 21, 2006 executive session",
+    "start_date": "2/21/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-02-15.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 16, 2006 Special Executive Session executive session",
+    "start_date": "2/16/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-02-17.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 7, 2006 executive session (rescheduled for February 9, 2006)",
+    "start_date": "2/9/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-02-02.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-02-15.pdf"
+  },
+  {
+    "title": "January 17, 2006 executive session",
+    "start_date": "1/17/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-01-12.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 10, 2006 executive session (canceled)",
+    "start_date": "1/10/2006",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-01-05.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2006/notice2006-01-12.pdf"
+  },
+  {
+    "title": "December 13, 2005 executive session",
+    "start_date": "12/13/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-12-08.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 7, 2005 executive session",
+    "start_date": "12/7/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-12-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 15, 2005 executive session",
+    "start_date": "11/15/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-11-10.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 1, 2005 executive session",
+    "start_date": "11/1/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-10-27.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 18, 2005 executive session",
+    "start_date": "10/20/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-10-13.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-10-27.pdf"
+  },
+  {
+    "title": "October 6, 2005 executive session",
+    "start_date": "10/6/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-09-30.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 27, 2005 executive session",
+    "start_date": "9/27/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-09-22.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 20, 2005 executive session",
+    "start_date": "9/20/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-09-15.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 16, 2005 executive session",
+    "start_date": "8/16/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-08-11.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 9, 2005 executive session (canceled)",
+    "start_date": "4/9/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-08-11.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July19, 2005 executive session",
+    "start_date": "7/19/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-07-14.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 12, 2005 executive session",
+    "start_date": "7/12/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-07-07.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 21, 2005 executive session",
+    "start_date": "6/21/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-06-16.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 19, 2005 executive session",
+    "start_date": "5/19/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-05-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 3, 2005 executive session",
+    "start_date": "5/3/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-04-28.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 19, 2005 executive session",
+    "start_date": "4/19/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-04-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 5, 2005 executive session",
+    "start_date": "4/5/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-03-31.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 22, 2005 executive session",
+    "start_date": "3/22/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-03-18.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 8 , 2005 executive session",
+    "start_date": "3/8/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-03-02.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 15, 2005 executive session (canceled)",
+    "start_date": "2/15/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-02-07.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-03-02.pdf"
+  },
+  {
+    "title": "February 8, 2005 executive session",
+    "start_date": "2/8/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-02-03.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 25, 2005 executive session (canceled)",
+    "start_date": "1/25/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-01-19.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-02-03.pdf"
+  },
+  {
+    "title": "January 11, 2005 executive session",
+    "start_date": "1/11/2005",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2005/notice2005-01-06.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 14, 2004 executive session",
+    "start_date": "12/14/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-12-10.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 30, 2004 executive session",
+    "start_date": "11/30/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-11-24.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 16, 2004 executive session (canceled)",
+    "start_date": "11/16/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-11-12.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-11-24.pdf"
+  },
+  {
+    "title": "November 9, 2004 executive session",
+    "start_date": "11/9/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-11-02.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 28, 2004 executive session",
+    "start_date": "11/28/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-10-22.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 19, 2004 executive session",
+    "start_date": "10/19/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-10-14.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 5, 2004 executive session (canceled)",
+    "start_date": "10/5/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-09-30.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 28, 2004 executive session",
+    "start_date": "9/28/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-09-23.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 14, 2004 executive session",
+    "start_date": "9/14/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-09-02.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 17, 2004 executive session",
+    "start_date": "8/17/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-08-12.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 10, 2004 executive session",
+    "start_date": "8/10/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-08-05.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 20, 2004 executive session",
+    "start_date": "7/20/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/notice2004-07-15.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 13, 2004 executive session",
+    "start_date": "7/13/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-15664.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 22, 2004 executive session",
+    "start_date": "6/22/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-13763.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 8, 2004 executive session",
+    "start_date": "6/8/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-12673.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 18, 2004 executive session",
+    "start_date": "5/18/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-10904.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 11, 2004 executive session (canceled)",
+    "start_date": "5/11/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-10386.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-10904.pdf"
+  },
+  {
+    "title": "April 27, 2004 executive session",
+    "start_date": "4/27/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-9322.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 13, 2004 executive session",
+    "start_date": "4/13/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-8124.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 30, 2004 executive session",
+    "start_date": "3/30/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-6866.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 23, 2004 executive session",
+    "start_date": "3/23/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-6194.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 9, 2004 executive session",
+    "start_date": "3/9/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-4353.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 24, 2004 executive session",
+    "start_date": "2/24/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-3185.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 17, 2004 executive session",
+    "start_date": "2/17/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-4008.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 3, 2004 executive session",
+    "start_date": "2/3/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-1964.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 27, 2004 executive session",
+    "start_date": "1/27/2004",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2004/04-1499.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 15, 2003 executive session (rescheduled from December 16, 2003)",
+    "start_date": "12/15/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n233p67849.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n238p69083.pdf"
+  },
+  {
+    "title": "December 2, 2003 executive session (canceled)",
+    "start_date": "12/2/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n229p66828.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n233p67849.pdf"
+  },
+  {
+    "title": "November 18, 2003 executive session",
+    "start_date": "11/18/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n220p64625.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 4, 2003 executive session",
+    "start_date": "11/4/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/03-27472.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 21, 2003 executive session",
+    "start_date": "10/21/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n200p59615.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 9, 2003 executive session",
+    "start_date": "10/9/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n192p57461.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n196p58347.pdf"
+  },
+  {
+    "title": "September 30, 2003 executive session",
+    "start_date": "9/30/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n186p55390.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 8, 2003 executive session",
+    "start_date": "9/8/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n171p52586.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 27, 2003 executive session",
+    "start_date": "8/27/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n162p50540.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 12, 2003 executive session",
+    "start_date": "8/12/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n152p47062.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 31, 2003 executive session",
+    "start_date": "7/31/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n142p43726.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 29, 2003 executive session (canceled)",
+    "start_date": "6/29/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n142p43726.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n152p47062.pdf"
+  },
+  {
+    "title": "July 22, 2003 executive session",
+    "start_date": "7/22/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n136p42058.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 15, 2003 executive session (canceled)",
+    "start_date": "6/15/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n132p41134.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n136p42058.pdf"
+  },
+  {
+    "title": "July 8, 2003 executive session",
+    "start_date": "7/8/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n128p39947.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 3, 2003 executive session",
+    "start_date": "7/3/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n128p39947.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 23, 2003 executive session",
+    "start_date": "6/23/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n117p36550.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 10, 2003 executive session",
+    "start_date": "6/10/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n109p33950.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 3, 2003 executive session (canceled)",
+    "start_date": "6/3/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n103p32039.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n109p33950.pdf"
+  },
+  {
+    "title": "May 20, 2003 executive session",
+    "start_date": "5/20/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n093p25888.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 13, 2003 executive session",
+    "start_date": "5/13/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n089p24741.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 6, 2003 executive session",
+    "start_date": "5/6/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n083p23136.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 22, 2003 executive session",
+    "start_date": "4/22/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/03-9586.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 8, 2003 executive session",
+    "start_date": "4/8/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n064p16283.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 1, 2003 executive session",
+    "start_date": "4/1/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n059p14981.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 25, 2003 executive session (canceled)",
+    "start_date": "5/25/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n054p13708.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n059p14981.pdf"
+  },
+  {
+    "title": "March 18, 2003 executive session",
+    "start_date": "3/18/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n049p12076.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 4, 2003 executive session",
+    "start_date": "3/4/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n039p09081.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 25, 2003 executive session",
+    "start_date": "2/25/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n036p08608.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 11, 2003 executive session",
+    "start_date": "2/11/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n025p06174.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 4, 2003 executive session",
+    "start_date": "2/4/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n020p04785.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 28, 2003 executive session (canceled)",
+    "start_date": "1/28/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n015p03253.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n020p04785.pdf"
+  },
+  {
+    "title": "January 14, 2003 executive session",
+    "start_date": "1/14/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n006p01187.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 7, 2003 executive session",
+    "start_date": "1/7/2003",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2003/fr68n002p00375.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 10, 2002 executive session",
+    "start_date": "12/10/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n234p72422.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 7, 2002 executive session",
+    "start_date": "12/7/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n230p71175.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 5, 2002 executive session",
+    "start_date": "12/5/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n230p71175.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 19, 2002 executive session",
+    "start_date": "11/19/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n220p69012.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 5, 2002 executive session",
+    "start_date": "11/5/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n211p66403.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 29, 2002 executive session (canceled)",
+    "start_date": "10/29/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n206p65354.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n211p66403.pdf"
+  },
+  {
+    "title": "October 22, 2002 executive session",
+    "start_date": "10/22/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n201p64121.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 8, 2002 executive session (canceled)",
+    "start_date": "10/8/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n191p61883.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n201p64121.pdf"
+  },
+  {
+    "title": "September 24, 2002 executive session",
+    "start_date": "9/24/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n182p59059.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 17, 2002 executive session (canceled)",
+    "start_date": "9/17/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n177p57816.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n182p59059.pdf"
+  },
+  {
+    "title": "September 10, 2002 executive session",
+    "start_date": "9/10/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n172p56834.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 27, 2002 executive session",
+    "start_date": "8/27/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n163p54422.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 20, 2002 executive session (canceled)",
+    "start_date": "8/20/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n158p53352.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n163p54422.pdf"
+  },
+  {
+    "title": "August 13, 2002 executive session",
+    "start_date": "8/13/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n153p51583.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 30, 2002 executive session",
+    "start_date": "7/30/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n143p48651.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 23, 2002 executive session",
+    "start_date": "7/23/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n138p47364.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 16, 2002 executive session",
+    "start_date": "7/16/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n133p45980.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 25, 2002 executive session (rescheduled)",
+    "start_date": "6/26/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n119p41996.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n133p45980.pdf"
+  },
+  {
+    "title": "June 18, 2002 executive session (canceled)",
+    "start_date": "6/18/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n114p40743.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n119p41996.pdf"
+  },
+  {
+    "title": "June 11, 2002 executive session",
+    "start_date": "6/11/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n109p39008.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 3, 2002 executive session (rescheduled)",
+    "start_date": "6/3/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n104p37804.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 21, 2002 executive session",
+    "start_date": "5/21/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n095p34927.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 14, 2002 executive session (canceled)",
+    "start_date": "5/14/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-05-09.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/fr67n095p34927.pdf"
+  },
+  {
+    "title": "May 7, 2002 executive session",
+    "start_date": "5/7/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-05-02.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 27, 2002 executive session (canceled)",
+    "start_date": "4/27/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-05-02.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 16, 2002 executive session",
+    "start_date": "4/16/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-04-11.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 10, 2002 executive session (rescheduled from April 9, 2002)",
+    "start_date": "4/10/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-04-04.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 19, 2002 executive session",
+    "start_date": "3/19/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-03-13.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 12, 2002 executive session",
+    "start_date": "3/12/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-03-07.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 26, 2002 executive session",
+    "start_date": "2/26/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-02-21.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 20, 2002 executive session",
+    "start_date": "2/20/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-02-14.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 12, 2002 executive session",
+    "start_date": "2/12/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-02-07.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 29, 2002 executive session",
+    "start_date": "1/29/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-01-24.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 23, 2002 executive session",
+    "start_date": "1/23/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-01-18.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 15, 2002 executive session",
+    "start_date": "1/15/2002",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2002/notice2002-01-10.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 11, 2001 executive session",
+    "start_date": "12/11/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice12-06-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 6, 2001 executive session",
+    "start_date": "12/6/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice11-29-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "December 4, 2001 executive session (canceled)",
+    "start_date": "12/4/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice11-29-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 27, 2001 executive session",
+    "start_date": "11/27/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice11-21-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "November 14, 2001 executive session (canceled)",
+    "start_date": "11/14/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice11-08-01.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice11-21-01.pdf"
+  },
+  {
+    "title": "November 6, 2001 executive session",
+    "start_date": "11/6/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice10-31-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "October 30, 2001 executive session",
+    "start_date": "10/30/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice10-25-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "September 25, 2001 executive session",
+    "start_date": "9/25/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice09-19-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 21, 2001 executive session",
+    "start_date": "8/21/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice08-16-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "August 7, 2001 executive session",
+    "start_date": "8/7/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice08-02-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 24, 2001 executive session",
+    "start_date": "7/24/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice07-19-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "July 10, 2001 executive session",
+    "start_date": "7/10/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice07-06-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 26, 2001 executive session",
+    "start_date": "6/26/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice06-20-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 19, 2001 executive session",
+    "start_date": "6/19/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice06-13-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 7, 2001 executive session",
+    "start_date": "6/7/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice06-01-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "June 5, 2001 executive session (canceled)",
+    "start_date": "6/5/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice06-01-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 22, 2001 executive session",
+    "start_date": "5/22/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice05-17-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 15, 2001 executive session",
+    "start_date": "5/15/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice05-10-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "May 8, 2001 executive session",
+    "start_date": "5/8/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice05-03-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 17, 2001 executive session",
+    "start_date": "4/17/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice04-11-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "April 3, 2001 executive session",
+    "start_date": "4/3/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-28-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 27, 2001 executive session",
+    "start_date": "3/27/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-21-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 20, 2001 executive session",
+    "start_date": "3/20/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-15-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 13, 2001 executive session",
+    "start_date": "3/13/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-08-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 6, 2001 executive session",
+    "start_date": "3/6/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-01-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "March 1, 2001 executive session",
+    "start_date": "3/1/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-08-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 27, 2001 executive session (canceled)",
+    "start_date": "2/27/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice02-22-01.pdf",
+    "second_notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice03-01-01.pdf"
+  },
+  {
+    "title": "February 13, 2001 executive session",
+    "start_date": "2/13/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice02-08-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "February 6, 2001 executive session",
+    "start_date": "2/6/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice01-31-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 30, 2001 executive session",
+    "start_date": "1/30/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice01-26-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 23, 2001 executive session",
+    "start_date": "1/23/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice01-18-01.pdf",
+    "second_notice_link": ""
+  },
+  {
+    "title": "January 9, 2001 executive session",
+    "start_date": "1/9/2001",
+    "end_date": "",
+    "notice_link": "https://www.fec.gov/resources/updates/sunshine-notices/2001/notice01-04-01.pdf",
+    "second_notice_link": ""
+  }
+]


### PR DESCRIPTION
This adds an import script and json file to import the pre-2017 executive session sunshine notices.

![image](https://user-images.githubusercontent.com/1696495/27302963-f3a79a76-54ed-11e7-9a6e-f40dabb56c5e.png)

Major thanks to @dorothyyeager for the heavy lifting on gathering the data!

Resolves https://github.com/18F/fec-cms/issues/980