### PR TITLE
fixes image path for no headshot image

### DIFF
--- a/fec/home/templates/partials/commissioner.html
+++ b/fec/home/templates/partials/commissioner.html
@@ -7,7 +7,7 @@
     {% image commissioner.picture original as commissioner_picture %}
     <img class="icon-heading__image" src="{{ commissioner_picture.url }}" alt="Headshot of {{ commissioner.title }}">
     {% else %}
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.png" %}" alt="Headshot of {{ commissioner.title }}">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of {{ commissioner.title }}">
     {% endif %}
     <div class="icon-heading__content">
       <div class="t-lead"><a href="{{ commissioner.url }}">{{ commissioner.title }}</a></div>

--- a/fec/home/templates/partials/current-commissioners.html
+++ b/fec/home/templates/partials/current-commissioners.html
@@ -10,7 +10,7 @@
 {% else %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.png" %}" alt="Headshot of vacant seat">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant Chair seat</div>
     </div>
@@ -23,7 +23,7 @@
 {% else %}
   <div class="grid__item commissioner-height">
   <div class="icon-heading">
-    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.png" %}" alt="Headshot of vacant seat">
+    <img class="icon-heading__image" src="{% static "img/headshot--no-photo.jpg" %}" alt="Headshot of vacant seat">
     <div class="icon-heading__content">
       <div class="t-lead">Vacant Vice-Chair seat</div>
     </div>


### PR DESCRIPTION
## Summary

- Addresses #1810 
This fixes the broken image for the no photo headshot. http://localhost:8000/about/leadership-and-structure/commissioners/

## Impacted areas of the application
List general components of the application that this PR will affect:

-  All Commissioners page