### PR TITLE
Move Form 5 quarterly reports to 'Regularly filed reports'

### DIFF
--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -569,7 +569,8 @@ $(document).ready(function() {
           order: [],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F7', 'F13', 'RFAI'],
+            form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13', 'RFAI'],
+            report_type: ['-24', '-48'],
             sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number']
           }, query),
           callbacks: {
@@ -584,7 +585,8 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11']
+            form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
+            report_type: ['-Q1', '-Q2', '-Q3', '-YE']
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);


### PR DESCRIPTION
## Summary

- Addresses bug #1691 

Modifies the "Filings" section of Committee Pages to show Form 5 quarterly reports under "Regularly Scheduled Reports" and exclude them from the "24- and 48- Hour Notices" section. HUGE thank you to @llienfec for helping me with this logic.

## Impacted areas of the application
Committee "Filing" pages ([Example](https://www.fec.gov/data/committee/C90013301/?cycle=2016&tab=filings))

## Screenshots

## Before
<kbd><img src="https://user-images.githubusercontent.com/31420082/36761540-84cec166-1bed-11e8-9d4e-121638b71338.png"  width="300"></kbd>

## After
<kbd><img src="https://user-images.githubusercontent.com/31420082/36761655-14c800ca-1bee-11e8-8f30-e184d2b837de.png" width="300"></kbd>

