### PR TITLE
Set `Secure` and `HttpOnly` flags on cookies.

### DIFF
--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -1,5 +1,3 @@
-import os
-
 from .base import *  # noqa
 from .env import env
 
@@ -7,6 +5,11 @@ SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY')
 
 DEBUG = False
 TEMPLATE_DEBUG = False
+
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
 
 # TODO(jmcarp) Update after configuring DNS
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
Should resolve cookie security issues raised in slack at https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1510695955000310. Please test before merging--I pulled this from the django docs but haven't had time to verify manually.

@LindsayYoung 