### PR TITLE
Fix district sort on election results page

### DIFF
--- a/fec/data/templates/election-lookup.jinja
+++ b/fec/data/templates/election-lookup.jinja
@@ -56,6 +56,7 @@
                 </select>
               </div>
               <div class="search-controls__submit">
+                <input type="hidden" value="district" name="sort" />
                 <button type="submit" class="button--search--text button--standard">Search</button>
               </div>
             </fieldset>

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -142,7 +142,7 @@ ElectionSearch.prototype.search = function(e, opts) {
     if (!_.isEqual(serialized, self.serialized)) {
       // Requested search options differ from saved options; request new data.
       self.xhr && self.xhr.abort();
-      self.xhr = $.getJSON(self.getUrl(serialized) + '&sort=district').done(function(response) {
+      self.xhr = $.getJSON(self.getUrl(serialized)).done(function(response) {
         self.results = self.removeWrongPresidentialElections(response.results, serialized.cycle);
         // Note: Update district color map before rendering results
         var encodedDistricts = self.encodeDistricts(self.results);

--- a/fec/fec/static/js/modules/election-search.js
+++ b/fec/fec/static/js/modules/election-search.js
@@ -142,7 +142,7 @@ ElectionSearch.prototype.search = function(e, opts) {
     if (!_.isEqual(serialized, self.serialized)) {
       // Requested search options differ from saved options; request new data.
       self.xhr && self.xhr.abort();
-      self.xhr = $.getJSON(self.getUrl(serialized)).done(function(response) {
+      self.xhr = $.getJSON(self.getUrl(serialized) + '&sort=district').done(function(response) {
         self.results = self.removeWrongPresidentialElections(response.results, serialized.cycle);
         // Note: Update district color map before rendering results
         var encodedDistricts = self.encodeDistricts(self.results);


### PR DESCRIPTION
## Summary

- Addresses #1782 
This adds the district sort to the election page search form

Example:
-  http://localhost:8000/data/elections/?cycle=2018&state=CA
