### PR TITLE
[MERGE WITH GITFLOW] localize timezone-aware date and handle DST(daylight savings time)

### DIFF
--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -1,6 +1,6 @@
 import datetime
 import pytz
-from pytz import timezone
+
 import re
 
 from django import template
@@ -8,6 +8,7 @@ from django.conf import settings
 from operator import attrgetter
 from itertools import chain, islice
 from datetime import date
+from pytz import timezone
 from home.models import (HomePageBannerAnnouncement, DigestPage, RecordPage, PressReleasePage,
                         TipsForTreasurersPage, ServicesLandingPage)
 

--- a/fec/home/templatetags/home_page.py
+++ b/fec/home/templatetags/home_page.py
@@ -1,4 +1,6 @@
 import datetime
+import pytz
+from pytz import timezone
 import re
 
 from django import template
@@ -14,7 +16,8 @@ register = template.Library()
 
 @register.inclusion_tag('partials/home-page-banner-announcement.html')
 def home_page_banner_announcement():
-    datetime_now = datetime.datetime.today()
+    eastern = timezone('America/New_York')
+    datetime_now = eastern.localize(datetime.datetime.today())
     banners = HomePageBannerAnnouncement.objects.live().filter(active=True, date_active__lte=datetime_now, date_inactive__gt=datetime_now).order_by('-date_active')[:2]
 
     return {


### PR DESCRIPTION
This is another attempt at solving timezone error related to timezone unaware date objects in the banner announcements code. Tested locally and it does not give error, but still need to see if other tests/monitors report errors/warnings. i.e.- Kibana