### PR TITLE
[MERGE WITH GITFLOW] Fixed monthy report deadlines appearing on homepage, under Events and…

### DIFF
--- a/fec/fec/constants.py
+++ b/fec/fec/constants.py
@@ -7,6 +7,8 @@ election_types = OrderedDict([
 
 deadline_types = OrderedDict([
     ('21', 'Reporting deadlines'),
+    ('25', 'Quarterly reports'),
+    ('26', 'Monthly reports'),
     ('27', 'Pre- and post-election')
 ])
 

--- a/fec/fec/static/js/modules/home-events.js
+++ b/fec/fec/static/js/modules/home-events.js
@@ -17,7 +17,7 @@ var eventsTemplate = require('../templates/homepage/events-and-deadlines.hbs');
 
 var updates = {
   '.js-next-commission-meeting': ['32', '39', '40'],
-  '.js-next-filing-deadline': ['21', '27'],
+  '.js-next-filing-deadline': ['21', '26', '27'],
   '.js-next-training-or-conference': ['33', '34'],
   '.js-next-public-comment-deadline': ['23']
 };

--- a/fec/fec/static/js/modules/home-events.js
+++ b/fec/fec/static/js/modules/home-events.js
@@ -17,7 +17,7 @@ var eventsTemplate = require('../templates/homepage/events-and-deadlines.hbs');
 
 var updates = {
   '.js-next-commission-meeting': ['32', '39', '40'],
-  '.js-next-filing-deadline': ['21', '26', '27'],
+  '.js-next-filing-deadline': ['21', '25', '26', '27'],
   '.js-next-training-or-conference': ['33', '34'],
   '.js-next-public-comment-deadline': ['23']
 };


### PR DESCRIPTION
Make Monthly Reports show on Homepage calendar events #1793

The FEC homepage alerts users to the next upcoming reporting deadline. Currently, this function isn't picking up code 26 (monthly filings) and isn't showing the February 20 filing date. We need to add code 26 to JS fecfiling. With the next report due Feb. 20, this will require a hotfix.