### PR TITLE
Implemented Custom Domain Path for CMS Uploads

### DIFF
--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -244,6 +244,7 @@ if FEC_CMS_ENVIRONMENT != 'LOCAL':
     AWS_ACCESS_KEY_ID = env.get_credential('CMS_AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = env.get_credential('CMS_AWS_SECRET_ACCESS_KEY')
     AWS_STORAGE_BUCKET_NAME = env.get_credential('CMS_AWS_STORAGE_BUCKET_NAME')
+    AWS_S3_CUSTOM_DOMAIN = env.get_credential('CMS_AWS_CUSTOM_DOMAIN')
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_LOCATION = 'cms-content'
     AWS_S3_REGION_NAME = env.get_credential('CMS_AWS_DEFAULT_REGION')


### PR DESCRIPTION
This resolves issue #1140 

Note that this will require an additional environmental variable added to set the custom path variable `CMS_AWS_CUSTOM_DOMAIN=www.fec.gov/resources`

This PR allows us to maintain user friendly URLs when accessing content uploaded to CMS.