### PR TITLE
Grid-item-w-image (for H4CC and Homepage getting started sections-PR 1441)

### DIFF
--- a/fec/fec/settings/dev.py
+++ b/fec/fec/settings/dev.py
@@ -10,7 +10,6 @@ for t in TEMPLATES:
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
-ALLOWED_HOSTS = ['*']
 
 try:
     from .local import *  # noqa

--- a/fec/fec/settings/dev.py
+++ b/fec/fec/settings/dev.py
@@ -10,6 +10,8 @@ for t in TEMPLATES:
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
+ALLOWED_HOSTS = ['*']
+
 try:
     from .local import *  # noqa
 except ImportError:

--- a/fec/fec/settings/dev.py
+++ b/fec/fec/settings/dev.py
@@ -10,7 +10,6 @@ for t in TEMPLATES:
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 
-
 try:
     from .local import *  # noqa
 except ImportError:

--- a/fec/fec/static/scss/layout/_grid.scss
+++ b/fec/fec/static/scss/layout/_grid.scss
@@ -74,29 +74,30 @@
 
 .grid__item--with-img {
   img {
+    height: u(15rem);
     object-fit: cover;
-    height:u(15rem);
   }
 }
 
-.grid__item--with-icon--primary {
+.grid__item--with-icon {
   img {
-    @include u-bg--primary();
-    padding: u(2rem);
+    height: u(15rem);
     object-fit: contain;
-    height:u(15rem);
-    width:100%;
+    padding: u(2rem);
+    width: 100%;
+    }
   }
-}
 
-.grid__item--with-icon--secondary {
+.grid__icon--secondary {
   img {
     @include u-bg--secondary();
-    padding: u(2rem);
-    object-fit: contain;
-    height:u(15rem);
-    width:100%;
-  }
+ }
+}
+
+.grid__icon--primary {
+  img {
+    @include u-bg--primary();
+ }
 }
 
 // We set a max-width to prevent the omega mixins from applying multiple times.

--- a/fec/fec/static/scss/layout/_grid.scss
+++ b/fec/fec/static/scss/layout/_grid.scss
@@ -85,6 +85,7 @@
     padding: u(2rem);
     object-fit: contain;
     height:u(15rem);
+    width:100%;
   }
 }
 
@@ -94,6 +95,7 @@
     padding: u(2rem);
     object-fit: contain;
     height:u(15rem);
+    width:100%;
   }
 }
 

--- a/fec/fec/static/scss/layout/_grid.scss
+++ b/fec/fec/static/scss/layout/_grid.scss
@@ -75,9 +75,7 @@
 .grid__item--with-img {
   img {
     object-fit: cover;
-    width:100%;
     height:u(15rem);
-    max-height:u(15rem);
   }
 }
 
@@ -86,7 +84,7 @@
     @include u-bg--primary();
     padding: u(2rem);
     object-fit: contain;
-    max-height:u(15rem);
+    height:u(15rem);
   }
 }
 
@@ -95,8 +93,7 @@
     @include u-bg--secondary();
     padding: u(2rem);
     object-fit: contain;
-    width:100%;
-    max-height:u(15rem);
+    height:u(15rem);
   }
 }
 

--- a/fec/fec/static/scss/layout/_grid.scss
+++ b/fec/fec/static/scss/layout/_grid.scss
@@ -72,6 +72,34 @@
   }
 }
 
+.grid__item--with-img {
+  img {
+    object-fit: cover;
+    width:100%;
+    height:u(15rem);
+    max-height:u(15rem);
+  }
+}
+
+.grid__item--with-icon--primary {
+  img {
+    @include u-bg--primary();
+    padding: u(2rem);
+    object-fit: contain;
+    max-height:u(15rem);
+  }
+}
+
+.grid__item--with-icon--secondary {
+  img {
+    @include u-bg--secondary();
+    padding: u(2rem);
+    object-fit: contain;
+    width:100%;
+    max-height:u(15rem);
+  }
+}
+
 // We set a max-width to prevent the omega mixins from applying multiple times.
 // This is based on $large-screen, but we have to convert to px so that we can
 // subtract a pixel. Otherwise, the breakpoints will overlap at 860px (the

--- a/fec/fec/static/scss/layout/_grid.scss
+++ b/fec/fec/static/scss/layout/_grid.scss
@@ -88,15 +88,15 @@
     }
   }
 
-.grid__icon--secondary {
+.grid__icon--deep-red {
   img {
-    @include u-bg--secondary();
+    background-color:$deep-red;
  }
 }
 
-.grid__icon--primary {
+.grid__icon--navy {
   img {
-    @include u-bg--primary();
+    background-color:$navy;
  }
 }
 

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -88,7 +88,7 @@
   </div>
   <div class="container">
      <ul class="grid grid--4-wide grid--flex">
-      <li class="grid__item grid__item--with-icon grid__icon--secondary">
+      <li class="grid__item grid__item--with-icon grid__icon--deep-red">
         <img src="{% static 'img/i-complex--regreport.svg' %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing information</a></h3>
       </li>
@@ -97,7 +97,7 @@
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/forms">Forms</a></h3>
         <p>All FEC registration reporting and forms</p>
       </li>
-      <li class="grid__item grid__item--with-icon grid__icon--secondary">
+      <li class="grid__item grid__item--with-icon grid__icon--deep-red">
         <img src="{% static 'img/i-complex--calendar.svg' %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Dates and deadlines</a></h3>
         <p>All FEC reporting deadlines, reporting periods and compliance periods</p>

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -73,7 +73,7 @@
     <h2>Popular topics</h2>
     <div class="grid grid--2-wide">
       <div class="grid__item">
-        <img src="{% static "img/feature--contributions-narrow.jpg" %}" alt="">
+        <img src="{% static 'img/feature--contributions-narrow.jpg' %}" alt="">
         <h3 class="u-no-margin"><a href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits-candidates/">Contribution limits</a></h3>
         <p>Under the Federal Election Campaign Finance Act, contributions are subject to limits. Those limits differ depending on the type of donor and recipient.</p>
       </div>
@@ -88,22 +88,22 @@
   </div>
   <div class="container">
      <ul class="grid grid--4-wide grid--flex">
-      <li class="grid__item grid__item--with-icon--secondary">
-        <img src="{% static "img/i-complex--regreport.svg" %}" alt="">
+      <li class="grid__item grid__item--with-icon grid__icon--secondary">
+        <img src="{% static 'img/i-complex--regreport.svg' %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing information</a></h3>
       </li>
       <li class="grid__item grid__item--with-img">
-        <img src="{% static "img/feature--forms.jpg" %}" alt="">
+        <img src="{% static 'img/feature--forms.jpg' %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/forms">Forms</a></h3>
         <p>All FEC registration reporting and forms</p>
       </li>
-      <li class="grid__item grid__item--with-icon--secondary">
-        <img src="{% static "img/i-complex--calendar.svg" %}" alt="">
+      <li class="grid__item grid__item--with-icon grid__icon--secondary">
+        <img src="{% static 'img/i-complex--calendar.svg' %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Dates and deadlines</a></h3>
         <p>All FEC reporting deadlines, reporting periods and compliance periods</p>
       </li>
       <li class="grid__item grid__item--with-img">
-        <img src="{% static "img/feature--training.jpg" %}" alt="">
+        <img src="{% static 'img/feature--training.jpg' %}" alt="">
         <h3 class="u-margin--top"><a href="https://transition.fec.gov/info/outreach.shtml">Education and learning</a></h3>
         <p>Videos, trainings, webinars and conferences</p>
       </li>

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -89,7 +89,7 @@
   <div class="container">
      <ul class="grid grid--4-wide grid--flex">
       <li class="grid__item grid__item--with-icon--secondary">
-        <img src="{% static "img/i-complex--regreport.png" %}" alt="">
+        <img src="{% static "img/i-complex--regreport.svg" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing information</a></h3>
       </li>
       <li class="grid__item grid__item--with-img">
@@ -98,7 +98,7 @@
         <p>All FEC registration reporting and forms</p>
       </li>
       <li class="grid__item grid__item--with-icon--secondary">
-        <img src="{% static "img/i-complex--calendar.png" %}" alt="">
+        <img src="{% static "img/i-complex--calendar.svg" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Dates and deadlines</a></h3>
         <p>All FEC reporting deadlines, reporting periods and compliance periods</p>
       </li>

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -92,8 +92,8 @@
         <img src="{% static "img/i-complex--regreport.png" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing information</a></h3>
       </li>
-      <li class="grid__item grid__item--with-icon--secondary">
-        <img src="{% static "img/feature--form-test.jpg" %}" alt="">
+      <li class="grid__item grid__item--with-img">
+        <img src="{% static "img/feature--forms.jpg" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/forms">Forms</a></h3>
         <p>All FEC registration reporting and forms</p>
       </li>

--- a/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
+++ b/fec/home/templates/home/candidate-and-committee-services/services_landing_page.html
@@ -80,7 +80,7 @@
       <div class="grid__item">
         <div class="heading--section heading--with-action">
           <h3 class="heading__left">Tips for treasurers</h3>
-          <a class="button button--alt heading__right" href="/updates/?update_type=tips-for-treasurers">All tips</a>
+          <a class="button button--updates heading__right" href="/updates/?update_type=tips-for-treasurers">All tips</a>
          </div>
             {% tips_for_treasurers_feed %}
       </div>
@@ -88,21 +88,21 @@
   </div>
   <div class="container">
      <ul class="grid grid--4-wide grid--flex">
-      <li class="grid__item">
-        <img src="{% static "img/feature--filing.jpg" %}" alt="">
+      <li class="grid__item grid__item--with-icon--secondary">
+        <img src="{% static "img/i-complex--regreport.png" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Electronic filing information</a></h3>
       </li>
-      <li class="grid__item">
-        <img src="{% static "img/feature--forms.jpg" %}" alt="">
+      <li class="grid__item grid__item--with-icon--secondary">
+        <img src="{% static "img/feature--form-test.jpg" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/forms">Forms</a></h3>
         <p>All FEC registration reporting and forms</p>
       </li>
-      <li class="grid__item">
-        <img src="{% static "img/feature--dates.jpg" %}" alt="">
+      <li class="grid__item grid__item--with-icon--secondary">
+        <img src="{% static "img/i-complex--calendar.png" %}" alt="">
         <h3 class="u-margin--top"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Dates and deadlines</a></h3>
         <p>All FEC reporting deadlines, reporting periods and compliance periods</p>
       </li>
-      <li class="grid__item">
+      <li class="grid__item grid__item--with-img">
         <img src="{% static "img/feature--training.jpg" %}" alt="">
         <h3 class="u-margin--top"><a href="https://transition.fec.gov/info/outreach.shtml">Education and learning</a></h3>
         <p>Videos, trainings, webinars and conferences</p>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -59,17 +59,17 @@
       <h2 class="heading--section u-margin--bottom">Get started</h2>
       <ul class="grid grid--3-wide grid--flex t-sans">
         <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static "img/feature--candidate-support.jpg" %}" alt="">
+          <img src="{% static 'img/feature--candidate-support.jpg' %}" alt="">
           <h3 class="t-sans u-margin--top">Find out how individuals can support federal candidates</h3>
           <div>Including making contributions, volunteering, internet activities and filing complaints</div>
           <a class="button button--cta button--go" href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/">Start learning</a>
         <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static "img/feature--compare-candidates.jpg" %}" alt="">
+          <img src="{% static 'img/feature--compare-candidates.jpg' %}" alt="">
           <h3 class="t-sans u-margin--top">Explore financial data for current and past elections and the candidates in those races</h3>
           <a class="button button--cta button--go" href="/data/#compare-candidates-in-an-election">Compare candidates</a>
         </li>
         <li class="grid__item grid__item--with-img grid__item--with-button">
-          <img src="{% static "img/feature--contributions.jpg" %}" alt="">
+          <img src="{% static 'img/feature--contributions.jpg' %}" alt="">
           <h3 class="t-sans u-margin--top">Learn about how much contributors can give to different types of committees</h3>
           <a class="button button--cta button--go" href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits-candidates/">Get the contribution limits</a>
         </li>
@@ -88,7 +88,7 @@
       <div class="grid grid--3-wide grid--no-border">
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--walther.jpg" %}" alt="Headshot of Steven T. Walther">
+            <img class="icon-heading__image" src="{% static 'img/headshot--walther.jpg' %}" alt="Headshot of Steven T. Walther">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
               <div class="t-note">Chairman</div>
@@ -98,7 +98,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--hunter.jpg" %}" alt="Headshot of Caroline C. Hunter">
+            <img class="icon-heading__image" src="{% static 'img/headshot--hunter.jpg' %}" alt="Headshot of Caroline C. Hunter">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
               <div class="t-note">Vice Chair</div>
@@ -108,7 +108,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--goodman.jpg" %}" alt="Headshot of Lee E. Goodman">
+            <img class="icon-heading__image" src="{% static 'img/headshot--goodman.jpg' %}" alt="Headshot of Lee E. Goodman">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/lee-e-goodman">Lee E. Goodman</a></div>
               <div class="t-sans">Republican</div>
@@ -117,7 +117,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--petersen.jpg" %}" alt="Headshot of Matthew S. Petersen">
+            <img class="icon-heading__image" src="{% static 'img/headshot--petersen.jpg' %}" alt="Headshot of Matthew S. Petersen">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/mathew-s-petersen">Matthew S. Petersen</a></div>
               <div class="t-sans">Republican</div>
@@ -126,7 +126,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--weintraub.jpg" %}" alt="Headshot of Ellen L. Weintraub">
+            <img class="icon-heading__image" src="{% static 'img/headshot--weintraub.jpg' %}" alt="Headshot of Ellen L. Weintraub">
             <div class="icon-heading__content">
               <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub">Ellen L. Weintraub</a></div>
               <div class="t-sans">Democrat</div>
@@ -135,7 +135,7 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Vacant Position">
+            <img class="icon-heading__image" src="{% static 'img/headshot--no-photo.jpg' %}" alt="Vacant Position">
             <div class="icon-heading__content">
               <div class="t-lead">Vacant seat</div>
               <div class="t-sans"></div>

--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -58,17 +58,17 @@
     <div class="container">
       <h2 class="heading--section u-margin--bottom">Get started</h2>
       <ul class="grid grid--3-wide grid--flex t-sans">
-        <li class="grid__item grid__item--with-button">
+        <li class="grid__item grid__item--with-img grid__item--with-button">
           <img src="{% static "img/feature--candidate-support.jpg" %}" alt="">
           <h3 class="t-sans u-margin--top">Find out how individuals can support federal candidates</h3>
           <div>Including making contributions, volunteering, internet activities and filing complaints</div>
           <a class="button button--cta button--go" href="/introduction-campaign-finance/understanding-ways-support-federal-candidates/">Start learning</a>
-        <li class="grid__item grid__item--with-button">
+        <li class="grid__item grid__item--with-img grid__item--with-button">
           <img src="{% static "img/feature--compare-candidates.jpg" %}" alt="">
           <h3 class="t-sans u-margin--top">Explore financial data for current and past elections and the candidates in those races</h3>
           <a class="button button--cta button--go" href="/data/#compare-candidates-in-an-election">Compare candidates</a>
         </li>
-        <li class="grid__item grid__item--with-button">
+        <li class="grid__item grid__item--with-img grid__item--with-button">
           <img src="{% static "img/feature--contributions.jpg" %}" alt="">
           <h3 class="t-sans u-margin--top">Learn about how much contributors can give to different types of committees</h3>
           <a class="button button--cta button--go" href="/help-candidates-and-committees/candidate-taking-receipts/contribution-limits-candidates/">Get the contribution limits</a>


### PR DESCRIPTION
**This PR replaces https://github.com/18F/fec-cms/pull/1441. Past history /screenshots can be seen there.** (This also incorporates requested review-edits from closed PR https://github.com/18F/fec-cms/pull/1466)

This PR specifically solves icon stretching problems that happened in mobile sizes when placing icon images in the generic grid items
This also solves the problem of unacceptably large image/icon-heights, taking up too much screen area in mobile sizes. 

This PR uses the object-fit property, among others, to apply styles to images that are inside of  responsive grid items.
This includes three new grid styles that expand upon existing styles--following the intended convention of modularity and the use of existing building blocks, rather that creating new.

**Browser compatibility:**
Browser support for object-fit is very good except for Internet Explorer Edge/11. However it has been prioritized for inclusion by MDN as of 10/17/17, and there are some workarounds that have been implemented here to limit any degradation of experience for IE users.

Screenshots show testing in Internet Explorer. By including 100%-width SVGs , instead of JPGs, icon stretching is eliminated. The mobile experience degradation is at an acceptable level for IE users.

![ie-11-screenshot](https://user-images.githubusercontent.com/5572856/32520247-56bda70a-c3dd-11e7-85c5-bc6df0c8e226.png)

![ie-11-screenshot_mobile](https://user-images.githubusercontent.com/5572856/32520254-5dd462d6-c3dd-11e7-9808-9f652a5c02df.png)


**IF ANY OF THE ABOVE FIELDS DO NOT APPLY, PLEASE DELETE THEM BEFORE SUBMITTING**