### PR TITLE
feature/add-disbursements-pac-filter-line-numbers

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -383,6 +383,8 @@ line_numbers = {
             ('F3X-28C', 'Refunds of contributions to other political committees (Line 28c)'),
             ('F3X-28D', 'Total contributions refunds (Line 28d)'),
             ('F3X-29', 'Other disbursements (Line 29)'),
+            ('F3X-30A', 'Allocated federal election activity/Schedule H6 (Line 30a)'),
+            ('F3X-30B', 'Federal election activity paid entirely with federal funds (Line 30b)'),
         ])
     }
 }

--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -383,8 +383,7 @@ line_numbers = {
             ('F3X-28C', 'Refunds of contributions to other political committees (Line 28c)'),
             ('F3X-28D', 'Total contributions refunds (Line 28d)'),
             ('F3X-29', 'Other disbursements (Line 29)'),
-            ('F3X-30A', 'Allocated federal election activity/Schedule H6 (Line 30a)'),
-            ('F3X-30B', 'Federal election activity paid entirely with federal funds (Line 30b)'),
+            ('F3X-30B', 'Party - Types 3 & 4 Federal Election Activity (FEA) (Line 30(b))'),
         ])
     }
 }


### PR DESCRIPTION
Added two missing Disbursements PAC filters:

('F3X-30A', 'Allocated federal election activity/Schedule H6 (Line 30a)'),
('F3X-30B', 'Federal election activity paid entirely with federal funds (Line 30b)'),