### PR TITLE
Replace overlay on datatable pages

### DIFF
--- a/fec/fec/static/scss/datatables.scss
+++ b/fec/fec/static/scss/datatables.scss
@@ -14,4 +14,5 @@
 @import "components/toggles";
 @import "components/tooltips";
 @import "components/type-styles";
+@import "components/overlay";
 @import "components/pagination";

--- a/fec/home/templatetags/filters.py
+++ b/fec/home/templatetags/filters.py
@@ -145,7 +145,7 @@ def asset_for_css(key):
     assets = json.load(open(settings.DIST_DIR + '/fec/static/css/rev-manifest-css.json'))
 
     if key in assets:
-        return '/static/css/' + assets[key] 
+        return '/static/css/' + assets[key]
     else:
         return key
 
@@ -157,5 +157,3 @@ def remove_word(str, words):
     Returns a new string
     """
     return str.replace(words, '')
-
-print (settings.DIST_DIR)


### PR DESCRIPTION
For some reason, we weren't including the overlay stylesheet for datatables pages. This replaces it. Also, removed a print statement left over from testing merge deploy.