### PR TITLE
[Hotfix merge with GITFLOW] - Added updated links for SSF guide section

### DIFF
--- a/fec/home/templates/home/candidate-and-committee-services/guides.html
+++ b/fec/home/templates/home/candidate-and-committee-services/guides.html
@@ -115,19 +115,19 @@
           <div class="grid__item">
             <ul class="t-sans list--spacious">
               <li><a href="/help-candidates-and-committees/registering-ssf/">Registering as an SSF</a> &#187;</li>
-              <li><span class="is-disabled">Taking in receipts as an SSF</span></li>
-              <li class="is-disabled">Fundraising for an SSF</li>
-              <li class="is-disabled">Making disbursements as an SSF</li>
+              <li><a href="/help-candidates-and-committees/taking-receipts-ssf/">Taking in receipts as an SSF</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/fundraising-for-ssf/">Fundraising for an SSF</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/">Making disbursements as an SSF or connected organization</a> &#187;</li>
+              <li><a href="/help-candidates-and-committees/keeping-ssf-records/">Keeping records as an SSF</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/filing-ssf-reports/">Filing SSF reports</a> &#187;</li>
-              <li class="is-disabled">Handling SSF loans, debts and advances</li>
-              <li><span class="is-disabled">Keeping records as an SSF</span></li>
+              <li><a href="/help-candidates-and-committees/handling-ssf-loans-and-debts/">Handling SSF loans, debts and advances</a> &#187;</li>
               <li><a href="/help-candidates-and-committees/terminating-a-committee/">Terminating a committee</a> &#187;</li>
             </ul>
           </div>
           <div class="grid__item">
             <img src="{% static 'img/thumbnail--pdf-guide.png' %}" alt="Icon representing a large PDF file">
             <span class="label">PDF Guide</span>
-            <a class="t-sans" href="https://transition.fec.gov/pdf/colagui.pdf">Corporations and labor organizations campaign guide</a>
+            <a class="t-sans" href="/resources/cms-content/documents/colagui.pdf">Corporations and labor organizations campaign guide</a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary

- Addresses https://github.com/18F/fec-cms/issues/1704
This enables and updates the links for the new SSF guide content under the Corporations and labor organizations guide section of our site.

Adding Dorothy and John as reviewers.
@dorothyyeager Can you please verify the content is correct?
@johnnyporkchops Please check the code is good to go.

## Impacted areas of the application
List general components of the application that this PR will affect:

-  https://www.fec.gov/help-candidates-and-committees/guides/?tab=corporations-and-labor-organizations

## Screenshots
<img width="988" alt="screen shot 2018-01-23 at 12 53 49 pm" src="https://user-images.githubusercontent.com/12799132/35292236-e71a8e98-003d-11e8-9929-5f1d60919417.png">
