### PR TITLE
Display Withdrawn instead of date for withdrawn AOs - use AO status 

### DIFF
--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -13,9 +13,9 @@ function SearchResults(props) {
   }
 
   function getIssueDate(advisory_opinion) {
-    if(advisory_opinion.status === "Pending") {
+    if(advisory_opinion.status === 'Pending') {
         return "Pending";
-    } else if (advisory_opinion.status === "Withdrawn") {
+    } else if (advisory_opinion.status === 'Withdrawn') {
         return "Withdrawn";
     } else {
         return moment(advisory_opinion.issue_date).format('MM/DD/YYYY');

--- a/fec/fec/static/js/legal/SearchResults.js
+++ b/fec/fec/static/js/legal/SearchResults.js
@@ -13,15 +13,13 @@ function SearchResults(props) {
   }
 
   function getIssueDate(advisory_opinion) {
-    if(advisory_opinion.issue_date === "1900-01-01") {
-      if(advisory_opinion.is_pending) {
+    if(advisory_opinion.status === "Pending") {
         return "Pending";
-      } else {
+    } else if (advisory_opinion.status === "Withdrawn") {
         return "Withdrawn";
-      }
     } else {
         return moment(advisory_opinion.issue_date).format('MM/DD/YYYY');
-      }
+    }
   }
 
   if(props.loading) {

--- a/fec/fec/static/js/legal/Tags.js
+++ b/fec/fec/static/js/legal/Tags.js
@@ -8,7 +8,7 @@ function Tags(props) {
   const namedFields = [];
   Array.prototype.push.apply(namedFields, requestorOptions);
   Array.prototype.push.apply(namedFields, documentTypes);
-  namedFields.push({value: 'ao_status', text: "Pending"});
+  namedFields.push({value: 'ao_status', text: 'Pending'});
   var citationRequireAll = props.query.ao_citation_require_all && props.query.ao_citation_require_all !== 'false';
 
   function removeQuery(name, value) {

--- a/fec/fec/static/js/legal/Tags.js
+++ b/fec/fec/static/js/legal/Tags.js
@@ -8,7 +8,7 @@ function Tags(props) {
   const namedFields = [];
   Array.prototype.push.apply(namedFields, requestorOptions);
   Array.prototype.push.apply(namedFields, documentTypes);
-  namedFields.push({value: 'ao_is_pending', text: "Pending"});
+  namedFields.push({value: 'ao_status', text: "Pending"});
   var citationRequireAll = props.query.ao_citation_require_all && props.query.ao_citation_require_all !== 'false';
 
   function removeQuery(name, value) {

--- a/fec/legal/views.py
+++ b/fec/legal/views.py
@@ -19,7 +19,7 @@ def advisory_opinions_landing(request):
         query='',
         query_type='advisory_opinions',
         ao_category='R',
-        ao_is_pending=True
+        ao_status='Pending'
     )
     return render(request, 'legal-advisory-opinions-landing.jinja', {
         'parent': 'legal',


### PR DESCRIPTION
Note: This branch needs to point to openFEC branch `feature/add-ao-status-2` to work

Along with https://github.com/18F/openFEC/pull/2738, this resolves https://github.com/18F/fec-cms/issues/1390 
