### PR TITLE
Hard-code API link in footer

### DIFF
--- a/fec/fec/templates/partials/footer-navigation.html
+++ b/fec/fec/templates/partials/footer-navigation.html
@@ -61,7 +61,7 @@
       <div class="grid__item">
         <ul>
           <li>
-            <a href="{{ FEC_API_URL }}">OpenFEC API</a>
+            <a href="https://api.open.fec.gov">OpenFEC API</a>
           </li>
           <li>
             <a href="https://github.com/18F/fec">GitHub repository</a>


### PR DESCRIPTION
Hard-code API link in footer until we can pass FEC_API_URL into the jinja templates

## Summary

- Addresses #1447 
Hard-code API link in footer jinja template until we can pass FEC_API_URL into the jinja templates properly

## Impacted areas of the application
www.fec.gov home page API link in footer currently redirects to www.fec.gov. This PR hard-codes it to https://api.open.fec.gov/

![image](https://user-images.githubusercontent.com/31420082/32805669-1cd58ce4-c958-11e7-8341-29d4256ffdb5.png)

[fec-cms/fec/fec/templates/partials/footer-navigation.html](https://github.com/18F/fec-cms/blob/94cf215d68735a1874a4350a91922aef85389e7d/fec/fec/templates/partials/footer-navigation.html#L64)

