### PR TITLE
Ensure CSRF cookie is present for feedback tool

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -1,3 +1,4 @@
+from django.views.decorators.csrf import ensure_csrf_cookie
 from django.shortcuts import render
 from django.http import Http404
 from django.http import JsonResponse
@@ -442,6 +443,7 @@ def spending(request):
     })
 
 
+@ensure_csrf_cookie
 def feedback(request):
     if request.method == 'POST':
 


### PR DESCRIPTION
This changeset addresses an issue with the feedback tool introduced with the CMS/web app merge.  The cookie with the CSRF token is not being sent or passsed to the view submitting the issue, so this change should make sure that does take place.  See https://docs.djangoproject.com/en/1.10/ref/csrf/#ajax for more details.