### PR TITLE
Set `Secure` and `HttpOnly` flags on cookies.

### DIFF
--- a/fec/fec/settings/production.py
+++ b/fec/fec/settings/production.py
@@ -1,5 +1,3 @@
-import os
-
 from .base import *  # noqa
 from .env import env
 
@@ -7,6 +5,11 @@ SECRET_KEY = env.get_credential('DJANGO_SECRET_KEY')
 
 DEBUG = False
 TEMPLATE_DEBUG = False
+
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+CSRF_COOKIE_SECURE = True
+CSRF_COOKIE_HTTPONLY = True
 
 # TODO(jmcarp) Update after configuring DNS
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/18F/fec-proxy/issues/67
This fix will add secure flag to the `csrftoken` cookie. This has been tested in dev. 

## Impacted areas of the application
List general components of the application that this PR will affect:

- Anywhere the csrf token is set. Also tested the portions of the site that may interact with this token such as the feedback form and wagtail. Seems to have worked seamlessly.   

## Screenshots
Screenshot of set cookie as secure.

![screen shot 2017-11-20 at 11 36 02 am](https://user-images.githubusercontent.com/12799132/33030159-923d0158-cde8-11e7-8a89-7af56b54e586.png)


## Related PRs
List related PRs against other branches:

Below branch and PR were merged into dev for testing. Test was successful.

cookie-headers | https://github.com/18F/fec-cms/pull/1494