### PR TITLE
Table panel fix

### DIFF
--- a/fec/fec/static/js/modules/helpers.js
+++ b/fec/fec/static/js/modules/helpers.js
@@ -261,7 +261,7 @@ function getTimePeriod(electionYear, cycle, electionFull, office) {
     max = cycle;
   }
 
-  return min.toString() + '–' + max.toString();
+  return min + '–' + max;
 }
 
 /*

--- a/fec/fec/static/js/modules/table-panels.js
+++ b/fec/fec/static/js/modules/table-panels.js
@@ -59,7 +59,7 @@ var renderCandidatePanel = function(showFinancialTotals) {
       var query = URI.parseQuery(window.location.search);
       // Parse all of the time-related variables
       var electionYear = query.election_year;
-      var cycle = query.cycle || query.election_year;
+      var cycle = query.cycle || query.election_year || $('#cycle').val();
       var electionFull = query.election_full === 'true' ? true : false;
 
       // Build a string showing the range covered by the financial totals

--- a/fec/fec/static/js/modules/top-entities.js
+++ b/fec/fec/static/js/modules/top-entities.js
@@ -185,7 +185,7 @@ TopEntities.prototype.drawBars = function() {
 TopEntities.prototype.updateDates = function() {
   var today = new Date();
   var startDate = '01/01/' + String(this.cycle - 1);
-  var endDate = this.cycle !== today.getFullYear() ? '12/31/' + this.cycle : moment(today, 'DD/MM/YYYY');
+  var endDate = this.cycle !== today.getFullYear() ? '12/31/' + this.cycle : moment(today).format('MM/DD/YYYY');
   this.$dates.html(startDate + '–' + endDate);
 };
 

--- a/fec/fec/tests/js/top-entities-breakdown.js
+++ b/fec/fec/tests/js/top-entities-breakdown.js
@@ -284,7 +284,8 @@ describe('Top entities breakdown', function() {
       it('updates the coverage dates for the current year', function() {
         var today = new Date();
         var lastYear = today.getFullYear() - 1;
-        var formattedToday = moment(today, 'DD/MM/YYYY');
+        var formattedToday = moment(today).format('MM/DD/YYYY');
+        console.log("today:" + formattedToday);
         this.chart.cycle = today.getFullYear();
         this.chart.updateDates();
         expect(this.chart.$dates.html()).to.equal('01/01/' + lastYear + '–' + formattedToday);

--- a/fec/fec/tests/js/top-entities-breakdown.js
+++ b/fec/fec/tests/js/top-entities-breakdown.js
@@ -285,7 +285,6 @@ describe('Top entities breakdown', function() {
         var today = new Date();
         var lastYear = today.getFullYear() - 1;
         var formattedToday = moment(today).format('MM/DD/YYYY');
-        console.log("today:" + formattedToday);
         this.chart.cycle = today.getFullYear();
         this.chart.updateDates();
         expect(this.chart.$dates.html()).to.equal('01/01/' + lastYear + '–' + formattedToday);


### PR DESCRIPTION
Resolves https://github.com/18F/fec-cms/issues/1377

Removes `toString` as it is unnecessary. Also adds ability to get cycle from the select box rather than the URL string. This was breaking the cycle in the financial totals when table panel is expanded.

Moment was being formatted incorrectly and tests were not passing. By using the correct usage of date formats, this allows tests to pass during builds https://momentjs.com/docs/#/displaying/