### PR TITLE
[MERGE WITH GITFLOW] Hotfix/fix candidate 2 yr summary cycle

### DIFF
--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -330,10 +330,10 @@ def committee(request, committee_id):
         # If there's no reports, find the first year with reports and redirect there
         for c in sorted(committee['cycles'], reverse=True):
             financials = api_caller.load_cmte_financials(committee['committee_id'], cycle=c)
-            if financials['reports']:
-                return redirect(
-                    reverse('committee-by-id', kwargs={'committee_id': committee['committee_id']}) + '?cycle=' + str(c)
-                )
+            # if financials['reports']:
+            #     return redirect(
+            #         url_for('committee_page', c_id=committee['committee_id'], cycle=c)
+            #     )
 
     # If it's not a senate committee and we're in the current cycle
     # check if there's any raw filings in the last three days

--- a/fec/fec/static/scss/layout/_layout.scss
+++ b/fec/fec/static/scss/layout/_layout.scss
@@ -171,7 +171,7 @@
 
 // Class applied to candidate and committee pages with tabs
 .tab-interface {
-  overflow-x: hidden;
+  overflow: hidden;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- Addresses https://github.com/18F/fec-cms/issues/1634
- The `election_full` url query string used to be passed into the application in openFEC-web-app as a boolean. However after merge, we failed to account for this and passed it into `data/views.py` as a string. This caused a failure in logic because if we check `if election_full`, it would always return `True` as a string. We fix this by converting `election_full` from a string to a boolean right after the get request.
- I also fixed a UI bug caused by newer versions (62+) of Chrome that would show overflows on side bars that take up the entire window which affected Candidate pages.

## Impacted areas of the application
- Candidate summary pages.

## Screenshots
Correct behavior:
<img width="844" alt="screen shot 2017-12-08 at 2 40 26 pm" src="https://user-images.githubusercontent.com/24054/33786288-c45a4f9c-dc25-11e7-905d-91f94765d2b6.png">

Fixes this Chrome overflow issue with side nav: 
<img width="1438" alt="screen shot 2017-12-08 at 1 21 21 pm" src="https://user-images.githubusercontent.com/24054/33786471-9026bf84-dc26-11e7-985e-5e7ce73bdf0a.png">
