### PR TITLE
Set default border radius on buttons

### DIFF
--- a/fec/fec/static/scss/elements/_forms.scss
+++ b/fec/fec/static/scss/elements/_forms.scss
@@ -210,6 +210,7 @@ button {
   @include appearance(none);
   background: none;
   border: none;
+  border-radius: 0;
   cursor: pointer;
   display: inline-block;
   font-family: $sans-serif;


### PR DESCRIPTION
## Set default border radius on buttons
Set default property `border-radius: 0;` on input buttons.

## Impacted areas of the application
It seems that Chrome now sets a default `border-radius: 4px` property for inputs if they are not pre-defined, causing accordions to have a border radius:
<img width="824" alt="screen shot 2017-12-05 at 12 56 00 pm" src="https://user-images.githubusercontent.com/24054/33627732-a88bbf42-d9bb-11e7-81ff-144f24c1c393.png">

After this fix, they should show up as they should:
<img width="831" alt="screen shot 2017-12-05 at 12 56 31 pm" src="https://user-images.githubusercontent.com/24054/33627770-bd17eba2-d9bb-11e7-8d0b-0f59f9c1e768.png">


