### PR TITLE
Add support back in for the cloud.gov feature space

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ jobs:
       - run:
           name: Install Node.js dependencies
           command: |
-            npm i -g npm webpack
-            npm install
+            sudo npm i -g npm webpack
+            sudo npm install
             npm run build
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,13 +9,13 @@ jobs:
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
       # Python
-      - image: circleci/python:3.5.3
+      - image: circleci/python:3.5.4-jessie-node
         environment:
           TZ: America/New_York
           DATABASE_URL: postgres://postgres@0.0.0.0/cfdm_cms_test
 
       # PostgreSQL
-      - image: circleci/postgres:9.6.2
+      - image: circleci/postgres:9.6.6
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: cfdm_cms_test
@@ -50,16 +50,8 @@ jobs:
             pip install -r requirements.txt
 
       - run:
-          name: Install node dependencies
+          name: Install Node.js dependencies
           command: |
-            curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh | bash
-            echo ". ~/.nvm/nvm.sh" >> $BASH_ENV
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install 8.9.1
-            nvm use 8.9.1
-            nvm alias default 8.9.1
             npm i -g npm webpack
             npm install
             npm run build
@@ -77,11 +69,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             . .env/bin/activate
-            nvm use default
             npm run build-js
             npm run build-sass
             cd fec
@@ -104,7 +92,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.32.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.34.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
 
@@ -112,9 +100,5 @@ jobs:
           name: Deploy CMS
           command: |
             export PATH=$HOME/bin:$PATH
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
             . .env/bin/activate
-            nvm use default
             invoke deploy --branch $CIRCLE_BRANCH --login True --yes

--- a/README.md
+++ b/README.md
@@ -282,6 +282,18 @@ cf target -s [feature|dev|stage|prod] && cf push -f manifest_<[feature|dev|stage
 **NOTE:**  Performing a deploy in this manner will result in a brief period of
 downtime.
 
+### A note about deploying to the `feature` space
+As noted above, you can manually deploy the application if you specify the space you want to deploy to, e.g., `invoke deploy --space feature`.
+
+In the case of the `feature` space, there are a few things to note:
+
+* There is no automated deployer account setup with this space; it is intended for manual deployments only.
+* Only the CMS app is setup and configured for the `feature` space; it points to the `dev` space for all other things (e.g., the API).
+* In order to deploy to the `feature` space, you must have the proper org and space permissions setup (please contact the cloud.gov account administrator if you do not).
+* The `feature` version of the CMS does have New Relic running against it.
+* The CMS in the `feature` space has its own database that has been loaded with data from a production backup; this data can be refreshed in the future using the same steps outline in the Wiki.
+* The `feature` space has its own S3 bucket for content.
+
 ## SSH
 *Likely only useful for 18F FEC team members*
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ and specifying the corresponding manifest, as well as the app you want, like
 so:
 
 ```bash
-cf target -s [feature|dev|stage|prod] && cf push -f manifest_<[feature|dev|stage|prod]>.yml [api|web]
+cf target -s [feature|dev|stage|prod] && cf push -f manifest_<[feature|dev|stage|prod]>.yml [api|cms]
 ```
 
 **NOTE:**  Performing a deploy in this manner will result in a brief period of
@@ -291,7 +291,7 @@ In the case of the `feature` space, there are a few things to note:
 * Only the CMS app is setup and configured for the `feature` space; it points to the `dev` space for all other things (e.g., the API).
 * In order to deploy to the `feature` space, you must have the proper org and space permissions setup (please contact the cloud.gov account administrator if you do not).
 * The `feature` version of the CMS does have New Relic running against it.
-* The CMS in the `feature` space has its own database that has been loaded with data from a production backup; this data can be refreshed in the future using the same steps outline in the Wiki.
+* The CMS in the `feature` space has its own database that has been loaded with data from a production backup; this data can be refreshed in the future using the same steps outlined in the Wiki.
 * The `feature` space has its own S3 bucket for content.
 
 ## SSH

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -48,6 +48,7 @@ ENVIRONMENTS = {
     'dev': 'DEVELOPMENT',
     'stage': 'STAGING',
     'prod': 'PRODUCTION',
+    'feature': 'FEATURE',
 }
 FEC_CMS_ENVIRONMENT = ENVIRONMENTS.get(env.get_credential('FEC_CMS_ENVIRONMENT'), 'LOCAL')
 CONTACT_EMAIL = 'webmanager@fec.gov'
@@ -248,14 +249,12 @@ AUTH_PASSWORD_VALIDATORS = [
 
 if FEC_CMS_ENVIRONMENT != 'LOCAL':
     AWS_QUERYSTRING_AUTH = False
-    AWS_ACCESS_KEY_ID = env.get_credential('CMS_AWS_ACCESS_KEY_ID')
-    AWS_SECRET_ACCESS_KEY = env.get_credential('CMS_AWS_SECRET_ACCESS_KEY')
-    AWS_STORAGE_BUCKET_NAME = env.get_credential('CMS_AWS_STORAGE_BUCKET_NAME')
-    AWS_S3_CUSTOM_DOMAIN = env.get_credential('CMS_AWS_CUSTOM_DOMAIN')
+    AWS_ACCESS_KEY_ID = env.get_credential('access_key_id')
+    AWS_SECRET_ACCESS_KEY = env.get_credential('secret_access_key')
+    AWS_STORAGE_BUCKET_NAME = env.get_credential('bucket')
+    AWS_S3_REGION_NAME = env.get_credential('region')
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_LOCATION = 'cms-content'
-    AWS_S3_REGION_NAME = env.get_credential('CMS_AWS_DEFAULT_REGION')
-
 
 UAA_CLIENT_ID = env.get_credential('CMS_LOGIN_CLIENT_ID', 'my-client-id')
 UAA_CLIENT_SECRET = env.get_credential('CMS_LOGIN_CLIENT_SECRET', 'my-client-secret')

--- a/fec/fec/settings/base.py
+++ b/fec/fec/settings/base.py
@@ -253,6 +253,7 @@ if FEC_CMS_ENVIRONMENT != 'LOCAL':
     AWS_SECRET_ACCESS_KEY = env.get_credential('secret_access_key')
     AWS_STORAGE_BUCKET_NAME = env.get_credential('bucket')
     AWS_S3_REGION_NAME = env.get_credential('region')
+    AWS_S3_CUSTOM_DOMAIN = env.get_credential('CMS_AWS_CUSTOM_DOMAIN')
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
     AWS_LOCATION = 'cms-content'
 

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,6 +5,7 @@ services:
   - cms-creds-dev
   - fec-creds-dev
   - fec-dev-cms
+  - content-s3
 env:
   FEC_API_URL: "https://fec-dev-api.app.cloud.gov"
   FEC_APP_URL: "/data"

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -6,8 +6,8 @@ services:
   - fec-creds-feature
   - fec-feature-cms
 env:
-  FEC_API_URL: https://fec-feature-api.app.cloud.gov
-  FEC_APP_URL: https://fec-feature-proxy.app.cloud.gov/data
-  FEC_CMS_DEBUG: true
-  FEC_CMS_ENVIRONMENT: dev
-  NEW_RELIC_APP_NAME: beta.fec.gov | cms | feature
+  # We are not setting up the API in feature, so we are pointing to the dev
+  # API instead.
+  FEC_API_URL: https://fec-dev-api.app.cloud.gov
+  FEC_CMS_ENVIRONMENT: feature
+  NEW_RELIC_APP_NAME: govcloud | cms | feature

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -5,6 +5,7 @@ services:
   - cms-creds-feature
   - fec-creds-feature
   - fec-feature-cms
+  - content-s3
 env:
   # We are not setting up the API in feature, so we are pointing to the dev
   # API instead.

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -10,5 +10,6 @@ env:
   # We are not setting up the API in feature, so we are pointing to the dev
   # API instead.
   FEC_API_URL: https://fec-dev-api.app.cloud.gov
+  FEC_APP_URL: '/data'
   FEC_CMS_ENVIRONMENT: feature
   NEW_RELIC_APP_NAME: govcloud | cms | feature

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -6,6 +6,7 @@ services:
   - cms-creds-prod
   - fec-creds-prod
   - fec-cms-prod
+  - content-s3
 env:
   FEC_API_URL: "https://api.open.fec.gov"
   FEC_APP_URL: "/data"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,6 +5,7 @@ services:
   - cms-creds-stage
   - fec-creds-stage
   - fec-stage-cms
+  - content-s3
 env:
   FEC_API_URL: https://api-stage.open.fec.gov
   FEC_APP_URL: '/data'


### PR DESCRIPTION
Fixes #904 
Addresses #1640 

This changeset makes the adjustments necessary to support the CMS in the feature space again within our cloud.gov account.  This also includes an updated CircleCI configuration to help improve that setup a bit.

**NOTE:** When this is merged into `develop` and deployed to the `dev` space and then subsequently deployed to the `stage` and `prod` spaces in the next release, this should automatically bind the S3 content bucket to the app in the respective environment as well.