### PR TITLE
Pluralize "Candidates" and "Committees" data table titles

### DIFF
--- a/fec/fec/static/js/pages/datatable-candidates.js
+++ b/fec/fec/static/js/pages/datatable-candidates.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     autoWidth: false,
-    title: 'Candidate',
+    title: 'Candidates',
     path: ['candidates'],
     columns: columns.candidates,
     order: [[6, 'desc']],

--- a/fec/fec/static/js/pages/datatable-committees.js
+++ b/fec/fec/static/js/pages/datatable-committees.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
   var $table = $('#results');
   new tables.DataTable($table, {
     autoWidth: false,
-    title: 'Committee',
+    title: 'Committees',
     path: ['committees'],
     columns: columns.committees,
     useFilters: true,


### PR DESCRIPTION
## Summary

- I happened to notice this randomly, so there is no corresponding issue.
- Previously, the page titles were singular "Candidate" and "Committee" — which is awkward and incorrect since the data tables show data for all candidates and all committees, not a single one. The breadcrumbs and url on each page also uses a plural format, so I think they were singular by mistake.
- This change also makes the titles consistent with all of the other data table page titles, which are plural.

## Impacted areas of the application
- [All candidates data table page](https://www.fec.gov/data/candidates/?has_raised_funds=true)
- [All committees data table page](https://www.fec.gov/data/committees/)

## Screenshots

**Before**
<img width="660" alt="screen shot 2017-12-06 at 11 03 12 am" src="https://user-images.githubusercontent.com/11636908/33671621-1bd0cfa0-da76-11e7-8fa0-b347bf590176.png">
<img width="633" alt="screen shot 2017-12-06 at 11 03 40 am" src="https://user-images.githubusercontent.com/11636908/33671622-1bdae4b8-da76-11e7-8e71-cb4729a3029f.png">


**After**
<img width="663" alt="screen shot 2017-12-06 at 11 03 29 am" src="https://user-images.githubusercontent.com/11636908/33671625-20a0c8d2-da76-11e7-9dd4-4069ab40d6ba.png">
<img width="634" alt="screen shot 2017-12-06 at 11 03 53 am" src="https://user-images.githubusercontent.com/11636908/33671626-20b00b08-da76-11e7-814d-9e068e1d1209.png">

