### PR TITLE
change png to jpg in img src path

### DIFF
--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -38,7 +38,7 @@
 {% for vacant in vacant_seats %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.png" %}" alt="Headshot of vacant seat">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant seat</div>
     </div>


### PR DESCRIPTION
Headshot placeholder image for "vacant seat" on about/leadership-and-structure was not showing up. Content team requested it be corrected for this release.