### PR TITLE
[MERGE WITH GITFLOW] Hotfix/revert model admin

### DIFF
--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -1,8 +1,20 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, ModelAdminGroup, modeladmin_register
+from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.wagtailcore import hooks
 
-from .models import Author, PressReleasePage, DigestPage, TipsForTreasurersPage, RecordPage
+from .models import Author
 from search.utils.search_indexing import handle_page_edit_or_create, handle_page_delete
+
+class AuthorAdmin(ModelAdmin):
+    model = Author
+    menu_icon = 'user'
+    menu_order = 200  # will put in 3rd place (000 being 1st, 100 2nd)
+    add_to_settings_menu = False  # or True to add your model to the Settings sub-menu
+    list_display = ('name', 'title', 'email')
+    list_filter = ()
+    search_fields = ('name', 'title', 'email')
+
+
+modeladmin_register(AuthorAdmin)
 
 
 @hooks.register('after_create_page')
@@ -18,54 +30,3 @@ def search_update(request, page):
 @hooks.register('after_delete_page')
 def remove_page(request, page):
     handle_page_delete(page.id)
-
-class AuthorAdmin(ModelAdmin):
-    model = Author
-    menu_icon = 'user'
-    menu_order = 300  # will put in 3rd place (000 being 1st, 100 2nd)
-    add_to_settings_menu = False  # or True to add your model to the Settings sub-menu
-    list_display = ('name', 'title', 'email')
-    list_filter = ()
-    search_fields = ('name', 'title', 'email')
-
-
-class PressReleaseModelAdmin(ModelAdmin):
-    menu_label = 'Press releases'
-    model = PressReleasePage
-    ordering = ['-date']
-    list_display = ('title', 'date', 'category')
-
-
-class DigestPageModelAdmin(ModelAdmin):
-    menu_label = 'Weekly digests'
-    model = DigestPage
-    ordering = ['-date']
-    list_display = ('title', 'date')
-
-
-class TipsForTreasurersPageModelAdmin(ModelAdmin):
-    menu_label = 'Tips for Treasurers'
-    model = TipsForTreasurersPage
-    ordering = ['-date']
-    list_display = ('title', 'date')
-
-
-class RecordPageModelAdmin(ModelAdmin):
-    menu_label = 'FEC Record'
-    model = RecordPage
-    ordering = ['-date']
-    list_display = ('title', 'date', 'category')
-
-
-class NewsAndUpdatesAdmin(ModelAdminGroup):
-    menu_label = 'News and updates'
-    menu_icon = 'folder-open-inverse'
-    menu_order = 200
-    items = (PressReleaseModelAdmin, DigestPageModelAdmin, TipsForTreasurersPageModelAdmin, RecordPageModelAdmin)
-
-modeladmin_register(AuthorAdmin)
-modeladmin_register(PressReleaseModelAdmin)
-modeladmin_register(DigestPageModelAdmin)
-modeladmin_register(TipsForTreasurersPageModelAdmin)
-modeladmin_register(RecordPageModelAdmin)
-modeladmin_register(NewsAndUpdatesAdmin)

--- a/fec/home/wagtail_hooks.py
+++ b/fec/home/wagtail_hooks.py
@@ -64,4 +64,8 @@ class NewsAndUpdatesAdmin(ModelAdminGroup):
     items = (PressReleaseModelAdmin, DigestPageModelAdmin, TipsForTreasurersPageModelAdmin, RecordPageModelAdmin)
 
 modeladmin_register(AuthorAdmin)
+modeladmin_register(PressReleaseModelAdmin)
+modeladmin_register(DigestPageModelAdmin)
+modeladmin_register(TipsForTreasurersPageModelAdmin)
+modeladmin_register(RecordPageModelAdmin)
 modeladmin_register(NewsAndUpdatesAdmin)


### PR DESCRIPTION
This reverts the custom admin panels for news and updates introduced in https://github.com/18F/fec-cms/pull/1200 . There is a mysterious bug in production that's preventing content managers from being able to create new updates posts. The bug is not reproducible locally. Hopefully this solves the current problem but we can follow up and restore the functionality fully.