### PR TITLE
hotfix-add case insensitive filter for hearings titles

### DIFF
--- a/fec/home/views.py
+++ b/fec/home/views.py
@@ -301,7 +301,7 @@ def index_meetings(request):
     meetings = MeetingPage.objects.live().order_by("-date")
     open_meetings = meetings.filter(meeting_type ='O')
     executive_sessions = meetings.filter(meeting_type ='E')
-    hearings= meetings.filter(title__contains='Hearing')
+    hearings= meetings.filter(title__icontains='Hearing')
     year = request.GET.get('year', '')
     search = request.GET.get('search', '')
     active = request.GET.get('tab', 'open-meetings')


### PR DESCRIPTION
Issue: https://github.com/18F/fec-cms/issues/1239
All hearings were not showing up in the hearings tab of /meetings because the filter was case sensitive, returning on titles containing "Hearing", but not "hearing" which is the sentence-case convention for newly created meetings.
Note: After this is deployed, the three 2017 hearings titles that exist should be changed back to sentence-case (they are capitalized now so they show up in the tab)