### PR TITLE
[MERGE WITH GIT FLOW] fix broken IE an PCE links on committee summary pages

### DIFF
--- a/fec/data/constants.py
+++ b/fec/data/constants.py
@@ -491,10 +491,10 @@ SPENDING_FORMATTER = OrderedDict([
         }}),
     ('independent_expenditures',  # F3X
         {'label': 'Independent expenditures', 'level': '2',
-            'link': 'independent_expenditures'}),
+            'link': 'independent-expenditures'}),
     ('coordinated_expenditures_by_party_committee',  # F3X
         {'label': 'Coordinated party expenditures', 'level': '2', 'type': {
-            'link': 'party_coordinated_expenditures',
+            'link': 'party-coordinated-expenditures',
         }}),
     ('loans_made',  # F3X
         {'label': 'Loans made', 'level': '2', 'type': {

--- a/fec/data/templates/macros/tables.jinja
+++ b/fec/data/templates/macros/tables.jinja
@@ -22,7 +22,7 @@
       <td class="simple-table__cell">
       {% set committee_id = committee_id|replace("['", "")|replace("']", "") %}
         {% if item[1]['link'] %}
-          <a href="/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
+          <a href="/data/{{ item[1]['link'] }}/?committee_id={{ committee_id }}&two_year_transaction_period={{ cycle }}&cycle={{ cycle }}">
             {{ item[0]|currency }}
           </a>
         {% elif item[1]['type'] and cycle|int > 2006 %}


### PR DESCRIPTION
- Addresses # https://github.com/18F/fec-cms/issues/1720- Bad IE link on committee summary page
-Addresses part of https://github.com/fecgov/FEC/issues/5452 - Party coordinated expenses link is busted and does not filter correctly.
**Affected areas of the application:**
https://github.com/18F/fec-cms/blob/develop/fec/data/templates/macros/tables.jinja seems to be the only place in the application that the ['link'] item in a dictionary (in constants.py )is being accessed so I am fairly confident that this will not break anything somewhere else.