### PR TITLE
fixed scss for numbered lists and alternating-bg cards

### DIFF
--- a/fec/fec/static/scss/components/_cards.scss
+++ b/fec/fec/static/scss/components/_cards.scss
@@ -212,6 +212,7 @@
 .card--alternating-bg {
   min-height: u(8.3rem);
   padding: 0;
+  border: 2px solid transparent;
 
   .card__image__container {
     @include span-columns(4);

--- a/fec/fec/static/scss/components/_list-styles.scss
+++ b/fec/fec/static/scss/components/_list-styles.scss
@@ -50,6 +50,10 @@
 }
 
 .list--numbered {
+  & > li {
+    list-style-type: decimal;
+  }
+
   ul {
     margin-bottom: 0;
     margin-left: u(1.5rem);

--- a/fec/fec/static/scss/components/_richtext.scss
+++ b/fec/fec/static/scss/components/_richtext.scss
@@ -4,7 +4,8 @@
 //
 
 .rich-text,
-.body-blocks {
+.body-blocks,
+.block-html {
   ul {
     @extend .list--bulleted;
    }
@@ -14,8 +15,10 @@
   }
 }
 
+
 .rich-text,
-.block-table {
+.block-table,
+.block-html {
   table {
     @extend .simple-table;
   }


### PR DESCRIPTION
Addresses:
add numbers to `list--numbered class` : https://github.com/18F/fec-cms/issues/1781
add transparent border to `.card--alternating-bg` : https://github.com/18F/fec-cms/issues/1734 
### **Numbered lists:**
![numbered_lists](https://user-images.githubusercontent.com/5572856/36229657-fc0265f0-11a5-11e8-8369-206c68e20a0b.gif)

### **Alternating-bg cards before/after**
**Before:**
![jump](https://user-images.githubusercontent.com/5572856/36285354-37a7844a-1279-11e8-8588-0dfe7fe57041.gif)


**After:**
![no_jump](https://user-images.githubusercontent.com/5572856/36285360-3d89d084-1279-11e8-8ad1-cb560cfc7bb9.gif)



