### PR TITLE
Remove django_coverage_plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 before_script:
   - psql -c 'create database cfdm_cms_unit_test;' -U postgres
   - travis_retry pip install -r requirements.txt
-  - travis_retry pip install coverage django_coverage_plugin
+  - travis_retry pip install coverage
   - ". $HOME/.nvm/nvm.sh"
   - nvm install v7.7.4
   - nvm use v7.7.4
@@ -31,7 +31,7 @@ before_script:
   - cd fec
   - webpack --optimize-minimize --define process.env.NODE_ENV="'production'"
 script:
-  - coverage run ./manage.py test
+  - ./manage.py test
   - npm run test-single
 after_success:
   - travis_retry pip install bandit

--- a/fec/.coveragerc
+++ b/fec/.coveragerc
@@ -1,5 +1,3 @@
 [run]
 branch = true
-plugins =
-    django_coverage_plugin
 source = .


### PR DESCRIPTION
Removing django_coverage_plugin because they don't work with the Jinja templates for data and legal apps.