### PR TITLE
Add license for assets that aren't in the public domain

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,20 +1,81 @@
-As a work of the United States Government, this project is in the public domain within the United States.
+# Licensing and attribution
 
-Additionally, we waive copyright and related rights in the work worldwide through the CC0 1.0 Universal public domain dedication.
+This project includes a mix of the following:
 
-A few restrictions limit the way you can use FEC data. For example, you can’t use contributor lists for commercial purposes or to solicit donations. [Learn more on FEC.gov.](http://www.fec.gov/pages/brochures/saleuse.shtml)
+* Open source works that are not in the public domain
+* Open source work by the U.S. government that is in the public domain
 
-## CC0 1.0 universal summary
+## Parts of this project that are not in the public domain
+
+### Files licensed under the SIL Open Font License
+
+The Karla font files in `fec-cms/fec/fec/static/fonts/` are from [Google Web Fonts](https://fonts.google.com/specimen/Karla), licensed under the [SIL Open Font License](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL), and copyright [Jonny Pinhorn](https://github.com/jonpinhorn) with Reserved Font Name ‘Karla'.
+
+
+### Files licensed under another license
+
+The Gandhi Serif font files in `fec-cms/fec/fec/static/fonts/` are from [Librerias Gandhi](http://www.tipografiagandhi.com/), and copyright 2012 [Librerias Gandhi S.A. de C.V.](http://www.gandhi.com.mx/) with Reserved Font Name ‘Gandhi Serif’. The English version of this License is reproduced below.
+
+#### Full English version of the license text for Gandhi Serif:
+
+```
+Conditions of use
+
+You may:
+- Install the fonts on as many devices as you wish.
+- Distribute the fonts to anyone you wish.
+- Use the fonts in any commercial or non-commercial document.
+- Save the fonts in a format that would best fit your purposes.
+
+You may not:
+- Modify the fonts in a font editor software.
+- Sell or rent out the fonts.
+
+Notes:
+- The fonts and any other accompanying written or electronic materials are provided "as is" without warranty of any kind, expressed or implied. The authors do not warrant that the functions contained in the fonts will meet the user's requirements.
+- The authors shall not be liable for any direct, indirect, consequential, or incidental damages (including damages from loss of business profits, business interruption, loss of business information, and the like) arising out of the use of or inability to use the fonts.
+```
+## Image licenses
+
+This site also includes a number of images that have various copyright statuses, including Creative Commons licenses and public domain. These images are in the `fec-cms/fec/fec/static/img/` directory.
+
+## The rest of this project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### CC0 1.0 universal summary
 What follows is a human-readable summary of the Legal Code. [Read the full text](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
 
-### No copyright
+#### No copyright
 The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
 
 You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
 
-### Other information
+### FEC data exceptions
+
+A few restrictions limit the way you can use FEC data. For example, you can’t use contributor lists for commercial purposes or to solicit donations. [Learn more on FEC.gov.](https://transition.fec.gov/pages/brochures/saleuse.shtml)
+
+#### Other information
 In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
 
 Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+## Reuse of open-source style guides
+Much of the design, guidance, and code in the FEC style guide is based on user interface (UI) patterns from the [U.S. Web Design Standards](https://standards.usa.gov/), including:
+- Grid column classes:  [/scss/_grid.scss](/blob/master/scss/_grid.scss)
+- Some colors in the color palette:  [/scss/_variables.scss](/blob/master/scss/_variables.scss)
+- Header navigation with mega menu
+- Footer navigation and guidance
+- Side navigation
+
+### Contributions to this project
+
+As stated in [CONTRIBUTING](CONTRIBUTING.md), all contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.
+
+
+
+
 
 

--- a/README.md
+++ b/README.md
@@ -281,11 +281,10 @@ More information about using SSH with cloud.dov can be found in the [cloud.gov S
 Accounts are handled in the cms admin. All accounts will be reviewed annually.
 
 
-## Copyright and licensing
-This project is in the public domain within the United States, and we waive
-worldwide copyright and related rights through [CC0 universal public domain
-dedication](https://creativecommons.org/publicdomain/zero/1.0/). Read more on
-our license page.
+## Licensing and attribution
+A few parts of this project are not in the public domain. Attribution and licensing information for those parts are described in detail in [LICENSE.md](LICENSE.md).
+
+The rest of this project is in the worldwide public domain, released under the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). Read more in [LICENSE.md](LICENSE.md).
 
 A few restrictions limit the way you can use FEC data. For example, you can't
 use contributor lists for commercial purposes or to solicit donations.  Learn


### PR DESCRIPTION
## Summary
When we merged the assets from `fec-style` into this repository, their licensing information didn't make the journey with them. This integrates special licenses specifically for fonts and images, as well as credits the US Web Design Standards. 

- FEC style license: https://github.com/18F/fec-style/blob/master/LICENSE.md

## Impacted areas if the application
List general components of the application that this PR will affect:

- Repository only