### PR TITLE
Match virtualenv name in CircleCI config to our ignore files

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -6,6 +6,8 @@ bower_components
 local.py
 
 *.py[cod]
+.cache
+.env
 
 # C extensions
 *.so

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,8 @@ jobs:
       - run:
           name: Install python dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
+            python3 -m venv .env
+            . .env/bin/activate
             pip install -U pip setuptools wheel codecov
             pip install -r requirements.txt
 
@@ -66,7 +66,7 @@ jobs:
 
       - save_cache:
           paths:
-            - ./venv
+            - ./.env
             - ./node_modules
           key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
@@ -80,7 +80,7 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            . venv/bin/activate
+            . .env/bin/activate
             nvm use default
             cd fec
             webpack
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Perform post-test checks
           command: |
-            . venv/bin/activate
+            . .env/bin/activate
             codecov
 
       - store_artifacts:
@@ -114,6 +114,6 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            . venv/bin/activate
+            . .env/bin/activate
             nvm use default
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes


### PR DESCRIPTION
This changeset updates the CircleCI config to use the same name for the Python virtual environment it creates for testing and deployment as we have in the `.gitignore` and `.cfignore` files.  When the name does not match, the virtual environment directory and its contents are pushed up to the cloud.gov environment, which we do not want as it is extra cruft and could potentially cause environment conflicts/issues.  This also updates the `.cfignore` file to include a couple of directories, including the virtual environment directory, that it was not ignoring before.