### PR TITLE
Improve New Relic initialization

### DIFF
--- a/fec/fec/wsgi.py
+++ b/fec/fec/wsgi.py
@@ -10,15 +10,21 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'fec.settings.production')
 
-import newrelic.agent
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
 from fec.settings.env import env
 
-settings = newrelic.agent.global_settings()
-settings.license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
-newrelic.agent.initialize()
+def initialize_newrelic():
+    license_key = env.get_credential('NEW_RELIC_LICENSE_KEY')
+
+    if license_key:
+        import newrelic.agent
+        settings = newrelic.agent.global_settings()
+        settings.license_key = license_key
+        newrelic.agent.initialize()
+
+initialize_newrelic()
 
 application = get_wsgi_application()
 application = DjangoWhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ django-audit-log
 invoke==0.15.0
 GitPython==1.0.1
 requests-mock==1.3.0
+pdbpp==0.9.1
 
 # Data import
 unicode-slugify==0.1.3


### PR DESCRIPTION
This changeset improves the New Relic initialization to take into account whether or not the New Relic license key is present or not.  In our current setup and workflow, the New Relic license key is always set in the cloud.gov environment, but never locally (unless we are testing this integration explicitly, in which case it is required).  The existing code assumes the license key is always present and attempts to initialize the New Relic Agent, resulting in a multitude of warnings and errors in local development environments that makes it difficult to debug and work.

The setup is copied from our current web app and API New Relic initialization configs.

Lastly, this also adds the pdbpp package for improved command line debugging.