### PR TITLE
Fixes cache rebuilds on dev and webpack error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,9 @@ jobs:
       - run:
           name: Install Node.js dependencies
           command: |
-            sudo npm i -g npm webpack
-            sudo npm install
+            sudo npm install -g npm 
+            npm install webpack
+            npm install
             npm run build
 
       #- save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ jobs:
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 
-      - restore_cache:
-          keys:
-          - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+      #- restore_cache:
+      #    keys:
+      #    - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-          - fec-cms-dependencies-
+      #    - fec-cms-dependencies-
 
       - run:
           name: Install python dependencies
@@ -56,11 +56,11 @@ jobs:
             sudo npm install
             npm run build
 
-      - save_cache:
-          paths:
-            - ./.env
-            - ./node_modules
-          key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+      #- save_cache:
+      #    paths:
+      #      - ./.env
+      #      - ./node_modules
+      #    key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ jobs:
             echo "en_US.UTF-8 UTF-8" | sudo tee /etc/locale.gen
             sudo locale-gen en_US.UTF-8
 
-      #- restore_cache:
-      #    keys:
-      #    - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+      - restore_cache:
+          keys:
+          - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-      ##    - fec-cms-dependencies-
+          - fec-cms-dependencies-
 
       - run:
           name: Install python dependencies
@@ -57,11 +57,11 @@ jobs:
             npm install
             npm run build
 
-      #- save_cache:
-      #    paths:
-      #      - ./.env
-      #      - ./node_modules
-      #    key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
+      - save_cache:
+          paths:
+            - ./.env
+            - ./node_modules
+          key: fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
 
       - run:
           name: Ensure database is available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       #    keys:
       #    - fec-cms-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "package.json" }}
           # fallback to using the latest cache if no exact match is found
-      #    - fec-cms-dependencies-
+      ##    - fec-cms-dependencies-
 
       - run:
           name: Install python dependencies

--- a/fec/webpack.config.js
+++ b/fec/webpack.config.js
@@ -104,7 +104,7 @@ module.exports = [
       ignored: /node_modules/
     },
     stats: {
-      assetSort: 'field',
+      assetsSort: 'field',
       modules: false,
       warnings: false
     }

--- a/fec/webpack.config.js
+++ b/fec/webpack.config.js
@@ -136,7 +136,7 @@ module.exports = [
       ]
     },
     stats: {
-      assetSort: 'field',
+      assetsSort: 'field',
       modules: false,
       warnings: false
     }

--- a/tasks.py
+++ b/tasks.py
@@ -74,7 +74,8 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    #('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/no-cache-build-test'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )

--- a/tasks.py
+++ b/tasks.py
@@ -74,8 +74,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    #('dev', lambda _, branch: branch == 'develop'),
-    ('dev', lambda _, branch: branch == 'feature/no-cache-build-test'),
+    ('dev', lambda _, branch: branch == 'develop'),
     # Uncomment below and adjust branch name to deploy desired feature branch to the feature space
     # ('feature', lambda _, branch: branch == 'feature/INSERT_BRANCH_NAME'),
 )


### PR DESCRIPTION
## Summary

- Addresses https://github.com/18F/fec-cms/issues/1746

No cache rebuilds were failing on dev. This fixes it by removing sudo on `npm install` and also fixes a webpack issue with webpack stats option, in which it was referencing an incorrect webpack configuration object `assetSort`, it should be `assetsSort`. 