### PR TITLE
Fix/tooltip under alignment

### DIFF
--- a/fec/fec/static/img/tooltip-point.svg
+++ b/fec/fec/static/img/tooltip-point.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="10px" viewBox="0 0 20 10" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <title>tooltip-point</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="tooltip-point">
+            <polygon id="Path-2" fill="#112E51" points="0 10 2.00851609 10 10.00819 10 17.9925609 10 20 10 10.00819 0"></polygon>
+            <polygon id="Triangle-2" fill="#FFFFFF" points="10 2.5 17.5 10 2.5 10"></polygon>
+        </g>
+    </g>
+</svg>

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -267,6 +267,17 @@
   }
 }
 
+.fc-event-container:nth-child(1) {
+  .cal-details {
+    margin-left: unset;
+
+    &::before {
+      right: auto;
+      left: u(2rem);
+    }
+  }
+}
+
 .fc-event-container:nth-child(7) {
   .cal-details {
     right: 0;

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -244,9 +244,9 @@
 // Event details
 .cal-details {
   font-size: u(1.4rem);
-  left: auto;
-  top: auto;
-  margin-top: u(1rem);
+  left: auto !important;
+  top: auto !important;
+  margin-top: u(1.5rem);
   margin-left: u(-8rem);
   padding: 0 !important;
   text-align: left;

--- a/fec/fec/static/scss/components/_calendar.scss
+++ b/fec/fec/static/scss/components/_calendar.scss
@@ -247,7 +247,8 @@
   left: auto;
   top: auto;
   margin-top: u(1rem);
-  padding: 0;
+  margin-left: u(-8rem);
+  padding: 0 !important;
   text-align: left;
   width: u(26rem);
   white-space: initial;
@@ -256,6 +257,7 @@
     @include triangle(2rem, $primary, up);
     background-image: none;
     left: 20%;
+    top: u(-2rem) !important;
   }
 
   .button--close--primary {

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -89,8 +89,6 @@
 .tooltip--under {
   $top: u(1rem);
   width: u(30rem);
-  left: u(-14rem);
-  top: calc(100% + #{$top});
 
   &::before {
     background-image: url('../img/tooltip-point.svg');

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -87,8 +87,10 @@
 //
 
 .tooltip--under {
+  $top: u(1.5rem);
   width: u(30rem);
-  margin-top: u(1.5rem);
+  left: u(-14rem);
+  top: calc(100% + #{$top});
 
   &::before {
     background-image: url('../img/tooltip-point.svg');

--- a/fec/fec/static/scss/components/_tooltips.scss
+++ b/fec/fec/static/scss/components/_tooltips.scss
@@ -87,8 +87,8 @@
 //
 
 .tooltip--under {
-  $top: u(1rem);
   width: u(30rem);
+  margin-top: u(1.5rem);
 
   &::before {
     background-image: url('../img/tooltip-point.svg');


### PR DESCRIPTION
This fix establishes override properties for the calendar detail tooltips so they are properly aligned on month-at-a-glance view. I also restored the top tooltip arrows so they show up now!

<img width="1038" alt="screen shot 2017-11-06 at 10 55 47 pm" src="https://user-images.githubusercontent.com/24054/32480934-106edd38-c346-11e7-854c-128bdb21eb75.png">
<img width="1044" alt="screen shot 2017-11-06 at 10 56 10 pm" src="https://user-images.githubusercontent.com/24054/32480937-12c85bea-c346-11e7-8f57-0ccfacc52765.png">
<img width="514" alt="screen shot 2017-11-06 at 10 55 40 pm" src="https://user-images.githubusercontent.com/24054/32480940-14a970b6-c346-11e7-839a-006c8ddc9ce0.png">

https://github.com/18F/fec-cms/issues/1274