### PR TITLE
Fixed CSRF token not being available for Feedback form

### DIFF
--- a/fec/data/templates/layouts/main.jinja
+++ b/fec/data/templates/layouts/main.jinja
@@ -119,6 +119,8 @@
 
 {% include './partials/glossary.html' %}
 
+{% csrf_token %}
+
 {% block modals %}{% endblock %}
 <script src="{{ asset_for_js('vendor.js') }}"></script>
 <script src="{{ asset_for_js('data-init.js') }}"></script>

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -1,4 +1,3 @@
-from django.views.decorators.csrf import ensure_csrf_cookie
 from django.shortcuts import render
 from django.http import Http404
 from django.http import JsonResponse
@@ -443,7 +442,6 @@ def spending(request):
     })
 
 
-@ensure_csrf_cookie
 def feedback(request):
     if request.method == 'POST':
 

--- a/fec/fec/static/js/modules/feedback.js
+++ b/fec/fec/static/js/modules/feedback.js
@@ -72,7 +72,7 @@ Feedback.prototype.submit = function(e) {
      beforeSend: function(xhr, settings) {
        if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
            // Only send the token to relative URLs i.e. locally.
-           xhr.setRequestHeader('X-CSRFToken', helpers.getCookie('csrftoken'));
+           xhr.setRequestHeader('X-CSRFToken', $('input[name="csrfmiddlewaretoken"]').val());
        }
      }
   });

--- a/fec/fec/templates/base.html
+++ b/fec/fec/templates/base.html
@@ -141,6 +141,8 @@
 
     {% include './partials/glossary.html' %}
 
+    {% csrf_token %}
+
     <script>
       window.CMS_URL = '{{ cms_url }}'
       window.FEC_APP_URL = '{{ settings.FEC_APP_URL }}';


### PR DESCRIPTION
This changeset fixes the missing CSRF token for the feedback form by rendering it directly in the templates instead of trying to leverage a cookie that is not being set.