### PR TITLE
Multiple numbered, amended Sunshine Act notices

### DIFF
--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -40,13 +40,9 @@
         {% for link in update.sunshine_act_links|splitlines %}
           <li>
             <a class="pdf-link" href="{{ link }}">
-              {% if forloop.counter == 1 %}
-              Sunshine Act Notice
-              {% else %}
-              Amended Sunshine Act Notice
-              - 
-              {{ forloop.counter0 }}
-              {% endif %}
+            {% if forloop.counter >= 2 %}Amended{% endif %}
+            Sunshine Act Notice
+            {% if update.sunshine_act_links|splitlines|length > 2 and forloop.counter >= 2 %}- {{ forloop.counter0 }}{% endif %}
             </a>
           </li>
         {% endfor %}

--- a/fec/fec/templates/partials/update.html
+++ b/fec/fec/templates/partials/update.html
@@ -37,11 +37,18 @@
         {% endfor %}
         {% endif %}
         {% if update.sunshine_act_links %}
-        {% for link in update.sunshine_act_links|splitlines reversed %}
-          <li><a href="{{ link }}">
-            {% if update.sunshine_act_links|splitlines|length > 1 and forloop.counter == 1%}Amended{% endif %}
-            Sunshine Act Notice
-          </a></li>
+        {% for link in update.sunshine_act_links|splitlines %}
+          <li>
+            <a class="pdf-link" href="{{ link }}">
+              {% if forloop.counter == 1 %}
+              Sunshine Act Notice
+              {% else %}
+              Amended Sunshine Act Notice
+              - 
+              {{ forloop.counter0 }}
+              {% endif %}
+            </a>
+          </li>
         {% endfor %}
         {% endif %}
         </ul>

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -123,12 +123,17 @@
       <h2 class="u-no-margin">Notices about this meeting</h2>
       <div class="list--spacious">
       <ul>
-      {% for link in self.sunshine_act_links|splitlines reversed %}
+      {% for link in self.sunshine_act_links|splitlines %}
         <li>
           <p>
             <a class="pdf-link" href="{{ link }}">
-              {% if self.sunshine_act_links|splitlines|length > 1 and forloop.counter == 1%}Amended{% endif %}
+              {% if forloop.counter == 1 %}
               Sunshine Act Notice
+              {% else %}
+              Amended Sunshine Act Notice
+              - 
+              {{ forloop.counter0 }}
+              {% endif %}
             </a>
           </p>
         </li>

--- a/fec/home/templates/home/meeting_page.html
+++ b/fec/home/templates/home/meeting_page.html
@@ -126,15 +126,11 @@
       {% for link in self.sunshine_act_links|splitlines %}
         <li>
           <p>
-            <a class="pdf-link" href="{{ link }}">
-              {% if forloop.counter == 1 %}
-              Sunshine Act Notice
-              {% else %}
-              Amended Sunshine Act Notice
-              - 
-              {{ forloop.counter0 }}
-              {% endif %}
-            </a>
+           <a class="pdf-link" href="{{ link }}">
+            {% if forloop.counter >= 2 %}Amended{% endif %}
+            Sunshine Act Notice
+            {% if self.sunshine_act_links|splitlines|length > 2 and forloop.counter >= 2%}- {{ forloop.counter0 }}{% endif %}
+           </a>
           </p>
         </li>
       {% endfor %}


### PR DESCRIPTION
Issue https://github.com/18F/fec-cms/issues/1144
Show multiple amended Sunshine Act notices with numbers. One change made to the meeting_page.html template is to show the notices in the order they are added to the field rather than reversed (newest first). If I left them reversed it was over-complicated to get the order correct, but adding the numbers solves any confusion with that on the rendered page.
## **New:**
![new_multiple_sunshines](https://user-images.githubusercontent.com/5572856/28443952-81616cf0-6d87-11e7-912e-601910b7086c.gif)
![new_multiple_sunshines_upates](https://user-images.githubusercontent.com/5572856/28443953-87f6a3a0-6d87-11e7-8dfd-6e850a934f4d.gif)