### PR TITLE
Include odd year special elections in Election dropdown as even years

### DIFF
--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -12,7 +12,12 @@
       >
     {% for each in cycles | sort(reverse=True) %}
       <option
+          {# If odd year election, increment to even election year #}
+          {% if each % 2 > 0  %}
+          value="{{ each + 1}}"
+          {% else %}
           value="{{ each }}"
+          {% endif %}
           {% if cycle and cycle <= each and cycle > (each - duration) %}selected{% endif %}
         >
         {% if range %}

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -11,14 +11,10 @@
         data-duration="{{ duration }}"
       >
     {% for each in cycles | sort(reverse=True) %}
-      {# if each is odd year special election, change to even year #}
-      {% if (each % 2 > 0) %}   
-        {% set each = each+1 %}
-      {% endif %}
-      <option
+        <option
           value="{{ each }}"
           {% if cycle and cycle <= each and cycle > (each - duration) %}selected{% endif %}
-      >
+        >
         {% if range %}
           {{ each|fmt_year_range }}
         {% else %}

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -9,7 +9,7 @@
         name="cycle"
         data-cycle-location="{{ location }}"
         data-duration="{{ duration }}"
-      >
+    >
     {% for each in cycles | sort(reverse=True) %}
         <option
           value="{{ each }}"

--- a/fec/data/templates/macros/cycle-select.jinja
+++ b/fec/data/templates/macros/cycle-select.jinja
@@ -11,15 +11,14 @@
         data-duration="{{ duration }}"
       >
     {% for each in cycles | sort(reverse=True) %}
+      {# if each is odd year special election, change to even year #}
+      {% if (each % 2 > 0) %}   
+        {% set each = each+1 %}
+      {% endif %}
       <option
-          {# If odd year election, increment to even election year #}
-          {% if each % 2 > 0  %}
-          value="{{ each + 1}}"
-          {% else %}
           value="{{ each }}"
-          {% endif %}
           {% if cycle and cycle <= each and cycle > (each - duration) %}selected{% endif %}
-        >
+      >
         {% if range %}
           {{ each|fmt_year_range }}
         {% else %}

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -107,8 +107,8 @@ def candidate(request, candidate_id):
         cycle=cycle, cycle_key='two_year_period',
         election_full=election_full,
     )
-# cycle corresponds to the two-year period for which the committee has financial activity.
-# when selected election cycle is not in list of election years, get the next election cycle
+    # cycle corresponds to the two-year period for which the committee has financial activity.
+    # when selected election cycle is not in list of election years, get the next election cycle
     if election_full and cycle and cycle not in candidate['election_years']:
 
         next_cycle = next(
@@ -155,7 +155,7 @@ def candidate(request, candidate_id):
     #  for displaying elections for pulldown menu in Candidate pages
     even_election_years = list()  # empty list
     for year in candidate['election_years']:
-        print("year is {}".format(year))
+ #       print("year is {}".format(year))
         if year % 2 > 0 :
             even_election_years.append(year+1)  # make even year
         else:

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -10,8 +10,6 @@ import datetime
 import github3
 import json
 import re
-# python debugger
-import pdb      
 
 from data import api_caller
 from data import constants
@@ -87,15 +85,11 @@ def advanced(request):
 
 
 def candidate(request, candidate_id):
-    pdb.set_trace()
     # grab url query string parameters
     cycle = request.GET.get('cycle', None)
-    print("cycle is:{}".format(cycle))
-    #print("election_years is:{}".format(election_years))
    
     election_full = request.GET.get('election_full', True)
-    print("election_full is:{}".format(election_full))
-
+ 
     if cycle is not None:
         cycle = int(cycle)
 
@@ -155,8 +149,7 @@ def candidate(request, candidate_id):
     #  for displaying elections for pulldown menu in Candidate pages
     even_election_years = list()  # empty list
     for year in candidate['election_years']:
- #       print("year is {}".format(year))
-        if year % 2 > 0 :
+         if year % 2 > 0 :
             even_election_years.append(year+1)  # make even year
         else:
             even_election_years.append(year)  # already even year

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -147,8 +147,8 @@ def candidate(request, candidate_id):
 
      # Addresses issue#1644 - make any odd year special election an even year 
     #  for displaying elections for pulldown menu in Candidate pages
-    #  Using Set to ensure no duplicate years in list
-    even_election_years = { year + (year % 2) for year in candidate.get('election_years', []) }
+    #  Using Set to ensure no duplicate years in final list
+    even_election_years = list({ year + (year % 2) for year in candidate.get('election_years', []) })
 
     # In the case of when a presidential or senate candidate has filed
     # for a future year that's beyond the current cycle,

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -149,7 +149,7 @@ def candidate(request, candidate_id):
     #  for displaying elections for pulldown menu in Candidate pages
     even_election_years = list()  # empty list
     for year in candidate['election_years']:
-         if year % 2 > 0 :
+        if year % 2 > 0 :
             even_election_years.append(year+1)  # make even year
         else:
             even_election_years.append(year)  # already even year

--- a/fec/data/views.py
+++ b/fec/data/views.py
@@ -145,15 +145,10 @@ def candidate(request, candidate_id):
         'candidateID': candidate['candidate_id']
     }
 
-    # Addresses issue#1644 - make any odd year special election even years 
+     # Addresses issue#1644 - make any odd year special election an even year 
     #  for displaying elections for pulldown menu in Candidate pages
-    even_election_years = list()  # empty list
-    for year in candidate['election_years']:
-        if year % 2 > 0 :
-            even_election_years.append(year+1)  # make even year
-        else:
-            even_election_years.append(year)  # already even year
-
+    #  Using Set to ensure no duplicate years in list
+    even_election_years = { year + (year % 2) for year in candidate.get('election_years', []) }
 
     # In the case of when a presidential or senate candidate has filed
     # for a future year that's beyond the current cycle,


### PR DESCRIPTION
## Summary 
- Addresses Issue# 1644 https://github.com/18F/fec-cms/issues/1644
Handles odd year special elections by changing to even year

## Impacted areas of the application
List general components of the application that this PR will affect:

- fec-cms/fec/data/views.py 
The candidate() function was updated to include new code for creating a new election years list of only even years from the API's returned election-years list.
- fec-cms/fec/fec/data/templates/macros/cycle-select.jinja
This macro uses the election years list for displaying the election years in the Elections pulldown menu. 

## Screenshots
Test Case: House Candidate Karen Handel had special election in 2017
https://www.fec.gov//data/candidate/H8GA06286/

-Before screenshot
![issue1644-odd year special elections-before](https://user-images.githubusercontent.com/24944162/35177678-2b9d3c24-fd4f-11e7-86b0-282abfd7216f.jpeg)

- After screenshot
![issue1644-odd year special elections-after](https://user-images.githubusercontent.com/24944162/35177644-ea81c598-fd4e-11e7-8231-7c7ff6cb7da2.jpeg)

## Related PRs
List related PRs against other branches: none


## Related Issues
Issue:2845 https://github.com/18F/openFEC/issues/2845 
- This PR1708 also resolves issue2845 with Time Periods 
____

**IF ANY OF THE ABOVE FIELDS DO NOT APPLY, PLEASE DELETE THEM BEFORE SUBMITTING**