### PR TITLE
Removing meetings from latest updates

### DIFF
--- a/fec/home/templates/home/latest_updates.html
+++ b/fec/home/templates/home/latest_updates.html
@@ -8,7 +8,6 @@
   <div class="js-accordion accordion--neutral" data-content-prefix="updates">
     <button type="button" class="js-accordion-trigger accordion__button">About latest updates</button>
     <div class="accordion__content">
-      <p>Commission meeting agendas are usually published a week before a scheduled meeting. Sunshine Act Notices are announcements of open meetings and executive sessions. Notices for open meetings are published at least a week before a scheduled meeting and announce the date, time and a general list of items for discussion.</p>
       <p>Weekly Digests are published every Friday and summarize the week's publicly disclosed activity. Press releases are published as news happens.</p>
       <p>FEC Record articles inform candidates and committees about FEC developments and are published as news happens. Tips for Treasurers are published once a week.</p>
     </div>
@@ -21,7 +20,6 @@
       <label class="label" for="publication-type">Publication type</label>
       <select id="publication-type" name="update_type">
         <option value="">All</option>
-        <option value="meetings" {% if 'meetings' in update_types %}selected{% endif %}>Commission meetings</option>
         <option value="fec-record" {% if 'fec-record' in update_types %}selected{% endif %}>FEC Record</option>
         <option value="press-release" {% if 'press-release' in update_types %}selected{% endif %}>Press releases</option>
         <option value="tips-for-treasurers" {% if 'tips-for-treasurers' in update_types %}selected{% endif %}>Tips for Treasurers</option>
@@ -48,13 +46,6 @@
                 {% if cat.0|slugify in category_list %}selected{% endif %}>
                 {{ cat.1 }}</option>
             {% endfor %}
-          </select>
-        {% elif 'meetings' in update_types %}
-          <label class="label" for="record-categories">Meeting type</label>
-          <select id="record-categories" name="category">
-            <option value="">All meetings</option>
-            <option value="O"{% if "O" in category_list %} selected{% endif %}>Open meetings</option>
-            <option value="E"{% if "E" in category_list %} selected{% endif %}>Executive sessions</option>
           </select>
         {% else %}
         <label class="label" for="empty-select">Subjects</label>

--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -92,29 +92,11 @@ def get_tips(year=None, search=None):
     return tips
 
 
-def get_meetings(category_list=None, year=False, search=None):
-    meetings = MeetingPage.objects.live()
-
-    if category_list:
-        for category in category_list:
-            meetings = meetings.filter(meeting_type=category)
-
-    if year:
-        year = int(year)
-        meetings = meetings.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
-
-    if search:
-        meetings = meetings.search(search)
-
-    return meetings
-
-
 def updates(request):
     digests = ''
     records = ''
     press_releases = ''
     tips = ''
-    meetings = ''
 
     # Get values from query
     update_types = request.GET.getlist('update_type', None)
@@ -135,8 +117,6 @@ def updates(request):
             digests = get_digests(year=year, search=search)
         if 'tips-for-treasurers' in update_types:
             tips = get_tips(year=year, search=search)
-        if 'meetings' in update_types:
-            meetings = get_meetings(category_list=category_list, year=year, search=search)
 
     else:
         # Get everything and filter by year if necessary
@@ -144,7 +124,6 @@ def updates(request):
         press_releases = PressReleasePage.objects.live()
         records = RecordPage.objects.live()
         tips = TipsForTreasurersPage.objects.live()
-        meetings = MeetingPage.objects.live()
 
         if year:
             # Trying to filter using the built-in date__year parameter doesn't
@@ -154,19 +133,17 @@ def updates(request):
             digests = digests.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
             records = records.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
             tips = tips.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
-            meetings = meetings.filter(date__gte=datetime(year, 1, 1)).filter(date__lte=datetime(year, 12, 31))
 
         if search:
             press_releases = press_releases.search(search)
             digests = digests.search(search)
             records = records.search(search)
             tips = tips.search(search)
-            meetings = meetings.search(search)
 
     # Chain all the QuerySets together
     # via http://stackoverflow.com/a/434755/1864981
     updates = sorted(
-      chain(press_releases, digests, records, tips, meetings),
+      chain(press_releases, digests, records, tips),
       key=attrgetter('date'),
       reverse=True
     )


### PR DESCRIPTION
This removes the meetings from the latest updates page now that they're on their own page. It doesn't do anything about moving the actual agendas within Wagtail out from under `/updates/` it just removes them from the feed.