### PR TITLE
Corrects link styling on related media for reporting example templates

### DIFF
--- a/fec/home/templates/home/reporting_example_page.html
+++ b/fec/home/templates/home/reporting_example_page.html
@@ -36,7 +36,7 @@
             <div class="grid__item">
               {% image block.image width-200 %}
               <span class="label">{{ block.media_type }}</span>
-              <p><a href="{{ block.url }}">{{ block.text }}</a></p>
+              <p><a class="t-sans" href="{{ block.url }}">{{ block.text }}</a></p>
             </div>
           {% endfor %}
         {% endwith %}


### PR DESCRIPTION
This corrects an applied text style that slipped through my earlier review by changing the title of the linked media to sans serif text. It's important to correct it now so that it can be used as precedent for the component to be re-used in https://github.com/18F/fec-cms/pull/1291


If I did things correctly, 

Before (left) | After (right)
<img width="512" alt="screen shot 2017-11-07 at 3 16 30 pm" src="https://user-images.githubusercontent.com/11636908/32516143-4e2abc70-c3d0-11e7-9bc9-d30aad2851fd.png">

cc @xtine @johnnyporkchops 