### PR TITLE
Changes h2 to h3 for visual styling

### DIFF
--- a/fec/home/templates/blocks/mur_search.html
+++ b/fec/home/templates/blocks/mur_search.html
@@ -3,7 +3,7 @@
 <div class="u-no-print">
   <div class="slab slab--neutral slab--inline u-padding--left u-padding--right">
     <div class="heading--section heading--with-action">
-      <h2 class="heading__left">Search closed MURs</h2>
+      <h3 class="heading__left">Search closed MURs</h3>
       <a class="button button--alt button--go heading__right" href="/data/legal/search/enforcement/">Advanced search</a>
     </div>
     <div class="row">


### PR DESCRIPTION
This seems like a visual and semantic improvement for https://fec-stage-proxy.app.cloud.gov/legal-resources/enforcement/ .

## Before, with search headers as `h2`
<img width="748" alt="screen shot 2017-10-23 at 8 08 10 pm" src="https://user-images.githubusercontent.com/11636908/31922073-f0e78146-b840-11e7-9c2b-e53d87a10a9c.png">


## After, with search headers as `h3`
<img width="750" alt="screen shot 2017-10-23 at 8 07 46 pm" src="https://user-images.githubusercontent.com/11636908/31922076-f791dadc-b840-11e7-993f-d3b9358d9332.png">
