### PR TITLE
Updated chair and vice chair references and also reordered commissioners

### DIFF
--- a/fec/home/templates/home/home_page.html
+++ b/fec/home/templates/home/home_page.html
@@ -88,21 +88,21 @@
       <div class="grid grid--3-wide grid--no-border">
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--walther.jpg' %}" alt="Headshot of Steven T. Walther">
+            <img class="icon-heading__image" src="{% static 'img/headshot--hunter.jpg' %}" alt="Headshot of Caroline C. Hunter">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
-              <div class="t-note">Chairman</div>
-              <div class="t-sans">Independent</div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
+              <div class="t-note">Chair</div>
+              <div class="t-sans">Republican</div>
             </div>
           </div>
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--hunter.jpg' %}" alt="Headshot of Caroline C. Hunter">
+            <img class="icon-heading__image" src="{% static 'img/headshot--weintraub.jpg' %}" alt="Headshot of Ellen L. Weintraub">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/caroline-c-hunter">Caroline C. Hunter</a></div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub">Ellen L. Weintraub</a></div>
               <div class="t-note">Vice Chair</div>
-              <div class="t-sans">Republican</div>
+              <div class="t-sans">Democrat</div>
             </div>
           </div>
         </div>
@@ -126,10 +126,10 @@
         </div>
         <div class="grid__item">
           <div class="icon-heading">
-            <img class="icon-heading__image" src="{% static 'img/headshot--weintraub.jpg' %}" alt="Headshot of Ellen L. Weintraub">
+            <img class="icon-heading__image" src="{% static 'img/headshot--walther.jpg' %}" alt="Headshot of Steven T. Walther">
             <div class="icon-heading__content">
-              <div class="t-lead"><a href="/about/leadership-and-structure/ellen-l-weintraub">Ellen L. Weintraub</a></div>
-              <div class="t-sans">Democrat</div>
+              <div class="t-lead"><a href="/about/leadership-and-structure/steven-t-walther">Steven T. Walther</a></div>
+              <div class="t-sans">Independent</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary (required)

- Addresses https://github.com/18F/fec-cms/issues/1665
Updates references for new commission Chair and Vice Chair for the 2018 calendar year.

## Impacted areas of the application
List general components of the application that this PR will affect:

- Homepage Commissioner's section

## Screenshots

![screen shot 2017-12-29 at 9 39 18 am](https://user-images.githubusercontent.com/12799132/34439551-d33e1fae-ec7c-11e7-9975-6f8f0fd887c5.png)