### PR TITLE
fix for deploy instructions

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -96,12 +96,13 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
     # These must be built prior to deploying due to the collectstatic
     # functionality of the Python buildpack conflicting with our setup.
     ctx.run('npm run build', echo=True)
+    ctx.run('cd fec', echo=True)
     ctx.run(
-        'DJANGO_SETTINGS_MODULE=fec.settings.production python fec/manage.py collectstatic --noinput -v 0',
+        'DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0',
         echo=True
     )
     ctx.run(
-        'DJANGO_SETTINGS_MODULE=fec.settings.production python fec/manage.py compress -v 0',
+        'DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py compress -v 0',
         echo=True
     )
 


### PR DESCRIPTION
Deploy management commands need to be run in the `fec` folder to find the JS manifest file correctly.