### PR TITLE
Changing ID of container for campaign guidance sections

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -56,7 +56,7 @@
 
     {% include 'partials/section-nav.html' with sections=self.sections container='options' %}
 
-    <div class="row" id="section-container">
+    <div class="row" id="campaign-guidance">
       <div class="main__content--right">
         {{ self.sections }}
       </div>


### PR DESCRIPTION
This adds an ID for `#campaign-guidance` to the div that contains the sections on Help for candidates and committees so that the new nav link from https://github.com/18F/fec-style/pull/752 takes you to the right place.