### PR TITLE
Feature/senate next election year

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -634,9 +634,3 @@ SENATE_CLASSES = {
     '2': ['AL', 'AK', 'AR', 'CO', 'DE', 'GA', 'ID', 'IL', 'IA', 'KS', 'KY', 'LA', 'ME', 'MA', 'MI', 'MN', 'MS', 'MT', 'NE', 'NH', 'NJ', 'NM', 'NC', 'OK', 'OR', 'RI', 'SC', 'SD', 'TN', 'TX', 'VA', 'WV', 'WY'],
     '3': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI']
 }
-
-# NEXT_SENATE_ELECTIONS = {
-#     '1': 2018,
-#     '2': 2020,
-#     '3': 2022
-# }

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -635,8 +635,8 @@ SENATE_CLASSES = {
     '3': ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'MD', 'MO', 'NV', 'NH', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'SC', 'SD', 'UT', 'VT', 'WA', 'WI']
 }
 
-NEXT_SENATE_ELECTIONS = {
-    '1': 2018,
-    '2': 2020,
-    '3': 2022
-}
+# NEXT_SENATE_ELECTIONS = {
+#     '1': 2018,
+#     '2': 2020,
+#     '3': 2022
+# }

--- a/fec/data/tests/test_utils.py
+++ b/fec/data/tests/test_utils.py
@@ -69,7 +69,11 @@ class TestCycles(unittest.TestCase):
         assert utils.get_cycles(2020) == range(2020, 1979, -2)
 
     def test_get_senate_cycles(self):
-        assert utils.get_senate_cycles(1) == range(2018, 1979, -6)
+        current_cycle = 2018
+        assert utils.get_senate_cycles('1') == range(current_cycle, 1979, -6)
+        assert utils.get_senate_cycles('2') == range(current_cycle + 2, 1979, -6)
+        assert utils.get_senate_cycles('3') == range(current_cycle + 4, 1979, -6)
+
 
     def test_state_senate_cycles(self):
 

--- a/fec/data/tests/test_utils.py
+++ b/fec/data/tests/test_utils.py
@@ -70,9 +70,28 @@ class TestCycles(unittest.TestCase):
 
     def test_get_senate_cycles(self):
         current_cycle = 2018
-        assert utils.get_senate_cycles('1') == range(current_cycle, 1979, -6)
-        assert utils.get_senate_cycles('2') == range(current_cycle + 2, 1979, -6)
-        assert utils.get_senate_cycles('3') == range(current_cycle + 4, 1979, -6)
+        assert utils.get_senate_cycles('1', current_cycle) == range(
+            2018, 1979, -6)
+        assert utils.get_senate_cycles('2', current_cycle) == range(
+            2020, 1979, -6)
+        assert utils.get_senate_cycles('3', current_cycle) == range(
+            2022, 1979, -6)
+
+        current_cycle = 2020
+        assert utils.get_senate_cycles('1', current_cycle) == range(
+            2024, 1979, -6)
+        assert utils.get_senate_cycles('2', current_cycle) == range(
+            2020, 1979, -6)
+        assert utils.get_senate_cycles('3', current_cycle) == range(
+            2022, 1979, -6)
+
+        current_cycle = 2022
+        assert utils.get_senate_cycles('1', current_cycle) == range(
+            2024, 1979, -6)
+        assert utils.get_senate_cycles('2', current_cycle) == range(
+            2026, 1979, -6)
+        assert utils.get_senate_cycles('3', current_cycle) == range(
+            2022, 1979, -6)
 
 
     def test_state_senate_cycles(self):

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -215,22 +215,24 @@ def get_next_senate_elections(current_cycle):
     For example, class 1 will always be up for election in years
     with year % 6 = 2, for example 2018.
     """
-    next_election_cycles = {
+    next_election_decoder = {
         2: {'1': current_cycle, '2': (current_cycle + 2), '3': (current_cycle + 4)},
         4: {'2': current_cycle, '3': (current_cycle + 2), '1': (current_cycle + 4)},
         0: {'3': current_cycle, '1': (current_cycle + 2), '2': (current_cycle + 4)}
     }
-    return next_election_cycles.get(current_cycle % 6)
+    return next_election_decoder.get(current_cycle % 6)
 
 
-def get_senate_cycles(senate_class, current_cycle=current_cycle()):
+def get_senate_cycles(senate_class, cycle=None):
     """
     Returns an list of elections based on senate class
     Uses get_next_senate_elections to find out
     which classes are up for election
     Adds years to current cycle depending on what position the class is in
     """
-    senate_classes = get_next_senate_elections(current_cycle)
+    if cycle is None:
+        cycle = current_cycle()
+    senate_classes = get_next_senate_elections(cycle)
     return range(senate_classes.get(senate_class), constants.START_YEAR, -6)
 
 

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -13,7 +13,6 @@ def current_cycle():
     year = datetime.datetime.now().year
     return year + year % 2
 
-
 class LRUCache(cachecontrol.cache.BaseCache):
     """A thread-safe least recently updated cache adapted to work with
     Cache-Control.
@@ -206,13 +205,43 @@ def process_ie_data(totals):
     return financial_summary_processor(totals, constants.IE_FORMATTER)
 
 
+def get_current_year_class():
+    """Get Class number for current year
+    """
+    if (current_cycle() - constants.END_YEAR) % 6 == 0:
+        current_year_class = '1'
+    elif (current_cycle() - constants.END_YEAR + 4) % 6 == 0:
+        current_year_class = '2'
+    elif (current_cycle() - constants.END_YEAR + 2) % 6 == 0:
+        current_year_class = '3'
+    return current_year_class
+
+
 def get_senate_cycles(senate_class):
-    if senate_class in '1':
-        next_election = current_cycle()
-    elif senate_class in '2':
-        next_election = current_cycle() + 2
-    elif senate_class in '3':
-        next_election = current_cycle() + 4
+
+    if get_current_year_class() in '1':
+        if senate_class in '1':
+            next_election = current_cycle()
+        elif senate_class in '2':
+            next_election = current_cycle() + 2
+        elif senate_class in '3':
+            next_election = current_cycle() + 4
+
+    elif get_current_year_class() in '2':
+        if senate_class in '1':
+            next_election = current_cycle() + 4
+        elif senate_class in '2':
+            next_election = current_cycle()
+        elif senate_class in '3':
+            next_election = current_cycle() + 2
+
+    elif get_current_year_class() in '3':
+        if senate_class in '1':
+            next_election = current_cycle() + 2
+        elif senate_class in '2':
+            next_election = current_cycle() + 4
+        elif senate_class in '3':
+            next_election = current_cycle()
 
     return range(next_election, constants.START_YEAR, -6)
 

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -205,45 +205,33 @@ def process_ie_data(totals):
     return financial_summary_processor(totals, constants.IE_FORMATTER)
 
 
-def get_current_year_class():
-    """Get Class number for current year
+def get_next_senate_elections(current_cycle):
     """
-    if (current_cycle() - constants.END_YEAR) % 6 == 0:
-        current_year_class = '1'
-    elif (current_cycle() - constants.END_YEAR + 4) % 6 == 0:
-        current_year_class = '2'
-    elif (current_cycle() - constants.END_YEAR + 2) % 6 == 0:
-        current_year_class = '3'
-    return current_year_class
+    Returns an dictionary of senate classes in chronological order
+    based on current cycle year
+    Uses mod 6 to determine what senate classes are up for election
+    in the current cycle
+
+    For example, class 1 will always be up for election in years
+    with year % 6 = 2, for example 2018.
+    """
+    next_election_cycles = {
+        2: {'1': current_cycle, '2': (current_cycle + 2), '3': (current_cycle + 4)},
+        4: {'2': current_cycle, '3': (current_cycle + 2), '1': (current_cycle + 4)},
+        0: {'3': current_cycle, '1': (current_cycle + 2), '2': (current_cycle + 4)}
+    }
+    return next_election_cycles.get(current_cycle % 6)
 
 
-def get_senate_cycles(senate_class):
-
-    if get_current_year_class() in '1':
-        if senate_class in '1':
-            next_election = current_cycle()
-        elif senate_class in '2':
-            next_election = current_cycle() + 2
-        elif senate_class in '3':
-            next_election = current_cycle() + 4
-
-    elif get_current_year_class() in '2':
-        if senate_class in '1':
-            next_election = current_cycle() + 4
-        elif senate_class in '2':
-            next_election = current_cycle()
-        elif senate_class in '3':
-            next_election = current_cycle() + 2
-
-    elif get_current_year_class() in '3':
-        if senate_class in '1':
-            next_election = current_cycle() + 2
-        elif senate_class in '2':
-            next_election = current_cycle() + 4
-        elif senate_class in '3':
-            next_election = current_cycle()
-
-    return range(next_election, constants.START_YEAR, -6)
+def get_senate_cycles(senate_class, current_cycle=current_cycle()):
+    """
+    Returns an list of elections based on senate class
+    Uses get_next_senate_elections to find out
+    which classes are up for election
+    Adds years to current cycle depending on what position the class is in
+    """
+    senate_classes = get_next_senate_elections(current_cycle)
+    return range(senate_classes.get(senate_class), constants.START_YEAR, -6)
 
 
 def three_days_ago():

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -207,7 +207,15 @@ def process_ie_data(totals):
 
 
 def get_senate_cycles(senate_class):
-    next_election = constants.NEXT_SENATE_ELECTIONS[str(senate_class)]
+    # next_election = constants.NEXT_SENATE_ELECTIONS[str(senate_class)]
+    if senate_class in '1':
+        next_election = current_cycle()
+    elif senate_class in '2':
+        next_election = current_cycle() + 2
+    elif senate_class in '3':
+        next_election = current_cycle() + 4
+
+    print(next_election)
     return range(next_election, constants.START_YEAR, -6)
 
 

--- a/fec/data/utils.py
+++ b/fec/data/utils.py
@@ -207,7 +207,6 @@ def process_ie_data(totals):
 
 
 def get_senate_cycles(senate_class):
-    # next_election = constants.NEXT_SENATE_ELECTIONS[str(senate_class)]
     if senate_class in '1':
         next_election = current_cycle()
     elif senate_class in '2':
@@ -215,7 +214,6 @@ def get_senate_cycles(senate_class):
     elif senate_class in '3':
         next_election = current_cycle() + 4
 
-    print(next_election)
     return range(next_election, constants.START_YEAR, -6)
 
 


### PR DESCRIPTION
## Summary (required)

- Addresses # [_Issue number_]
_Include a summary of proposed changes._

## Impacted areas of the application

1) modify function **def get_senate_cycles** in utils.py to get next election year from a formula instead of from constants.py

2)remove the NEXT_SENATE_ELECTIONS from constants.py

3)add test case into test_utils.py 
def test_get_senate_cycles

## Related issue on openFEC repo #2692:
[https://github.com/18F/openFEC/issues/2692
](url)


