### PR TITLE
Fix deploy steps to run commands in proper working directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "build": "cd fec && webpack",
     "build-icons": "cd fec && gulp minify-icons && gulp consolidate-icons",
     "build-js": "cd fec && webpack",
+    "build-production": "cd fec && webpack --optimize-minimize --define process.env.NODE_ENV='production'",
     "test": "karma start",
     "test-single": "karma start --single-run --browsers PhantomJS",
     "watch": "nswatch"

--- a/tasks.py
+++ b/tasks.py
@@ -95,13 +95,14 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
     # Build static assets
     # These must be built prior to deploying due to the collectstatic
     # functionality of the Python buildpack conflicting with our setup.
-    ctx.run('npm run build', echo=True)
+    ctx.run('npm run build-production', echo=True)
+    ctx.run('cd fec', echo=True)
     ctx.run(
-        'DJANGO_SETTINGS_MODULE=fec.settings.production python fec/manage.py collectstatic --noinput -v 0',
+        'DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0',
         echo=True
     )
     ctx.run(
-        'DJANGO_SETTINGS_MODULE=fec.settings.production python fec/manage.py compress -v 0',
+        'DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py compress -v 0',
         echo=True
     )
 


### PR DESCRIPTION
This changeset fixes an issue we are having with the deploy step in the CircleCI environment.  It appears that the Django commands are not able to find where certain files are located, particularly those found in the `fec/dist` directory.

There is a larger issue here with the referencing to the path(s) of static assets, but we are fixing the immediate problem first.

Huge h/t to @tbaxter-18f and @cmc333333 for their help in debugging this issue!