### PR TITLE
AO URL Fix

### DIFF
--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -15,10 +15,10 @@
     <div class="slab slab--neutral slab--inline u-padding--left u-padding--right">
       <div class="heading--section heading--with-action">
         <h2 class="heading__left">Search advisory opinions</h2>
-        <a class="button button--alt button--go heading__right" href="/data/legal/search/advisory_opinions">Advanced search</a>
+        <a class="button button--alt button--go heading__right" href="/data/legal/search/advisory-opinions">Advanced search</a>
       </div>
       <div class="row">
-        <form action="/data/legal/search/advisory_opinions/" autocomplete="off" class="search__container u-padding--top">
+        <form action="/data/legal/search/advisory-opinions/" autocomplete="off" class="search__container u-padding--top">
           <div class="search-controls__row">
             <div class="search-controls__either">
               <label for="ao_no" class="label">Find by AO number</label>
@@ -84,7 +84,7 @@
   </div>
   <div class="content__section">
     <p>The Commission issues an advisory opinion when four or more Commissioners vote to approve it. These votes almost always occur during an <a href="/calendar/?category=Open+Meetings">open meeting</a>.</p>
-    <a class="button button--standard button--browse" href="/data/legal/search/advisory_opinions}">Explore all advisory opinions</a>
+    <a class="button button--standard button--browse" href="/data/legal/search/advisory-opinions}">Explore all advisory opinions</a>
   </div>
   <div class="post-feed">
     {% for ao in recent_aos %}

--- a/fec/legal/urls.py
+++ b/fec/legal/urls.py
@@ -6,14 +6,13 @@ urlpatterns = [
     url(r'^data/legal/advisory-opinions/(?P<ao_no>[\w-]+)/$',
         views.advisory_opinion_page),
     url(r'^data/legal/advisory-opinions/$', views.advisory_opinions_landing),
-    url(r'^data/legal/advisory_opinions/$', views.advisory_opinions_landing),
     url(r'^data/legal/matter-under-review/(?P<mur_no>[0-9]+)/$',
         views.mur_page),
     url(r'^data/legal/statutes/$', views.statutes_landing),
     # Legal search results
     url(r'^data/legal/search/$', views.legal_search),
 
-    url(r'^data/legal/search/advisory_opinions/$', views.legal_doc_search_ao),
+    url(r'^data/legal/search/advisory-opinions/$', views.legal_doc_search_ao),
     url(r'^data/legal/search/enforcement/$', views.legal_doc_search_mur),
     url(r'^data/legal/search/murs/$', views.legal_doc_search_mur),
     url(r'^data/legal/search/regulations/$',


### PR DESCRIPTION
In the merged CMS and Web app code, there is a reference to both URLs for AOs, one with a dash and one with an underscore. The underscore was incorrect. This was breaking our paths. Will also set a redirect in Wagtail for the version with underscores just in case.

**Correct:**
`data/legal/advisory-opinions/`
`data/legal/search/advisory-opinions/`
 
**Incorrect:**
`data/legal/advisory_opinions/`
`data/legal/search/advisory_opinions/`