### PR TITLE
Fix AND operator in boolean logic

### DIFF
--- a/fec/fec/static/js/modules/keyword-modal.js
+++ b/fec/fec/static/js/modules/keyword-modal.js
@@ -75,7 +75,7 @@ KeywordModal.prototype.combineFields = function() {
   });
 
   if (this.$excludeField.val() && query) {
-    query = '(' + query + ') & (' + self.parseValue(this.$excludeField) + ')';
+    query = '(' + query + ') AND (' + self.parseValue(this.$excludeField) + ')';
   } else if (this.$excludeField.val()) {
     query = self.parseValue(this.$excludeField);
   }
@@ -92,7 +92,7 @@ KeywordModal.prototype.parseValue = function($input) {
   var words = $input.val().replace(/"/g,'').split(' ');
   var operator = $input.data('operator');
   if (operator === 'and') {
-    return words.join(' & ');
+    return words.join(' AND ');
   } else if (operator === 'or') {
     return words.join(' OR ');
   } else if (operator === 'exact') {

--- a/fec/home/templates/partials/legal-keyword-modal.html
+++ b/fec/home/templates/partials/legal-keyword-modal.html
@@ -46,7 +46,7 @@
                 <td class="simple-table__cell">or</td>
               </tr>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">&amp;</td>
+                <td class="simple-table__cell">AND</td>
                 <td class="simple-table__cell">and</td>
               </tr>
               <tr class="simple-table__row">

--- a/fec/legal/templates/partials/legal-keyword-modal.jinja
+++ b/fec/legal/templates/partials/legal-keyword-modal.jinja
@@ -45,7 +45,7 @@
                 <td class="simple-table__cell">or</td>
               </tr>
               <tr class="simple-table__row">
-                <td class="simple-table__cell">&amp;</td>
+                <td class="simple-table__cell">AND</td>
                 <td class="simple-table__cell">and</td>
               </tr>
               <tr class="simple-table__row">


### PR DESCRIPTION
Resolves https://github.com/18F/fec-cms/issues/1365

AND operator logic was not working and breaking during pagination because it was trying to pass an amperstand (`&`) instead of the word `AND`. This PR should fix that functionality.

