### PR TITLE
Meeting refinements

### DIFF
--- a/fec/fec/templates/partials/meeting.html
+++ b/fec/fec/templates/partials/meeting.html
@@ -2,7 +2,7 @@
   <tr class="simple-table__row">
     <td class="simple-table__cell">
       <a href="{{ meeting.url }}" class="t-bold">
-        {% if hearing is meeting %} {{ meeting.title }}{% else %}{{ meeting.date|date:'F j, Y' }}{% endif %}
+        {{ meeting.title | strip:'open meeting' }}
       </a>
     </td>
      <td class="simple-table__cell">
@@ -10,7 +10,7 @@
         <ul>
           {% for link in meeting.sunshine_act_links|splitlines %}
           {% if forloop.counter >= 2 %}
-            &nbsp;| <a href="{{ link }}">Amended
+            <br><a href="{{ link }}">Amended
           {% else %}
             <a href="{{ link }}">
           {% endif %}

--- a/fec/fec/templates/partials/meeting.html
+++ b/fec/fec/templates/partials/meeting.html
@@ -2,7 +2,11 @@
   <tr class="simple-table__row">
     <td class="simple-table__cell">
       <a href="{{ meeting.url }}" class="t-bold">
-        {{ meeting.title | strip:'open meeting' }}
+        {% if executive_session is meeting %}
+        {{ meeting.title | remove_word:'executive session' }}
+        {% else %}
+        {{ meeting.title | remove_word:'open meeting' }}
+        {% endif %}
       </a>
     </td>
      <td class="simple-table__cell">

--- a/fec/home/models.py
+++ b/fec/home/models.py
@@ -1011,6 +1011,7 @@ class MeetingPage(Page):
     ]
 
     search_fields =  Page.search_fields + [
+        index.FilterField('title'),
         index.FilterField('meeting_type'),
         index.FilterField('date'),
         index.SearchField('imported_html'),

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -60,7 +60,7 @@
                         {% endfor %}
                       </select>
                   </div>
-                  <div class="filter">
+                  <div class="filter filter--wide">
                     <div class="combo combo--filter--mini">
                       <label for="search" class="label">Search</label>
                       <input id="search" class="combo__input" name="search" type="text" value="{{ meetings_query }}">
@@ -121,7 +121,7 @@
                         {% endfor %}
                       </select>
                   </div>
-                  <div class="filter">
+                  <div class="filter filter--wide">
                     <div class="combo combo--filter--mini">
                       <label for="search" class="label">Search</label>
                       <input id="search" class="combo__input" name="search" type="text" value="{{ hearings_query }}">

--- a/fec/home/templates/home/commission_meetings.html
+++ b/fec/home/templates/home/commission_meetings.html
@@ -174,21 +174,13 @@
             <div class="filters--horizontal">
                <form action="" id="executive_form" method="get" class="js-form-nav container">
                   <div class="filter">
-                      <label for="year" class="label">Year</label>
-                      <select id="year" name="year">
-                        <option value="">All</option>
-                        {% for item in executive_years %}
-                        <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
-                        {% endfor %}
-                      </select>
-                  </div>
-                  <div class="filter">
-                    <div class="combo combo--filter--mini">
-                      <label for="search" class="label">Search</label>
-                      <input id="search" class="combo__input" name="search" type="text" value="{{ executive_query }}">
-                      <button type="submit" id="executive_sub" class="combo__button button button--standard button--search"><span class="u-visually-hidden">Search</span></button>
-                      <input type="hidden" name="tab" value="executive-sessions">
-                    </div>
+                    <label for="year" class="label">Year</label>
+                    <select id="year" name="year">
+                      <option value="">All</option>
+                      {% for item in executive_years %}
+                      <option value="{{ item }}" {% if year == item %}selected {% endif %}>{{ item }}</option>
+                      {% endfor %}
+                    </select>
                   </div>
               </form>
              </div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -34,7 +34,7 @@
         <li class="grid__item grid__item--event">
           <div class="t-bold">Next commission meeting:</div>
           <div class="js-next-commission-meeting"></div>
-          <a class="button button--alt button--updates" href="/updates/?update_type=meetings">All meetings</a>
+          <a class="button button--alt button--updates" href="/meetings">All meetings</a>
         <li class="grid__item grid__item--event">
           <div class="t-sans t-bold">Next filing deadline:</div>
           <div class="js-next-filing-deadline"></div>

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -123,6 +123,10 @@ def get_meta_description(content_section):
         return 'The new fec.gov makes it easier than ever to find what you need to know about the federal campaign finance process. Explore legal resources, campaign finance data, help for candidates and committees, and more.'
 
 
-@register.filter(name='strip')
-def strip(str, characters):
-    return str.strip(characters)
+@register.filter(name='remove_word')
+def remove_word(str, words):
+    """
+    Removes a word or words from a string
+    Returns a new string
+    """
+    return str.replace(words, '')

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -121,3 +121,8 @@ def get_meta_description(content_section):
         return 'Clarify campaign finance legal requirements on the new fec.gov. Search across advisory opinions, Matters Under Review, statutes, and regulations all at once, with search results designed to help you find what you need quickly.'
     else:
         return 'The new fec.gov makes it easier than ever to find what you need to know about the federal campaign finance process. Explore legal resources, campaign finance data, help for candidates and committees, and more.'
+
+
+@register.filter(name='strip')
+def strip(str, characters):
+    return str.strip(characters)


### PR DESCRIPTION
This includes a few meeting refinements after pairing with @jenniferthibault . 

![image](https://user-images.githubusercontent.com/1696495/29582608-3944da00-8732-11e7-9bba-93a0ecc7841e.png)

- Search inputs are now wider
- There's no search input on exec sessions
- The list now uses the `title` field to display and I added a filter for stripping away the words `open meeting` or `executive session` so that you can include the "cancelled" status in the meeting title

Requires an fec-style change