### PR TITLE
Lowercase "serving"

### DIFF
--- a/fec/home/templates/home/commissioner_page.html
+++ b/fec/home/templates/home/commissioner_page.html
@@ -32,7 +32,7 @@
           ({{ self.reappointed_dates }})
           {% endif %}
         {% else %}
-          Currently Serving
+          Currently serving
         {% endif %}
         </div>
       </div>


### PR DESCRIPTION
`Currently Serving` > `Currently serving` for commissioner terms

As seen:
<img width="1024" alt="screen shot 2017-06-22 at 3 57 01 pm" src="https://user-images.githubusercontent.com/11636908/27453167-85ad892c-5763-11e7-9c77-b3bfb37fdb96.png">

