### PR TITLE
Fixes for RFAI filings

### DIFF
--- a/fec/fec/static/js/pages/candidate-single.js
+++ b/fec/fec/static/js/pages/candidate-single.js
@@ -207,7 +207,10 @@ function initOtherDocumentsTable() {
     path: path,
     query: {
       candidate_id: candidateId,
-      form_type: 'F99'
+      form_type: ['F99','RFAI'],
+      //exclude all request types except for RQ-5: RFAI referencing Statement of Candidacy
+      request_type: ['-1','-2','-3','-4','-6','-7','-8','-9'],
+      sort_hide_null: ['false']
     },
     columns: otherDocumentsColumns,
     order: [[2, 'desc']],

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -571,7 +571,7 @@ $(document).ready(function() {
           query: _.extend({
             form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13', 'RFAI'],
             report_type: ['-24', '-48'],
-            //exclude all request types except for RQ-2: Report of Receipts and Expenditures
+            //exclude all request types except for RQ-2: RFAI referencing Report of Receipts and Expenditures
             request_type: ['-1','-3','-4','-5','-6','-7','-8','-9'],
             sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number'],
             sort_hide_null: ['false']
@@ -602,7 +602,7 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F1','RFAI'],
-            //exclude all request types except for RQ-1: Statement of organization
+            //exclude all request types except for RQ-1: RFAI referencing Statement of organization
             request_type: ['-2','-3','-4','-5','-6','-7','-8','-9'],
             sort_hide_null: ['false']
           }, query),
@@ -616,7 +616,7 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F1M', 'F8', 'F99', 'F12','RFAI'],
-            //exclude all request types except for RQ-9, Multicandidate status
+            //exclude all request types except for RQ-9: RFAI referencing Multicandidate status
             request_type: ['-1','-2','-3','-4','-5','-6','-7','-8'],
             sort_hide_null: ['false']
           }, query),

--- a/fec/fec/static/js/pages/committee-single.js
+++ b/fec/fec/static/js/pages/committee-single.js
@@ -571,7 +571,10 @@ $(document).ready(function() {
           query: _.extend({
             form_type: ['F3', 'F3X', 'F3P', 'F3L', 'F4', 'F5', 'F7', 'F13', 'RFAI'],
             report_type: ['-24', '-48'],
-            sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number']
+            //exclude all request types except for RQ-2: Report of Receipts and Expenditures
+            request_type: ['-1','-3','-4','-5','-6','-7','-8','-9'],
+            sort: ['-coverage_end_date', 'report_type_full', '-beginning_image_number'],
+            sort_hide_null: ['false']
           }, query),
           callbacks: {
             afterRender: filings.renderModal
@@ -586,7 +589,8 @@ $(document).ready(function() {
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
             form_type: ['F5', 'F24', 'F6', 'F9', 'F10', 'F11'],
-            report_type: ['-Q1', '-Q2', '-Q3', '-YE']
+            report_type: ['-Q1', '-Q2', '-Q3', '-YE'],
+            sort_hide_null: ['false']
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);
@@ -597,7 +601,10 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F1']
+            form_type: ['F1','RFAI'],
+            //exclude all request types except for RQ-1: Statement of organization
+            request_type: ['-2','-3','-4','-5','-6','-7','-8','-9'],
+            sort_hide_null: ['false']
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);
@@ -608,7 +615,10 @@ $(document).ready(function() {
           order: [[2, 'desc']],
           path: ['committee', committeeId, 'filings'],
           query: _.extend({
-            form_type: ['F1M', 'F8', 'F99', 'F12']
+            form_type: ['F1M', 'F8', 'F99', 'F12','RFAI'],
+            //exclude all request types except for RQ-9, Multicandidate status
+            request_type: ['-1','-2','-3','-4','-5','-6','-7','-8'],
+            sort_hide_null: ['false']
           }, query),
         }, filingsOpts);
         tables.DataTable.defer($table, opts);


### PR DESCRIPTION
## Summary (required)

- Addresses #1760 
Ensuring that the following RFAIs show up in the correct tables.
### Missing from candidate pages
RQ-5s - Request for Additional Information (RFAI) referencing the Statement of Candidacy. Test URL: http://localhost:8000/data/candidate/H8AR04122/?tab=about-candidate
### Missing from committee pages
RQ-1 - RFAI referencing the Statement of Organization. Test URL: http://localhost:8000/data/committee/C00637983/?tab=filings
RQ-2 - RFAI referencing Report of Receipts and Expenditures. Test URL: http://localhost:8000/data/committee/C00637983/?tab=filings
RQ-9 - Multicandidate status. Test URL: http://localhost:8000/data/committee/C00659672/?tab=filings

## Impacted areas of the application
List general components of the application that this PR will affect:

-  Committee filing page
- Candidate about page

## Screenshots

### RFAIs of RQ 2 Only
<img width="429" alt="screen shot 2018-03-02 at 10 06 17 am" src="https://user-images.githubusercontent.com/12799132/36905635-d5d28adc-1e01-11e8-8478-b02ffd805424.png">

### RFAIs of RQ 1 Only
<img width="400" alt="screen shot 2018-03-02 at 10 06 27 am" src="https://user-images.githubusercontent.com/12799132/36905620-d0710abe-1e01-11e8-9571-37012c791c5c.png">

### RFAIs of RQ 9 Only
<img width="443" alt="screen shot 2018-03-02 at 10 05 58 am" src="https://user-images.githubusercontent.com/12799132/36905637-d5e25ad4-1e01-11e8-9de5-70ba98dd3e32.png">

### RFAIs of RQ 5 Only
<img width="199" alt="screen shot 2018-03-04 at 10 36 26 pm" src="https://user-images.githubusercontent.com/12799132/36956492-ac59652a-1ffc-11e8-89fe-adf7f6bab0ac.png">
