### PR TITLE
Election 'cycle' text changes to web pages

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -46,7 +46,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year Period</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query">
         {% for each in cycles | sort(reverse=True) %}
           <option
@@ -63,7 +63,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year Period</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="path">
         {% for each in cycles | sort(reverse=True) %}
           <option

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -30,7 +30,7 @@
 {% macro candidate_cycle_select(cycles, cycle=none, id='') %}
 {% set cycle = cycle | int %}
   <div class="content__section">
-    <label for="{{id}}-cycle" class="label cycle-select__label">Election cycle</label>
+    <label for="{{id}}-cycle" class="label cycle-select__label">Election</label>
     <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query" data-election-full="False">
       {% for each in cycles | sort(reverse=True) %}
         <option
@@ -46,7 +46,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Election cycle</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year Period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="query">
         {% for each in cycles | sort(reverse=True) %}
           <option
@@ -63,7 +63,7 @@
 {% set cycle = cycle | int %}
   <div class="row content__section">
     <div class="cycle-select">
-      <label for="{{id}}-cycle" class="label cycle-select__label">Election cycle</label>
+      <label for="{{id}}-cycle" class="label cycle-select__label">Two-year Period</label>
       <select id="{{id}}-cycle" class="js-cycle" name="cycle" data-cycle-location="path">
         {% for each in cycles | sort(reverse=True) %}
           <option

--- a/fec/fec/static/js/templates/election-cycles.hbs
+++ b/fec/fec/static/js/templates/election-cycles.hbs
@@ -9,7 +9,7 @@
       />
     <span class="button--alt">
       {{#if full}}
-      Full cycle:
+      All Years:
       {{/if}}
       {{min}}–{{max}}
     </span>

--- a/fec/fec/static/js/templates/election-cycles.hbs
+++ b/fec/fec/static/js/templates/election-cycles.hbs
@@ -9,7 +9,7 @@
       />
     <span class="button--alt">
       {{#if full}}
-      All Years:
+      All years:
       {{/if}}
       {{min}}–{{max}}
     </span>

--- a/fec/fec/static/js/templates/electionCycles.hbs
+++ b/fec/fec/static/js/templates/electionCycles.hbs
@@ -13,7 +13,7 @@
         />
       <span class="button--alt {{#unless active}}is-disabled{{/unless}}">
         {{#if electionFull}}
-        All Years:
+        All years:
         {{/if}}
         {{min}}–{{max}}
       </span>

--- a/fec/fec/static/js/templates/electionCycles.hbs
+++ b/fec/fec/static/js/templates/electionCycles.hbs
@@ -13,7 +13,7 @@
         />
       <span class="button--alt {{#unless active}}is-disabled{{/unless}}">
         {{#if electionFull}}
-        Full cycle:
+        All Years:
         {{/if}}
         {{min}}–{{max}}
       </span>

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -82,7 +82,7 @@ describe('cycle select', function() {
     it('renders two-year period select', function() {
       var $cycles = this.cycleSelect.$cycles.find('span');
       expect($cycles.length).to.equal(3);
-      var labels = ['All Years: 2013–2016', '2013–2014', '2015–2016'];
+      var labels = ['All years: 2013–2016', '2013–2014', '2015–2016'];
       expect(
         $cycles.map(function(idx, elm) {
           return trim($(elm).text());

--- a/fec/fec/tests/js/cycle-select.js
+++ b/fec/fec/tests/js/cycle-select.js
@@ -82,7 +82,7 @@ describe('cycle select', function() {
     it('renders two-year period select', function() {
       var $cycles = this.cycleSelect.$cycles.find('span');
       expect($cycles.length).to.equal(3);
-      var labels = ['Full cycle: 2013–2016', '2013–2014', '2015–2016'];
+      var labels = ['All Years: 2013–2016', '2013–2014', '2015–2016'];
       expect(
         $cycles.map(function(idx, elm) {
           return trim($(elm).text());

--- a/fec/fec/tests/js/election-filter.js
+++ b/fec/fec/tests/js/election-filter.js
@@ -27,7 +27,7 @@ describe('Election filter', function() {
         'data-full-name="election_full"' +
         'data-duration="4"' +
         'data-default-cycle="2016">' +
-        '<label class="label" for="election_year">Election cycle</label>' +
+        '<label class="label" for="election_year">Election</label>' +
         '<select name="election_year" class="js-election">' +
             '<option value="2016">2016</option>' +
             '<option value="2012">2012</option>' +


### PR DESCRIPTION
## Summary (required)

- Addresses # 1444 https://app.zenhub.com/workspace/o/18f/fec-cms/issues/1444

- Changes the use of the verbiage 'cycle' on various web pages

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Front end web pages components: 
cycle-select, candidate-cycle-select, election-cycle-select and election-filter

## Changes Completed:
Before screenshots can be seen in issue#1444

- Changed the Candidate Profile pages
After design discussions this month, the final decision was to change the text from: "full cycle"
to: "All Years"
Manual Testing:
a)candidate/financial-summary==>Candidate Profile pages
Presidential
https://www.fec.gov/data/candidate/P60022654/
![election periods - presidential- after 1444 chgs](https://user-images.githubusercontent.com/24944162/33968324-627b2fbc-e035-11e7-97eb-1602b4b16464.jpeg)

Senate
https://www.fec.gov/data/candidate/S6MD03177/
b)Candidate/other-spending-tab
https://www.fec.gov/data/candidate/S6MD03177/?tab=other-spending
c)Candidate/about-candidate
https://www.fec.gov/data/candidate/S6MD03177/?tab=about-candidate

- Changed the Candidates for President data table (Edit Filters section)
pulldown menu label text from: "Full Cycle" to : “All Years”
Manual Testing:
https://www.fec.gov/data/candidates/president/?election_year=2016&cycle=2016&election_full=true
![presidential candidate edit filters](https://user-images.githubusercontent.com/24944162/33968335-6f5a90ba-e035-11e7-8d67-e0072f1f2a61.jpeg)


- Changed the Election lookup pages
Changed the text label above the period from: "Election Cycle" to: "2-year period"
see separate issue --> #1605

- Raising and Spending pages
Changed the label text for the heading on the Elections pulldown menu from ‘Election Cycle’ to ‘Election’
Manual Testing:
https://www.fec.gov/data/candidate/H8WI01024/?tab=raising
https://www.fec.gov/data/candidate/P80001571/?tab=raising
https://www.fec.gov/data/candidate/S2MA00170/?tab=raising
https://www.fec.gov/data/candidate/S2MA00170/?tab=spending
![candidate profile - raising page after 1444](https://user-images.githubusercontent.com/24944162/33968341-77a1ea3e-e035-11e7-8625-74081db08779.jpeg)
![candidate profile - spending page after 1444](https://user-images.githubusercontent.com/24944162/33968345-7c16f910-e035-11e7-8ca2-837af21a32d5.jpeg)


## Related PRs
List related PRs against other branches:
Issue 1605 https://app.zenhub.com/workspace/o/18f/fec-cms/issues/1605
PR 1630 https://app.zenhub.com/workspace/o/18f/fec-cms/issues/1630
