### PR TITLE
Applies most recent styles to cards components on data landing page

### DIFF
--- a/fec/data/templates/landing.jinja
+++ b/fec/data/templates/landing.jinja
@@ -111,74 +111,106 @@
 
   <section class="content__section content__section--ruled">
     <h2>Browse full advanced data sets</h2>
-    <ul class="grid grid--4-wide">
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-receipt"><span class="u-visually-hidden">Icon of a piggy bank</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=raising">Raising</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-disbursement"><span class="u-visually-hidden">Icon of representing spending</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=spending">Spending</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-candidate"><span class="u-visually-hidden">Icon of a candidate</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=candidates">Candidates</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-committee"><span class="u-visually-hidden">Icon representing a committeek</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=committees">Committees</a>
-        </div>
-      </li>
-    </ul>
-    <ul class="grid grid--4-wide">
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-filings"><span class="u-visually-hidden">Icon representing filings</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=filings">Filings and reports</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-loans"><span class="u-visually-hidden">Icon representing loans and debts</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=loans-debts">Loans and debts</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-bulk"><span class="u-visually-hidden">Icon representing bulk data</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=other">Bulk data and other sources</a>
-        </div>
-      </li>
-      <li class="grid__item card card--horizontal card--primary">
-        <div class="card__image__container">
-          <span class="card__icon i-external"><span class="u-visually-hidden">Icon representing external pages</span></span>
-        </div>
-        <div class="card__content">
-          <a href="/data/advanced?tab=external">External data sources</a>
-        </div>
-      </li>
-    </ul>
+    <div class="grid grid--4-wide">
+      <div class="grid__item">
+        <a href="/data/advanced?tab=raising">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-receipt"><span class="u-visually-hidden">Icon of a piggy bank</span></span>
+            </div>
+            <div class="card__content">
+              Raising
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=spending">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-disbursement"><span class="u-visually-hidden">Icon of representing spending</span></span>
+            </div>
+            <div class="card__content">
+              Spending
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=candidates">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-candidate"><span class="u-visually-hidden">Icon of a candidate</span></span>
+            </div>
+            <div class="card__content">
+              Candidates
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=committees">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-committee"><span class="u-visually-hidden">Icon of a committee</span></span>
+            </div>
+            <div class="card__content">
+              Committees
+            </div>
+          </aside>
+        </a>
+      </div>
+    </div>
+    <div class="grid grid--4-wide">
+      <div class="grid__item">
+        <a href="/data/advanced?tab=filings">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-filings"><span class="u-visually-hidden">Icon of filed papers</span></span>
+            </div>
+            <div class="card__content">
+              Filings and reports
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=loans-debts">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-loans"><span class="u-visually-hidden">Icon of an open hand with a dollar symbol</span></span>
+            </div>
+            <div class="card__content">
+              Loans and debts
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=other">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-bulk"><span class="u-visually-hidden">Icon of bulk data</span></span>
+            </div>
+            <div class="card__content">
+              Bulk data and other sources
+            </div>
+          </aside>
+        </a>
+      </div>
+      <div class="grid__item">
+        <a href="/data/advanced?tab=external">
+          <aside class="card card--horizontal card--primary">
+            <div class="card__image__container">
+              <span class="card__icon i-external"><span class="u-visually-hidden">Icon representing external pages</span></span>
+            </div>
+            <div class="card__content">
+              External data sources
+            </div>
+          </aside>
+        </a>
+      </div>
+    </div>
   </section>
 
   <div class="content__section--extra">


### PR DESCRIPTION
## Summary

- This updates the styles (and underlying front end code structure) of the cards on the data landing page to use the most up-to-date approach. The notice-able visual change is that the links on the card will no longer be underlined.
- Previously, @johnnyporkchops had done some great work adjusting the hover states and implementations of these cards as a pattern, and this instance just hadn't been updated yet. It was a tiny thing that was irking me, so I had five minutes and fixed it instead of making a coffee :)

## Impacted areas of the application
- Data landing page: https://www.fec.gov/data/

## Screenshots

**Before:**
<img width="1052" alt="screen shot 2018-02-27 at 1 28 59 pm" src="https://user-images.githubusercontent.com/11636908/36747146-32eb8440-1bc2-11e8-816c-d4f847891818.png">

**After:**
<img width="1060" alt="screen shot 2018-02-27 at 12 59 23 pm" src="https://user-images.githubusercontent.com/11636908/36747153-370490e4-1bc2-11e8-9c28-c7b134f919a0.png">

