### PR TITLE
Adding custom admin panels for news and updates

### DIFF
--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -1,20 +1,8 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
 from wagtail.wagtailcore import hooks
 
-from .models import Author
+from .models import Author, PressReleasePage, DigestPage, TipsForTreasurersPage, RecordPage
 from search.utils.search_indexing import handle_page_edit_or_create, handle_page_delete
-
-class AuthorAdmin(ModelAdmin):
-    model = Author
-    menu_icon = 'user'
-    menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
-    add_to_settings_menu = False  # or True to add your model to the Settings sub-menu
-    list_display = ('name', 'title', 'email')
-    list_filter = ()
-    search_fields = ('name', 'title', 'email')
-
-
-modeladmin_register(AuthorAdmin)
 
 
 @hooks.register('after_create_page')
@@ -30,3 +18,54 @@ def search_update(request, page):
 @hooks.register('after_delete_page')
 def remove_page(request, page):
     handle_page_delete(page.id)
+
+class AuthorAdmin(ModelAdmin):
+    model = Author
+    menu_icon = 'user'
+    menu_order = 300  # will put in 3rd place (000 being 1st, 100 2nd)
+    add_to_settings_menu = False  # or True to add your model to the Settings sub-menu
+    list_display = ('name', 'title', 'email')
+    list_filter = ()
+    search_fields = ('name', 'title', 'email')
+
+
+class PressReleaseModelAdmin(ModelAdmin):
+    menu_label = 'Press releases'
+    model = PressReleasePage
+    ordering = ['-date']
+    list_display = ('title', 'date', 'category')
+
+
+class DigestPageModelAdmin(ModelAdmin):
+    menu_label = 'Weekly digests'
+    model = DigestPage
+    ordering = ['-date']
+    list_display = ('title', 'date')
+
+
+class TipsForTreasurersPageModelAdmin(ModelAdmin):
+    menu_label = 'Tips for Treasurers'
+    model = TipsForTreasurersPage
+    ordering = ['-date']
+    list_display = ('title', 'date')
+
+
+class RecordPageModelAdmin(ModelAdmin):
+    menu_label = 'FEC Record'
+    model = RecordPage
+    ordering = ['-date']
+    list_display = ('title', 'date', 'category')
+
+
+class NewsAndUpdatesAdmin(ModelAdminGroup):
+    menu_label = 'News and updates'
+    menu_icon = 'folder-open-inverse'
+    menu_order = 200
+    items = (PressReleaseModelAdmin, DigestPageModelAdmin, TipsForTreasurersPageModelAdmin, RecordPageModelAdmin)
+
+modeladmin_register(AuthorAdmin)
+modeladmin_register(PressReleaseModelAdmin)
+modeladmin_register(DigestPageModelAdmin)
+modeladmin_register(TipsForTreasurersPageModelAdmin)
+modeladmin_register(RecordPageModelAdmin)
+modeladmin_register(NewsAndUpdatesAdmin)

--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -64,8 +64,4 @@ class NewsAndUpdatesAdmin(ModelAdminGroup):
     items = (PressReleaseModelAdmin, DigestPageModelAdmin, TipsForTreasurersPageModelAdmin, RecordPageModelAdmin)
 
 modeladmin_register(AuthorAdmin)
-modeladmin_register(PressReleaseModelAdmin)
-modeladmin_register(DigestPageModelAdmin)
-modeladmin_register(TipsForTreasurersPageModelAdmin)
-modeladmin_register(RecordPageModelAdmin)
 modeladmin_register(NewsAndUpdatesAdmin)


### PR DESCRIPTION
This uses Wagtail's `ModelAdmin` hooks to implement custom admin panels for the latest updates. 

Now, there will be a new menu item for "News and updates", which contains links to each type of update:
![image](https://user-images.githubusercontent.com/1696495/29331382-1c401572-81b1-11e7-85ea-15fdd9d13cd9.png)

Each one of those takes you to a view that is default sorted by the original date of the item:
![image](https://user-images.githubusercontent.com/1696495/29331413-2ea6b7de-81b1-11e7-966c-76fd230d3436.png)

I think this is actually a much better approach than the "Folder" concept earlier as it doesn't require any redirects or moving pages around. 