### PR TITLE
Make senate special cycles in election dropdowns data-driven

### DIFF
--- a/fec/data/api_caller.py
+++ b/fec/data/api_caller.py
@@ -311,3 +311,67 @@ def _get_sorted_documents(ao):
     sorted_documents = sorted(ao['documents'], key=itemgetter('description', 'document_id'), reverse=False)
     sorted_documents = sorted(sorted_documents, key=itemgetter('date'), reverse=True)
     return sorted_documents
+
+
+def call_senate_specials(state):
+    """ Call the API to get Senate special election information for
+        given state. Returns a list of dictionaries
+        Example: [{details for election1}][{details for election2}]
+    """
+    api_response = _call_api('election-dates',
+                             election_type_id='SG',
+                             office_sought='S',
+                             election_state=state)
+
+    special_results = api_response['results']
+
+    return special_results if 'results' in api_response else None
+
+
+def format_special_results(special_results):
+    """ Takes special_results, which is a list of dictionaries,
+        returns a list of election years. Round odd years up to even.
+        Example: [2008, 2000]
+    """
+    senate_specials = []
+
+    for result in special_results:
+
+        # Round odd years up to even years
+        result['election_year'] = result['election_year'] + (result['election_year'] % 2)
+
+        senate_specials.append(result['election_year'])
+
+    return senate_specials
+
+
+def get_regular_senate_cycles(state):
+    """ Get the list of election cycles based off Senate class
+    """
+    senate_cycles = []
+
+    for senate_class in ['1', '2', '3']:
+        if state.upper() in constants.SENATE_CLASSES[str(senate_class)]:
+            senate_cycles += utils.get_senate_cycles(senate_class)
+
+    return senate_cycles
+
+
+def get_all_senate_cycles(state):
+    """  Add together regularly scheduled and special senate elections
+        Return a list of election years sorted in descending order
+    """
+    senate_specials = format_special_results(call_senate_specials(state))
+    senate_regular_cycles = get_regular_senate_cycles(state)
+
+    all_senate_cycles = senate_regular_cycles
+
+    for special_year in senate_specials:
+        # Prevent duplicates
+        if special_year not in all_senate_cycles:
+            all_senate_cycles.append(special_year)
+
+    # Sort for readability
+    all_senate_cycles.sort(reverse=True)
+
+    return all_senate_cycles

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -632,13 +632,11 @@ IE_FORMATTER = OrderedDict([
 SENATE_CLASSES = {
     '1': ['AZ', 'CA', 'CT', 'DE', 'FL', 'HI', 'IN', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NJ', 'NM', 'NY', 'ND', 'OH', 'PA', 'RI', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
     '2': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY'],
-    '3': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI'],
-    'special': ['AL']
+    '3': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI']
 }
 
 NEXT_SENATE_ELECTIONS = {
     '1': 2018,
     '2': 2020,
-    '3': 2022,
-    'special': 2018
+    '3': 2022
 }

--- a/fec/data/tests/test_utils.py
+++ b/fec/data/tests/test_utils.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 from data.templatetags import filters
 import data.utils as utils
+import data.api_caller as api_caller
 
 class TestUtils(TestCase):
     def test_currency_filter_not_none(self):
@@ -71,9 +72,32 @@ class TestCycles(unittest.TestCase):
         assert utils.get_senate_cycles(1) == range(2018, 1979, -6)
 
     def test_state_senate_cycles(self):
+
+        # Testing mock result from call_senate_specials()
+        # and format_special_results() results
+        call_senate_specials_mock_wv = [{
+            'election_type_id': 'SG',
+            'election_type_full': 'Special election general',
+            'create_date': '2010-07-22T17:27:1600:00',
+            'election_state': 'WV',
+            'election_party': None,
+            'update_date': None,
+            'election_year': 2010,
+            'office_sought': 'S',
+            'election_date': '2010-11-02',
+            'election_notes': "Sen. Robert Byrd's Seat.",
+            'primary_general_date': '2016-09-16T16:09:22.555513'}]
+
+        # According to our mock call, WV has a special in 2010 and not 2018
+        westvirginia = api_caller.format_special_results(
+            call_senate_specials_mock_wv)
+
+        assert 2010 in westvirginia
+        assert 2018 not in westvirginia
+
         # Testing with an example state, Wisconsin
         # There should be an election in 2016 but not 2014
         # because of the classes the state has
-        wisconsin = utils.get_state_senate_cycles('wi')
+        wisconsin = api_caller.get_regular_senate_cycles('wi')
         assert 2016 in wisconsin
         assert 2014 not in wisconsin

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -211,14 +211,6 @@ def get_senate_cycles(senate_class):
     return range(next_election, constants.START_YEAR, -6)
 
 
-def get_state_senate_cycles(state):
-    senate_cycles = []
-    for senate_class in ['1', '2', '3', 'special']:
-        if state.upper() in constants.SENATE_CLASSES[str(senate_class)]:
-            senate_cycles += get_senate_cycles(senate_class)
-    return senate_cycles
-
-
 def three_days_ago():
     """Find the date three days ago"""
     three_days_ago = datetime.datetime.today() - datetime.timedelta(days=3)

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -366,7 +366,7 @@ def elections(request, office, cycle, state=None, district=None):
     if office.lower() == 'president':
         cycles = [each for each in cycles if each % 4 == 0]
     elif office.lower() == 'senate':
-        cycles = utils.get_state_senate_cycles(state)
+        cycles = api_caller.get_all_senate_cycles(state)
 
     if office.lower() not in ['president', 'senate', 'house']:
         raise Http404()


### PR DESCRIPTION
## Summary
Senate special elections can occur in years when there isn't usually an election in that state. Currently we're hard-coding states with specials in 2018, which isn't very sustainable for future cycles and states. This PR adds to `api_caller.py` so that senate specials on the data/elections pages are data-driven. 

- Addresses # [2621](https://github.com/18F/openFEC/issues/2621)
Change the logic so only the senate special cycles are added to the dropdown and not count backwards by 6 for that year. This will automatically add senate election years as new special elections are added to the `trc_election` tables. Made tests for new functionality. 

This also addressed a bug I found where extra elections were being added to AL due to senate special logic:

## Before
![image](https://user-images.githubusercontent.com/31420082/32969229-46220724-cbb2-11e7-8b97-403823f4b551.png)

## After
![image](https://user-images.githubusercontent.com/31420082/32969377-e843f256-cbb2-11e7-8dc4-a4080947414c.png)



## Impacted areas of the application
www.fec.gov/data/elections/office/state/cycle
www.fec.gov/data/elections/office/cycle
Example: http://fec.gov/data/elections/senate/AL/2018/
`views.py` -> `elections()`
`api_caller.py`
