### PR TITLE
Fixed redirect to cycle with data

### DIFF
--- a/fec/data/urls.py
+++ b/fec/data/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     url(r'^data/search/$', views.search),
     url(r'^data/advanced/$', views.advanced),
     url(r'^data/candidate/(?P<candidate_id>\w+)/$', views.candidate),
-    url(r'^data/committee/(?P<committee_id>\w+)/$', views.committee),
+    url(r'^data/committee/(?P<committee_id>\w+)/$', views.committee, name='committee-by-id'),
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<district>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<state>\w+)/(?P<cycle>[0-9]+)/$', views.elections),
     url(r'^data/elections/(?P<office>\w+)/(?P<cycle>[0-9]+)/$', views.elections),

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render, redirect
+from django.urls import reverse
 from django.http import Http404
 from django.http import JsonResponse
 from django.conf import settings
@@ -323,10 +324,10 @@ def committee(request, committee_id):
         # If there's no reports, find the first year with reports and redirect there
         for c in sorted(committee['cycles'], reverse=True):
             financials = api_caller.load_cmte_financials(committee['committee_id'], cycle=c)
-            # if financials['reports']:
-            #     return redirect(
-            #         url_for('committee_page', c_id=committee['committee_id'], cycle=c)
-            #     )
+            if financials['reports']:
+                return redirect(
+                    reverse('committee-by-id', kwargs={'committee_id': committee['committee_id']}) + '?cycle=' + str(c)
+                )
 
     # If it's not a senate committee and we're in the current cycle
     # check if there's any raw filings in the last three days


### PR DESCRIPTION
## Summary

- Addresses #1461 
- Previous implementation was using a `url_for` function to construct the redirect, which is using a flask function. To fix this, we needed to convert the redirect to use a django url constructor. Django's `reverse()` was used in the PR.

## Impacted areas of the application
List general components of the application that this PR will affect:
-  Data section of the site. Examples of url that was previously effected: http://localhost:8000/data/committee/C90011677/. The redirect now redirects to the most recent cycle with data.