### PR TITLE
Update text on advisory opinion overview page

### DIFF
--- a/fec/fec/static/js/legal/LegalSearch.js
+++ b/fec/fec/static/js/legal/LegalSearch.js
@@ -135,7 +135,7 @@ class LegalSearch extends React.Component {
           <Tags query={this.state.lastQuery} resultCount={this.state.resultCount} handleRemove={this.instantQuery} />
           <div className="u-padding--left u-padding--right">
             <div className="message message--info">
-              <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
+              <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requestors and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
             </div>
           </div>
         </div>

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -9,6 +9,9 @@
     <p class="t-lead">
       Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
     </p>
+    <p>
+      This archive contains advisory opinions from 1975 to the present. It also contains documents related to advisory opinions &mdash such as requests, drafts and public comments &mdash from 1990 to the present.
+    </p>
     <a class="button button--cta button--go" href="/legal-resources/advisory-opinions-process/">The advisory opinion process</a>
   </div>
   <div class="u-no-print">

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -51,7 +51,7 @@
       </div>
       <div class="row">
         <div class="message message--info">
-          <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
+          <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requestors and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
         </div>
       </div>
     </div>

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -10,7 +10,7 @@
       Advisory opinions are official Commission responses to questions about how federal campaign finance law applies to specific, factual situations.
     </p>
     <p>
-      This archive contains advisory opinions from 1975 to the present. It also contains documents related to advisory opinions &mdash such as requests, drafts and public comments &mdash from 1990 to the present.
+      This archive contains advisory opinions from 1975 to the present. It also contains documents related to advisory opinions &mdash; such as requests, drafts and public comments &mdash; from 1990 to the present.
     </p>
     <a class="button button--cta button--go" href="/legal-resources/advisory-opinions-process/">The advisory opinion process</a>
   </div>

--- a/fec/legal/templates/legal-advisory-opinions-landing.jinja
+++ b/fec/legal/templates/legal-advisory-opinions-landing.jinja
@@ -77,7 +77,7 @@
   </div>
   {% else %}
   <div class="message message--info">
-    <h3>No pending Advisory Opinions</h3>
+    <h3>No pending advisory opinions</h3>
   </div>
   {% endif %}
 </section>

--- a/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
+++ b/fec/legal/templates/partials/legal-search-results-advisory-opinion.jinja
@@ -1,5 +1,5 @@
 <div class="message message--info">
-  <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requesters and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
+  <p>The advisory opinion search feature includes all FEC advisory opinions &#40;AOs&#41; to date. You can search all FEC AOs using keywords, AO numbers, names of requestors and more. For additional search filters, you can still search AOs using our legacy <a href="http://saos.fec.gov/saos/searchao">AO search</a>.</p>
 </div>
 
 {% for advisory_opinion in advisory_opinions %}


### PR DESCRIPTION
## Summary
This work helps us prepare for replacing the old legal resources landing page with the new design.

## Changes
- Moves text from the landing page to the AO overview page as part of https://github.com/18F/fec-cms/issues/1393
- Makes the spelling of "requesters"/"requestors" consistently "requestors" across the messages. Resolves https://github.com/18F/fec-cms/issues/1435
- Uncapitalizes "Advisory Opinions" in the "No pending AOs" message because we don't use it as a proper noun unless it's the title of an AO

## Screenshots

⚠️  I'm still having trouble running the site locally, so these screenshots are from the inspector. The reviewer *must* run this locally before approving and merging.

<img width="1179" alt="screen shot 2017-11-02 at 10 28 16 am" src="https://user-images.githubusercontent.com/11636908/32351185-ebcc7cca-bff2-11e7-9cc0-21d1b1ce2df1.png">
<img width="973" alt="screen shot 2017-11-02 at 5 19 48 pm" src="https://user-images.githubusercontent.com/11636908/32351186-eda88660-bff2-11e7-8103-7f94840c9894.png">
<img width="857" alt="screen shot 2017-11-02 at 5 18 38 pm" src="https://user-images.githubusercontent.com/11636908/32351191-ef304284-bff2-11e7-999e-23a8e2d02765.png">
