### PR TITLE
Adds space between "Amended" and type of notice

### DIFF
--- a/fec/fec/templates/partials/meeting.html
+++ b/fec/fec/templates/partials/meeting.html
@@ -13,7 +13,7 @@
 
        {% if meeting.sunshine_act_doc_upld %}
           {% for block in meeting.sunshine_act_doc_upld %}
-            <a href="{{ block.value.file.url }}">{% if forloop.counter >= 2 %}Amended{% endif %}Sunshine Act Notice</a>
+            <a href="{{ block.value.file.url }}">{% if forloop.counter >= 2 %}Amended {% endif %}Sunshine Act Notice</a>
             {% if meeting.sunshine_act_doc_upld|length > 2 and forloop.counter >= 2%}- {{ forloop.counter0 }}{% endif %}
             <br>
           {% endfor %}


### PR DESCRIPTION
## Summary

- Fixes #1484 
- Adds a space after "Amended" so that any type of document following with automatically have a space between the two words

## Impacted areas of the application
-  Meeting page feed: https://www.fec.gov/meetings/

## Screenshots

**Before**
<img width="756" alt="screen shot 2017-11-13 at 7 42 34 pm" src="https://user-images.githubusercontent.com/11636908/32757146-e999868e-c8ab-11e7-9019-31ef0a671ef1.png">

**After**
<img width="770" alt="screen shot 2017-11-13 at 7 42 53 pm" src="https://user-images.githubusercontent.com/11636908/32757155-f4fd5186-c8ab-11e7-8757-f9d3b8f51044.png">


____
❗️ Please run locally before merging to ensure this works as expected. 