### PR TITLE
Replace 'Election Cycle' filter label text with 'Two year' period

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -46,7 +46,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Election cycle</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query">
         {% for each in cycles | sort(reverse=True) %}
           <option
@@ -63,7 +63,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Election cycle</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="path">
         {% for each in cycles | sort(reverse=True) %}
           <option


### PR DESCRIPTION
## Summary (required)
Relabel (replace text) the heading for the drop-down from "Election cycle" to "Two-year period"
on the following types of webpages:
- Election Summary / Candidate Financial Comparisons pages
- Election Summary / Candidate Contributions Comparisons pages
- Committee profile pages

Addresses # 1605 https://github.com/18F/fec-cms/issues/1605

Summary of changes:
Changes to the cycle-select Jiinja file for the following templates:
1) election_cycle_select template 
2) committee_cycle_select component / template

## Impacted areas of the application
List general components of the application that this PR will affect:
-  Election Cycle (now 'Two-Year Period') drop down menu - text on label / heading only

## Screenshots
House election summary: Compare Candidate Financial Totals
https://www.fec.gov/data/elections/house/DC/00/2018/

Before:
![house election summary page](https://user-images.githubusercontent.com/24944162/33784030-34976a18-dc2d-11e7-878c-26c320284c26.jpeg)

After:
![compare candidate financial totals](https://user-images.githubusercontent.com/24944162/33784056-5327595c-dc2d-11e7-88ef-20f549cbb079.jpeg)


Compare Individual Contributions
After:
![compare individual contributions](https://user-images.githubusercontent.com/24944162/33784064-5d883fd8-dc2d-11e7-9f2f-7b32a99e56c3.jpeg)

Committee Profile- Financial Summary
After:
![committee profile- financial summary](https://user-images.githubusercontent.com/24944162/33784070-6a09e3f6-dc2d-11e7-9ea3-2e2fd8a8b889.jpeg)

## Related PRs
List related PRs against other branches: none