### PR TITLE
Fix 3 typos in Glossary

### DIFF
--- a/fec/fec/static/js/data/terms.json
+++ b/fec/fec/static/js/data/terms.json
@@ -221,7 +221,7 @@
   },
   {
     "term": "Federally chartered corporation",
-    "definition": "- A corporation that is organized pursuant to a federal statute and that became a corporation when it received a charter from a federal agency. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1988-12\">AOs 1988-12</a> and <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1984-63\">1984-63</a>."
+    "definition": "A corporation that is organized pursuant to a federal statute and that became a corporation when it received a charter from a federal agency. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1988-12\">AOs 1988-12</a> and <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1984-63\">1984-63</a>."
   },
   {
     "term": "Filing",

--- a/fec/fec/static/js/data/terms.json
+++ b/fec/fec/static/js/data/terms.json
@@ -400,7 +400,7 @@
     "definition": "An individual, partnership, political committee, corporation, labor organization or any other organization or group of persons, not including the federal government. 11 CFR <a href=\"https://www.fec.gov/regulations/100-10/CURRENT#100-10\">100.10</a>."
   },
   {
-    "term": "Personal funds of a candidae",
+    "term": "Personal funds of a candidate",
     "definition": "The personal funds of a candidate include: <ol><li>Assets which the candidate has a legal right of access to or control over, and which he or she has legal title to or an equitable interest in, at the time of candidacy;</li><li>Income from employment;</li><li>Dividends and interest from, and proceeds from sale or liquidation of, stocks and other investments;</li><li>Income from trusts, if established before the election cycle;</li><li>Income from trusts established by bequests (even after candidacy)</li><li>Bequests to the candidate;</li><li>Personal gifts that had been customarily received by the candidate prior to the beginning of the election cycle; and</li><li>Proceeds from lotteries and similar games of chance.</li></ol> 11 CFR <a href=\"https://www.fec.gov/regulations/100-33/CURRENT#100-33\">100.33(a) and (b)</a>."
   },
   {

--- a/fec/fec/static/js/data/terms.json
+++ b/fec/fec/static/js/data/terms.json
@@ -149,7 +149,7 @@
   },
   {
     "term": "District",
-    "definition": "A U.S. House of Representatives District. Because senators represent an entire state, Senate races do not have districts associated with them."
+    "definition": "A U.S. House of Representatives District. Because Senators represent an entire state, Senate races do not have districts associated with them."
   },
   {
     "term": "Donation",


### PR DESCRIPTION
## Summary
Fix missing "t" in "personal funds..." 
Remove "- "from "Federally Chartered"
Capitalize "Senator" in "District"