### PR TITLE
Hotfix/redirect mitigation

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -322,10 +322,10 @@ def committee(request, committee_id):
         # If there's no reports, find the first year with reports and redirect there
         for c in sorted(committee['cycles'], reverse=True):
             financials = api_caller.load_cmte_financials(committee['committee_id'], cycle=c)
-            if financials['reports']:
-                return redirect(
-                    url_for('committee_page', c_id=committee['committee_id'], cycle=c)
-                )
+            # if financials['reports']:
+            #     return redirect(
+            #         url_for('committee_page', c_id=committee['committee_id'], cycle=c)
+            #     )
 
     # If it's not a senate committee and we're in the current cycle
     # check if there's any raw filings in the last three days


### PR DESCRIPTION
Remove the redirect for now- that will get rid of the feature where it will default to the most recent cycle with data, but it will get you to the current page and then you can manually change cycles