### PR TITLE
Candidate and committees datatables fix

### DIFF
--- a/fec/data/templates/candidates-single.jinja
+++ b/fec/data/templates/candidates-single.jinja
@@ -136,6 +136,6 @@
 <script>
   var context = {{ context_vars|to_json|safe }};
 </script>
-<script src="{{ asset_for_js('candidate-single.js') }}"></script>
 <script src="{{ asset_for_js('dataviz-common.js') }}"></script>
+<script src="{{ asset_for_js('candidate-single.js') }}"></script>
 {% endblock %}

--- a/fec/data/templates/committees-single.jinja
+++ b/fec/data/templates/committees-single.jinja
@@ -159,6 +159,6 @@ var context = {{ context_vars | to_json | safe }};
   context.showIndependentExpenditures = true;
 {% endif %}
 </script>
-<script src="{{ asset_for_js('committee-single.js') }}"></script>
 <script src="{{ asset_for_js('dataviz-common.js') }}"></script>
+<script src="{{ asset_for_js('committee-single.js') }}"></script>
 {% endblock %}

--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -194,9 +194,17 @@ Handlebars.registerHelper('format_range', function(year) {
     return new Handlebars.SafeString(firstYear.toString() + '–' + year.toString());
 });
 
+/**
+  Formats a cycle range based on a year and a duration.
+  If no year is provided, return null;
+**/
 function formatCycleRange(year, duration) {
+  // Year and duration is requred, if not provided return null
+  if( year == null || duration == null) {
+    return null;
+  }
   var firstYear = Number(year) - duration + 1;
-  return firstYear.toString() + '–' + year.toString();
+  return firstYear + '–' + year;
 }
 
 function cycleDates(year) {

--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -247,7 +247,9 @@ function initSpendingTables() {
       election_full: $table.data('election-full')
     };
     var displayCycle = helpers.formatCycleRange($table.data('cycle'), $table.data('duration'));
-
+    if(displayCycle == null) {
+      displayCycle = "unspecified cycle";
+    }
     if (opts) {
       tables.DataTable.defer($table, {
         path: opts.path,
@@ -275,15 +277,22 @@ function initSpendingTables() {
 function initDisbursementsTable() {
   var $table = $('table[data-type="itemized-disbursements"]');
   var path = ['schedules', 'schedule_b'];
+  var committeeIdData = $table.data('committee-id');
+  var committeeIds = "";
+  if(committeeIdData) {
+    committeeIds = committeeIdData.split(',').filter(Boolean);
+  }
   var opts = {
     // possibility of multiple committees, so split into array
-    committee_id: $table.data('committee-id').split(','),
+    committee_id: committeeIds,
     title: 'itemized disbursements',
     name: $table.data('name'),
     cycle: $table.data('cycle')
   };
   var displayCycle = helpers.formatCycleRange($table.data('cycle'), $table.data('duration'));
-
+  if(displayCycle == null) {
+    displayCycle = "unspecified cycle";
+  }
   tables.DataTable.defer($table, {
     path: path,
     query: {
@@ -315,10 +324,15 @@ function initContributionsTables() {
   var $contributorState = $('table[data-type="contributor-state"]');
   var displayCycle = helpers.formatCycleRange($allTransactions.data('cycle'), 2);
   var candidateName = $allTransactions.data('name');
+  var committeeIdData = $allTransactions.data('committee-id');
+  var committeeIds = "";
+  if(committeeIdData) {
+    committeeIds = committeeIdData.split(',').filter(Boolean);
+  }
   var opts = {
     // possibility of multiple committees, so split into array
     // also, filter array to remove any blank values
-    committee_id: $allTransactions.data('committee-id').split(',').filter(Boolean),
+    committee_id: committeeIds,
     candidate_id: $allTransactions.data('candidate-id'),
     title: 'individual contributions',
     name: candidateName,


### PR DESCRIPTION
resolves https://github.com/18F/fec-cms/issues/1329

Rearranged javascript loading order for candidate and committee pages. The candidate and committee pages has a dependency to load dataviz first before loading candidate-single.js or committee-single.js.
 
There were some errors due to attempting to call split or toString methods on null values, this is now handled so that the page can still be processed without error. 