### PR TITLE
feature/update cycle on breakdown pages

### DIFF
--- a/fec/data/templates/raising-breakdown.jinja
+++ b/fec/data/templates/raising-breakdown.jinja
@@ -15,6 +15,7 @@
 <form action="" method="get" class="breakdown-cycle">
   <label for="cycle" class="label">Time period</label>
   <select id="cycle" name="cycle" class="js-cycle" aria-controls="raising-breakdowns">
+    <option value="2018" {% if cycle == '2018' %}selected{% endif %}>2017&ndash;2018</option>
     <option value="2016" {% if cycle == '2016' %}selected{% endif %}>2015&ndash;2016</option>
     <option value="2012" {% if cycle == '2012' %}selected{% endif %}>2011&ndash;2012</option>
   </select>

--- a/fec/data/templates/spending-breakdown.jinja
+++ b/fec/data/templates/spending-breakdown.jinja
@@ -15,6 +15,7 @@
 <form action="" method="get" class="breakdown-cycle">
   <label for="cycle" class="label">Time period</label>
   <select id="cycle" name="cycle" class="js-cycle" aria-controls="spending-breakdown">
+    <option value="2018" {% if cycle == '2018' %}selected{% endif %}>2017&ndash;2018</option>
     <option value="2016" {% if cycle == '2016' %}selected{% endif %}>2015&ndash;2016</option>
     <option value="2012" {% if cycle == '2012' %}selected{% endif %}>2011&ndash;2012</option>
   </select>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -386,7 +386,7 @@ def elections(request, office, cycle, state=None, district=None):
 
 def raising(request):
     top_category = request.GET.get('top_category', 'P')
-    cycle = request.GET.get('cycle', 2016)
+    cycle = request.GET.get('cycle', 2018)
 
     if top_category in ['pac']:
         top_raisers = api_caller.load_top_pacs('-receipts', cycle=cycle, per_page=10)
@@ -416,7 +416,7 @@ def raising(request):
 
 def spending(request):
     top_category = request.GET.get('top_category', 'P')
-    cycle = request.GET.get('cycle', 2016)
+    cycle = request.GET.get('cycle', 2018)
 
     if top_category in ['pac']:
         top_spenders = api_caller.load_top_pacs('-disbursements', cycle=cycle, per_page=10)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -386,7 +386,7 @@ def elections(request, office, cycle, state=None, district=None):
 
 def raising(request):
     top_category = request.GET.get('top_category', 'P')
-    cycle = request.GET.get('cycle', 2018)
+    cycle = request.GET.get('cycle', constants.DEFAULT_TIME_PERIOD)
 
     if top_category in ['pac']:
         top_raisers = api_caller.load_top_pacs('-receipts', cycle=cycle, per_page=10)
@@ -416,7 +416,7 @@ def raising(request):
 
 def spending(request):
     top_category = request.GET.get('top_category', 'P')
-    cycle = request.GET.get('cycle', 2018)
+    cycle = request.GET.get('cycle', constants.DEFAULT_TIME_PERIOD)
 
     if top_category in ['pac']:
         top_spenders = api_caller.load_top_pacs('-disbursements', cycle=cycle, per_page=10)


### PR DESCRIPTION
Change to current two year cycle (currently 2017-2018) as default for raising/spending breakdown pages. (It was hardcoded before.)

Issue: https://github.com/18F/openFEC-web-app/issues/2280