### PR TITLE
Fix static asset paths for rev-manifest.json files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,8 +63,6 @@ jobs:
             npm i -g npm webpack
             npm install
             npm run build
-            cd fec
-            webpack --optimize-minimize --define process.env.NODE_ENV="'production'"
 
       - save_cache:
           paths:
@@ -85,6 +83,8 @@ jobs:
             . venv/bin/activate
             nvm use default
             cd fec
+            webpack
+            DJANGO_SETTINGS_MODULE=fec.settings.production python manage.py collectstatic --noinput -v 0
             ./manage.py test
             npm run test-single
 

--- a/fec/data/templatetags/filters.py
+++ b/fec/data/templatetags/filters.py
@@ -1,13 +1,15 @@
-from django_jinja import library
+import datetime
+import json
+import locale
+import os
+import re
 
 import jinja2
 
-import re
-import json
-import locale
-import datetime
-
 from dateutil.parser import parse as parse_date
+
+from django.conf import settings
+from django_jinja import library
 
 from data import constants
 
@@ -151,6 +153,6 @@ def asset_for(path):
     If the path doesn't exist there, then just return the path to the static file
     without a hash"""
     key = '/static/js/{}'.format(path)
-    assets = json.load(open('./dist/fec/static/js/rev-manifest.json'))
-    assets.update(json.load(open('./dist/fec/static/js/rev-legal-manifest.json')))
+    assets = json.load(open(os.path.join(settings.STATIC_ROOT, 'js/rev-manifest.json')))
+    assets.update(json.load(open(os.path.join(settings.STATIC_ROOT, 'js/rev-legal-manifest.json'))))
     return assets[key] if key in assets else key

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -1,12 +1,12 @@
-import re
 import json
+import os
+import re
 
-from django.conf import settings
 from django import template
-from django.utils.html import conditional_escape
+from django.conf import settings
+from django.templatetags.static import static
+from django.utils.html import conditional_escape, format_html
 from django.utils.safestring import mark_safe
-from django.utils.html import format_html
-from django.contrib.staticfiles.templatetags.staticfiles import static
 from wagtail.wagtailcore.models import Page
 
 register = template.Library()
@@ -131,7 +131,7 @@ def asset_for(path):
     without a hash"""
 
     key = '/static/js/{}'.format(path)
-    assets = json.load(open('./dist/fec/static/js/rev-manifest.json'))
+    assets = json.load(open(os.path.join(settings.STATIC_ROOT, 'js/rev-manifest.json')))
 
     return assets[key] if key in assets else key
 


### PR DESCRIPTION
This changeset fixes an issue with static file paths being hardcoded and therefore not being found if things are being run outside of an expected directory.  It leverages the `STATIC_ROOT` setting in Django to form the first part of the file path referencing the static asset.

Furthemore, the Django tests expect all static assets to be in the `STATIC_ROOT` directory, so this changeset also adds a tweak to the CircleCI config to do that before running the tests.

The imports have also been tidied up in these two files.