### PR TITLE
Feature/1139 about menu site nav

### DIFF
--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -117,18 +117,13 @@
 
         <div class="grid grid--6-wide">
 
-          <div class="grid__item"></div>
-
           <div class="grid__item">
             <ul>
               <li>
-                <a href="/about/">About the FEC</a>
+                <a href="/about/">About</a>
               </li>
               <li>
                 <a href="/about/careers/">Careers</a>
-              </li>
-              <li>
-                <a href="/contact-us/">Contact</a>
               </li>
               <li>
                 {% if self.title == "Homepage" or self.title == "Home" %}
@@ -136,9 +131,13 @@
                 {% endif %}
                 <a href="/press/">Press</a>
               </li>
+              <li>
+                <a href="/contact-us/">Contact</a>
+              </li>
             </ul>
           </div>
-
+          <div class="grid__item"></div>
+          <div class="grid__item"></div>
           <div class="grid__item">
             <ul>
               <li>
@@ -152,20 +151,6 @@
               </li>
               <li>
                 <a href="/about/reports-about-fec/strategy-budget-and-performance/">Strategy, budget and performance</a>
-              </li>
-            </ul>
-          </div>
-
-          <div class="grid__item">
-            <ul>
-              <li>
-                <a href="https://api.open.fec.gov/">OpenFEC API</a>
-              </li>
-              <li>
-                <a href="https://github.com/18F/fec">GitHub repository</a>
-              </li>
-              <li>
-                <a href="https://github.com/18F/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
               </li>
             </ul>
           </div>
@@ -190,7 +175,13 @@
           <div class="grid__item">
             <ul>
               <li>
-                <a href="{{ cms_url }}/updates/">Latest updates</a>
+                <a href="https://api.open.fec.gov/">OpenFEC API</a>
+              </li>
+              <li>
+                <a href="https://github.com/18F/fec">GitHub repository</a>
+              </li>
+              <li>
+                <a href="https://github.com/18F/FEC/blob/master/release_notes/release_notes.md">Release notes</a>
               </li>
             </ul>
           </div>

--- a/fec/fec/templates/partials/navigation.html
+++ b/fec/fec/templates/partials/navigation.html
@@ -22,6 +22,11 @@
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>
+      <li class="site-nav__item" data-submenu="about">
+        <a href="{{ cms_url }}/about" tabindex="0" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}">
+          <span class="site-nav__link__title">About</span>
+        </a>
+      </li>
       <li class="site-nav__item utility-nav__item u-under-lg-only">
         <a class="site-nav__link" href="/calendar">Calendar</a>
       </li>

--- a/fec/fec/templates/partials/navigation.html
+++ b/fec/fec/templates/partials/navigation.html
@@ -22,7 +22,7 @@
           <span class="site-nav__link__title">Legal resources</span>
         </a>
       </li>
-      <li class="site-nav__item" data-submenu="about">
+      <li class="site-nav__item--secondary" data-submenu="about">
         <a href="{{ cms_url }}/about" tabindex="0" class="site-nav__link {% if self.content_section == 'about' %}is-parent{% endif %}">
           <span class="site-nav__link__title">About</span>
         </a>


### PR DESCRIPTION
This is work to add the About menu to the main navigation of the fec-cms: 18F/fec-cms#1139

Also updated the footer to reflect appropriate changes in issue.

Dependent on fec-style PR here: 18F/fec-style#748