### PR TITLE
Hide django-admin unless in debug mode

### DIFF
--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -50,4 +50,4 @@ if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
     #hide django-admin unless DEBUG=True
-    urlpatterns.insert(0,url(r'^django-admin/', include(admin.site.urls)))
+    urlpatterns.insert(1,url(r'^django-admin/', include(admin.site.urls)))

--- a/fec/fec/urls.py
+++ b/fec/fec/urls.py
@@ -15,7 +15,6 @@ from search import views as search_views
 
 urlpatterns = [
     url(r'^documents/(\d+)/(.*)$', home_views.serve_wagtail_doc, name='wagtaildocs_serve'),
-    url(r'^django-admin/', include(admin.site.urls)),
     url(r'^auth/', include(uaa_urls)),
     url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^calendar/$', home_views.calendar),
@@ -49,3 +48,6 @@ if settings.DEBUG:
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+    #hide django-admin unless DEBUG=True
+    urlpatterns.insert(0,url(r'^django-admin/', include(admin.site.urls)))


### PR DESCRIPTION
After pointing out that /django-admin shows the Django admin interface, @LindsayYoung and @ccostino asked me to do a PR to make it so you would only see this if in debug mode. I removed the URL pattern for this in the global urlpatterns and added it to the "if DEBUG" section.

With this change,  locally , If I set ```DEBUG= False``` in fec/settings/dev.py, the Django admin does not show, setting it to true makes it show. I am not sure how this fits in with production.py and base.py on the live site. 

If this is wrong or incomplete and it requires adding a setting/change to base.py and/or production.py, please let me know and I can make the change. At least this PR gets the change started.