### PR TITLE
Removing line about archived murs not being included

### DIFF
--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -19,7 +19,7 @@
     <span class="t-note t-sans search__example">Examples: filings; 2405</span>
     <div class="message message--info">
       <h3>This feature is still in progress</h3>
-      <p>We're actively building the <strong>MUR search</strong> feature. Results don't include most of the cases closed between 1975 and 1998. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|classic_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
+      <p>We're actively building the <strong>MUR search</strong> feature. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|classic_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This removes the line about the archived MURs not being included on enforcement page:
![image](https://user-images.githubusercontent.com/1696495/28900752-63a1e5de-77a8-11e7-938b-9b320b774875.png)
