### PR TITLE
Replacing AO and MUR banners across site

### DIFF
--- a/fec/fec/static/js/legal/LegalSearch.js
+++ b/fec/fec/static/js/legal/LegalSearch.js
@@ -135,10 +135,7 @@ class LegalSearch extends React.Component {
           <Tags query={this.state.lastQuery} resultCount={this.state.resultCount} handleRemove={this.instantQuery} />
           <div className="u-padding--left u-padding--right">
             <div className="message message--info">
-              <h3>This feature is still in progress</h3>
-              <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
-              advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
-              opinions on the old fec.gov</a>.</p>
+              <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
             </div>
           </div>
         </div>

--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -41,8 +41,7 @@
     </div>
     <div class="row">
       <div class="message message--info">
-        <h3>This feature is still in progress</h3>
-        <p>We&#39;re actively building the <strong>MUR search</strong> feature. Search cases closed between 1975 and 1998 on the old FEC.gov through the <a href="{{'/MUR/'|classic_url}}">MUR archive</a> and cases from 1999 to present on the <a href="http://eqs.fec.gov">Enforcement Query System</a>.</p>
+        <p>The MUR search feature includes all cases dating back to 1977. You can search all FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
       </div>
     </div>
   </div>

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -48,10 +48,7 @@
       </div>
       <div class="row">
         <div class="message message--info">
-          <h3>This feature is still in progress</h3>
-          <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
-          advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
-          opinions on the old FEC.gov</a>.</p>
+          <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
         </div>
       </div>
     </div>

--- a/fec/legal/templates/legal-search-results-murs.jinja
+++ b/fec/legal/templates/legal-search-results-murs.jinja
@@ -25,10 +25,7 @@
 
 {% block message %}
 <div class="message message--info">
-  <h3>This feature is still in progress.</h3>
-  <p>We&#39;re actively building the <strong>MUR search</strong>, and it doesn&#39;t yet include some
-  advanced search functions. If you can&#39;t find what you&#39;re looking for,
-  you can still <a href="http://eqs.fec.gov/eqs/searcheqs">search MURS on the old fec.gov</a>.</p>
+  <p>The MUR search feature includes all cases dating back to 1977. You can search all FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
 </div>
 {% endblock %}
 

--- a/fec/legal/templates/legal-search-results.jinja
+++ b/fec/legal/templates/legal-search-results.jinja
@@ -94,10 +94,7 @@
                   {% if results["total_" + category] %}
                       {% with murs = results[category] %}
                       <div class="message message--info">
-                        <h3>This feature is still in progress.</h3>
-                        <p>We&#39;re actively building the <span className="font-bold">MUR search</span>, and it doesn&#39;t yet include some
-                        advanced search functions. If you can&#39;t find what you&#39;re looking for,
-                        you can still <a href="http://eqs.fec.gov/eqs/searcheqs">search MURS on the old fec.gov</a>.</p>
+                        <p>The MUR search feature includes all cases dating back to 1977. You can search all FEC MURs using keywords, MUR numbers, names of respondents and more. For additional search filters, you can still search MURs using our legacy <a href="http://eqs.fec.gov">FEC Enforcement Query System</a>.</p>
                       </div>
                       {% include 'partials/legal-search-results-mur.jinja' %}
                       {% endwith %}

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -1,8 +1,5 @@
 <div class="message message--info">
-  <h3>This feature is still in progress.</h3>
-  <p>We&#39;re actively building the <strong>advisory opinion search</strong>, and it doesn&#39;t yet include some
-  advanced search functions. If you can&#39;t find what you&#39;re looking for, you can still <a href="http://saos.fec.gov/saos/searchao">search
-  opinions on the old FEC.gov</a>.</p>
+  <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
 </div>
 
 {% for advisory_opinion in advisory_opinions %}


### PR DESCRIPTION
Resolves this issue: https://github.com/18F/openFEC-web-app/issues/2303

Need a design eye to see if we need to tweak this design pattern in any way. This is what the Info messages look like in the pattern library: https://fec-pattern-library.app.cloud.gov/components/detail/inverse-alt--info-messages.html

<img width="764" alt="screen shot 2017-10-11 at 9 06 42 pm" src="https://user-images.githubusercontent.com/12799132/31474350-2a9d113a-aec8-11e7-92f9-416ed83f7a91.png">

<img width="846" alt="screen shot 2017-10-11 at 8 42 36 pm" src="https://user-images.githubusercontent.com/12799132/31474338-0eca16f6-aec8-11e7-86ba-777c3842d256.png">
