### PR TITLE
[MERGE WITH GITFLOW] Hotfix: Fix homepage "Events and Deadlines" section

### DIFF
--- a/fec/fec/static/js/modules/home-events.js
+++ b/fec/fec/static/js/modules/home-events.js
@@ -12,11 +12,14 @@ var todaysDate = year + '-' + month + '-' + day;
 
 var eventsTemplate = require('../templates/homepage/events-and-deadlines.hbs');
 
+// These values come from constants.py
+// and need to match API parameter `calendar_category_id`
+
 var updates = {
-  '.js-next-commission-meeting': ['Executive+Sessions', 'Open+Meetings', 'Public+Hearings'],
-  '.js-next-filing-deadline': ['report+E', 'report-M', 'report-MY', 'report-Q', 'report-YE'],
-  '.js-next-training-or-conference': ['Conferences', 'Roundtables'],
-  '.js-next-public-comment-deadline': ['AOs+and+Rules']
+  '.js-next-commission-meeting': ['32', '39', '40'],
+  '.js-next-filing-deadline': ['21', '27'],
+  '.js-next-training-or-conference': ['33', '34'],
+  '.js-next-public-comment-deadline': ['23']
 };
 
 // Home Page: Events and deadlines
@@ -25,7 +28,7 @@ function HomepageEvents() {
     var url = calendarHelpers.getUrl('calendar-dates',
       { 'sort': 'start_date',
         'min_start_date': todaysDate,
-        'category': eventCategories
+        'calendar_category_id': eventCategories
       });
 
     $.getJSON(url).done(function(events) {


### PR DESCRIPTION
## Summary

As a result of recent calendar changes, the homepage "Events and Deadlines" section was showing the same event for all four categories:

## Screenshots
**Before**
<img width="1032" alt="screen shot 2017-12-27 at 2 05 56 pm" src="https://user-images.githubusercontent.com/31420082/34390678-428e8c46-eb0f-11e7-9300-3c285ad8b49f.png">

**After**
<img width="1038" alt="screen shot 2017-12-27 at 1 57 05 pm" src="https://user-images.githubusercontent.com/31420082/34390692-592ad1e4-eb0f-11e7-98d0-b9ad12bd9557.png">