### PR TITLE
Fixes AO pagination

### DIFF
--- a/fec/fec/static/js/legal/Pagination.js
+++ b/fec/fec/static/js/legal/Pagination.js
@@ -1,8 +1,22 @@
 const React = require('react');
 
 function Pagination(props) {
-  function interceptHandleChange(increment) {
-    const syntheticEvent = { target: { name: 'from_hit', value: props.from_hit + increment } };
+  function interceptHandleChange(offset) {
+    
+    // from_hit is a zero-based index
+    var updatedFromHit = props.from_hit + offset;
+
+    // when from_hit is less than 0, reset to 0 (ensures no negative value)
+    if (updatedFromHit < 0){
+      updatedFromHit = 0;
+    } 
+    // ensures that from_hit is less than result count
+    else if (updatedFromHit >= props.resultCount) {
+      updatedFromHit = props.resultCount - 1;
+    }
+
+    // create an event to update from_hit
+    const syntheticEvent = { target: { name: 'from_hit', value: updatedFromHit } };
     props.handleChange(syntheticEvent);
   }
 
@@ -11,10 +25,10 @@ function Pagination(props) {
           {props.from_hit + 1}&ndash;{props.from_hit + props.advisory_opinions.length} of {props.resultCount}</div>
           <div className="dataTables_paginate">
             {props.from_hit > 0 ? <a className="paginate_button previous"
-             onClick={() => interceptHandleChange(-props.advisory_opinions.length)}>Previous</a>
+             onClick={() => interceptHandleChange(-20)}>Previous</a>
               : <span className="paginate_button previous is-disabled">Previous</span> }
             {props.from_hit + props.advisory_opinions.length < props.resultCount ? <a className="paginate_button next"
-             onClick={() => interceptHandleChange(props.advisory_opinions.length)}>Next</a>
+             onClick={() => interceptHandleChange(20)}>Next</a>
               : <span className="paginate_button next is-disabled">Next</span> }
           </div>
         </div> : null

--- a/fec/fec/static/js/legal/Pagination.js
+++ b/fec/fec/static/js/legal/Pagination.js
@@ -4,10 +4,10 @@ function Pagination(props) {
   function interceptHandleChange(offset) {
     
     // from_hit is a zero-based index
-    var updatedFromHit = props.from_hit + offset;
+    let updatedFromHit = props.from_hit + offset;
 
     // when from_hit is less than 0, reset to 0 (ensures no negative value)
-    if (updatedFromHit < 0){
+    if (updatedFromHit < 0) {
       updatedFromHit = 0;
     } 
     // ensures that from_hit is less than result count
@@ -16,7 +16,12 @@ function Pagination(props) {
     }
 
     // create an event to update from_hit
-    const syntheticEvent = { target: { name: 'from_hit', value: updatedFromHit } };
+    const syntheticEvent = { 
+      target: { 
+        name: 'from_hit', 
+        value: updatedFromHit 
+      }
+    };
     props.handleChange(syntheticEvent);
   }
 


### PR DESCRIPTION
Resolves https://github.com/18F/fec-cms/issues/1382

This sets the standard offset to 20 and accounts for boundaries in the from_hit value. This ensures no negative pages or pages that would go beyond the total result count.