### PR TITLE
Adding accordion.css to calendar

### DIFF
--- a/fec/fec/static/scss/calendar.scss
+++ b/fec/fec/static/scss/calendar.scss
@@ -1,5 +1,6 @@
 @import '../../../node_modules/fec-style/scss/base';
 
+@import '../../../node_modules/fec-style/scss/components/accordions';
 @import '../../../node_modules/fec-style/scss/components/filters';
 @import '../../../node_modules/fec-style/scss/components/data-container';
 @import '../../../node_modules/fec-style/scss/components/calendar';


### PR DESCRIPTION
This adds the necessary style file for the accordions used in the calendar filter area.