### PR TITLE
Make 24/48 hr reports default filter selection for viewing independent expenditures

### DIFF
--- a/fec/data/templates/macros/filters/ie-reports.jinja
+++ b/fec/data/templates/macros/filters/ie-reports.jinja
@@ -10,13 +10,13 @@
       </div>
     </div>
   </div>
-  <label for="summary{{id_suffix}}" class="toggle">
-    <input type="radio" class="toggle" value="false" id="summary{{id_suffix}}" checked name="is_notice" data-tag-value="Regularly scheduled reports">
-    <span class="button--alt">Regularly scheduled reports</span>
-  </label>
   <label for="notice{{id_suffix}}" class="toggle">
     <input type="radio" class="toggle" value="true" id="notice{{id_suffix}}" name="is_notice" data-tag-value="24- and 48-Hour Reports">
     <span class="button--alt">24- and 48-Hour Reports</span>
+  </label>
+  <label for="summary{{id_suffix}}" class="toggle">
+    <input type="radio" class="toggle" value="false" id="summary{{id_suffix}}" checked name="is_notice" data-tag-value="Regularly scheduled reports">
+    <span class="button--alt">Regularly scheduled reports</span>
   </label>
 </fieldset>
 {% endmacro %}

--- a/fec/data/templates/macros/filters/ie-reports.jinja
+++ b/fec/data/templates/macros/filters/ie-reports.jinja
@@ -11,11 +11,11 @@
     </div>
   </div>
   <label for="notice{{id_suffix}}" class="toggle">
-    <input type="radio" class="toggle" value="true" id="notice{{id_suffix}}" name="is_notice" data-tag-value="24- and 48-Hour Reports">
+    <input type="radio" class="toggle" value="true" id="notice{{id_suffix}}" checked name="is_notice" data-tag-value="24- and 48-Hour Reports">
     <span class="button--alt">24- and 48-Hour Reports</span>
   </label>
   <label for="summary{{id_suffix}}" class="toggle">
-    <input type="radio" class="toggle" value="false" id="summary{{id_suffix}}" checked name="is_notice" data-tag-value="Regularly scheduled reports">
+    <input type="radio" class="toggle" value="false" id="summary{{id_suffix}}" name="is_notice" data-tag-value="Regularly scheduled reports">
     <span class="button--alt">Regularly scheduled reports</span>
   </label>
 </fieldset>

--- a/fec/data/templates/macros/filters/ie-reports.jinja
+++ b/fec/data/templates/macros/filters/ie-reports.jinja
@@ -6,7 +6,7 @@
     <div id="data-type-tooltip" role="tooltip" class="tooltip tooltip--under tooltip--left">
       <div class="tooltip__content">
         <p class="tooltip__content">Political committees file regular reports about their financial activity.</p>
-        <p class="tooltip__content">In certain circumstances — in addition to regularly scheduled repots — committees must also report independent expenditures within 24 or 48 hours.</p>
+        <p class="tooltip__content">In certain circumstances — in addition to regularly scheduled reports — committees must also report independent expenditures within 24 or 48 hours.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Addresses #1434 
- Changes the 24/48 hour report toggle to be the default option selected on page load. To support this, it also moves the selected option into the first position.
- I also caught a small typo in the tooltip content while I was looking.

## Impacted areas of the application
[Independent expenditures data table](https://www.fec.gov/data/independent-expenditures)

## Screenshots

If I did everything correctly, the before/after should look like this:

**Before:**
![screen shot 2017-11-15 at 1 43 29 pm](https://user-images.githubusercontent.com/11636908/32853936-ef0173ba-ca0a-11e7-9908-e0082b0499e1.png)


**After:** 
![screen shot 2017-11-15 at 1 42 28 pm](https://user-images.githubusercontent.com/11636908/32853904-d590b3c8-ca0a-11e7-9b12-942154bae5d8.png)

______________

❗️❗️  Please test this by running it locally (as you usually would)—I've had trouble with my local env so have not been able to test the functionality.