### PR TITLE
Change cycle select on candidate pages to use 2-year cycles

### DIFF
--- a/fec/data/templates/partials/candidate/about-candidate.jinja
+++ b/fec/data/templates/partials/candidate/about-candidate.jinja
@@ -7,7 +7,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
-      {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-2") }}
+      {{ select.cycle_select(cycles, cycle, duration=duration, id="cycle-2") }}
     </div>
 
     <div class="entity__figure entity__figure--narrow row" id="information">

--- a/fec/data/templates/partials/candidate/financial-summary.jinja
+++ b/fec/data/templates/partials/candidate/financial-summary.jinja
@@ -6,7 +6,7 @@
   <h2 id="section-1-heading">Financial summary</h2>
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
-      {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-1") }}
+      {{ select.cycle_select(cycles, cycle, duration=duration, id="cycle-1") }}
     </div>
 
     {% if committee_groups['P'] or committee_groups['A']%}

--- a/fec/data/templates/partials/candidate/other-spending-tab.jinja
+++ b/fec/data/templates/partials/candidate/other-spending-tab.jinja
@@ -8,7 +8,7 @@
 
   <div class="slab slab--inline slab--neutral u-padding--left u-padding--right">
     <div class="content__section">
-      {{ select.cycle_select(election_years, cycle, duration=duration, id="cycle-3") }}
+      {{ select.cycle_select(cycles, cycle, duration=duration, id="cycle-3") }}
     </div>
 
     <div class="entity__figure row" id="independent-expenditures">


### PR DESCRIPTION
## Summary

Change cycle select on candidate pages to use 2-year cycles, not election year

The [cycle-select macro](https://github.com/18F/fec-cms/blob/2771e98c1bdc15c71a573e9f8e3ac1fa1626b6a5/fec/data/templates/macros/cycle-select.jinja#L1) was designed to be passed a list of 2-year cycles, not election years. When these election years are odd, it can lead to bad links and wrong time periods being displayed.
- Addresses # [1642](https://github.com/18F/fec-cms/issues/1642)
_Changed the cycle select macro to look at the list of election cycles for a candidate, not election years. Odd-year special elections in dropdowns were causing 404 errors. The cycle select macro is looking at election cycles in every other part of the application_

## Impacted areas of the application
- About Candidate: `data/templates/partials/candidate/about-candidate.jinja`
https://www.fec.gov/data/candidate/H8CA34258/?tab=about-candidate
- Financial Summary: `data/templates/partials/candidate/financial-summary.jinja`
https://www.fec.gov/data/candidate/H8CA34258/?tab=summary
- Other Spending:  `data/templates/partials/candidate/other-spending-tab.jinja`
https://www.fec.gov/data/candidate/H8CA34258/?tab=other-spending


## Screenshots
**Choosing odd years in dropdowns causes 404 errors:**
<img width="728" alt="screen shot 2017-12-27 at 10 04 47 am" src="https://user-images.githubusercontent.com/31420082/34384980-782ed9d6-eaed-11e7-8b2b-9541a32e6690.png">

- **About Candidate**
Before:
<img width="540" alt="screen shot 2017-12-27 at 10 01 27 am" src="https://user-images.githubusercontent.com/31420082/34384897-1784b056-eaed-11e7-96f1-a7e8a93c54bc.png">

- **Financial Summary**
Before:
<img width="553" alt="screen shot 2017-12-27 at 10 01 14 am" src="https://user-images.githubusercontent.com/31420082/34384927-3a0b420c-eaed-11e7-8c6a-56d90d4b4478.png">

- **Other Spending**
Before:
<img width="542" alt="screen shot 2017-12-27 at 10 01 35 am" src="https://user-images.githubusercontent.com/31420082/34384955-53c50ef8-eaed-11e7-8e7a-e7a472c29f5e.png">


Note: There's still a weird issue with Doug Jones where it's displaying 2004 as an option. Created this issue: https://github.com/18F/openFEC/issues/2849

  