### PR TITLE
Fix logging of user info on page delete

### DIFF
--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -188,12 +188,15 @@ def log_user_save(sender, **kwargs):
 @receiver(pre_delete, sender=PageRevision)
 @receiver(post_save, sender=PageRevision)
 def log_revisions(sender, **kwargs):
-    try:
-        user_id = int(kwargs.get('instance').user_id)
-        user = User.objects.get(id=user_id)
-    except User.DoesNotExist:
+    user_id = kwargs.get('instance').user_id
+    if user_id:
+        try:
+            user = User.objects.get(id=user_id)
+            logger.info("page was modified: {0} by user {1}".format(kwargs.get('instance'), user.get_username()))
+        except User.DoesNotExist:
+            logger.info("User not found")
+    else:
         logger.info("User not found")
-    logger.info("page was modified: {0} by user {1}".format(kwargs.get('instance'), user.get_username()))
 
 
 def user_groups_changed(sender, **kwargs):

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -188,15 +188,17 @@ def log_user_save(sender, **kwargs):
 @receiver(pre_delete, sender=PageRevision)
 @receiver(post_save, sender=PageRevision)
 def log_revisions(sender, **kwargs):
-    user_id = kwargs.get('instance').user_id
-    if user_id:
-        try:
-            user = User.objects.get(id=user_id)
-            logger.info("page was modified: {0} by user {1}".format(kwargs.get('instance'), user.get_username()))
-        except User.DoesNotExist:
-            logger.info("User not found")
-    else:
-        logger.info("User not found")
+    username = '(user not found)'
+    user = kwargs.get('instance').user
+
+    if user:
+        username = user.get_username()
+
+    logger.info('Page modified: {0} by user {1}'.format(
+        kwargs.get('instance'),
+        username
+    ))
+
 
 
 def user_groups_changed(sender, **kwargs):


### PR DESCRIPTION
Currently, trying to delete a page in Wagtail can result in a server error if there is not a `user_id` in `kwargs['instance']`. This just updates the logic a to be a little more forgiving if that's the case. 

Can @ccostino or @LindsayYoung double-check this?

Resolves https://github.com/18F/fec-cms/issues/1189