### PR TITLE
Fix webpack production issue

### DIFF
--- a/fec/webpack.config.js
+++ b/fec/webpack.config.js
@@ -66,8 +66,12 @@ module.exports = [
         basePath: '/static/js/'
       }),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+      new webpack.DefinePlugin({
+        'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
       // Uncomment to compress and analyze the size of bundles
-      // new webpack.optimize.UglifyJsPlugin(),
       // new BundleAnalyzerPlugin()
     ],
     output: {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "build-icons": "cd fec && gulp minify-icons && gulp consolidate-icons",
     "build-sass": "cd fec && gulp build-sass",
     "build-js": "cd fec && webpack",
-    "build-production": "cd fec && webpack --optimize-minimize --define process.env.NODE_ENV='production' && gulp build-sass",
+    "build-production": "cd fec && webpack -p && gulp build-sass",
     "test": "karma start",
     "test-single": "karma start --single-run --browsers PhantomJS",
     "watch": "nswatch"


### PR DESCRIPTION
It seemed that setting the production node_env variable inline was not ideal as it broke AO datatables. To fix this, we are setting the value from within the webpack config itself. While it seems counterintuitive, for now it works because setting the node_env variable to production allows for webpack to compress `vendor.js` and because we don't use the variable in any of our JS files currently, it is ok for local development.

I have also used the more preferred compression flag `webpack -p`, which automatically runs UglifyJS for the build-production command.

Fixes: https://github.com/18F/fec-cms/issues/1363